### PR TITLE
Handle import conflicts explicitly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 # Node
 node_modules/
+.pnpm-store/
+.ratel/
+tmp/
 
 # Build output
 dist/

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ For summarizing the resulting JSONL stream, see [`@ratel-ai/cli`'s `ratel inspec
 
 ### Backups & undo
 
-Every `import`, `link`, `add`, `edit`, and `remove` snapshots the files it touches into `~/.ratel/backups/<ISO>/` with a `manifest.json`. `ratel-mcp backup list` shows what's available; `ratel-mcp backup undo` (deliberately hidden from `--help`) restores the most recent set.
+Every `import`, `link`, `add`, `edit`, and `remove` snapshots the files it touches into `~/.ratel/backups/<ISO>/` with a `manifest.json`. `ratel-mcp backup list` shows what's available; `ratel-mcp backup undo` restores the most recent set.
 
 ### Browser UI
 

--- a/src/cli/cli.test.ts
+++ b/src/cli/cli.test.ts
@@ -177,6 +177,7 @@ describe("runCli — help and routing", () => {
     await runCli(["backup"], { logger: (m) => logs.push(m) });
     const out = logs.join("\n");
     expect(out).toMatch(/list/);
+    expect(out).toMatch(/undo/);
   });
 
   it("rejects an unknown command with ArgError", async () => {

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -36,7 +36,7 @@ const TOP_USAGE = `usage: ratel-mcp <command> [args...]
 Commands:
   serve    start the gateway over stdio (use --config <path>; repeat for multi-file merge)
   mcp      manage MCP servers (add, remove, list, get, edit, import, link, auth)
-  backup   manage backup snapshots (list)
+  backup   manage backup snapshots (list, undo)
   ui       launch a local browser UI mirroring the CLI [--port N] [--no-open]
 
 Run \`ratel-mcp <group>\` for the verbs available in a group.`;

--- a/src/cli/handlers/backup.ts
+++ b/src/cli/handlers/backup.ts
@@ -6,7 +6,8 @@ import { runUndo } from "./undo.js";
 export const BACKUP_USAGE = `usage: ratel-mcp backup <verb> [args...]
 
 Verbs:
-  list    list backup sets under ~/.ratel/backups/`;
+  list    list backup sets under ~/.ratel/backups/
+  undo    restore the latest backup set`;
 
 export async function runBackup(ctx: HandlerCtx): Promise<void> {
   switch (ctx.argv.verb) {

--- a/src/cli/handlers/import.test.ts
+++ b/src/cli/handlers/import.test.ts
@@ -114,16 +114,24 @@ function conflictStrategyPrompts(
 ): {
   prompts: PromptAdapter;
   conflictMessages: string[];
+  selectOptions: string[];
 } {
   const conflictMessages: string[] = [];
+  const selectOptions: string[] = [];
   return {
     conflictMessages,
+    selectOptions,
     prompts: {
       ...autoConfirm(),
       note(message, title) {
         if (title === "Conflicts") conflictMessages.push(message);
       },
-      async select() {
+      async select(opts) {
+        selectOptions.splice(
+          0,
+          selectOptions.length,
+          ...opts.options.map((o) => o.value as string),
+        );
         return strategy;
       },
       async multiselect(opts) {
@@ -143,7 +151,7 @@ function decliningStageB(): PromptAdapter {
     ...autoConfirm(),
     async confirm() {
       stage += 1;
-      return stage === 1; // accept Stage A, decline Stage B
+      return stage === 1; // accept Ratel config changes, decline Claude Code config changes
     },
   };
 }
@@ -347,12 +355,14 @@ describe("runImport", () => {
         mcpServers: { fs: { type: "stdio", command: "existing" } },
       }),
     );
-    const { prompts, conflictMessages } = conflictStrategyPrompts("replace-from-agent");
+    const { prompts, conflictMessages, selectOptions } =
+      conflictStrategyPrompts("replace-from-agent");
     const { ctx } = ctxOf(fs, prompts, false);
     await runImport(ctx, { bin: BIN });
 
     expect(conflictMessages.join("\n")).toMatch(/source agent/i);
     expect(conflictMessages.join("\n")).toMatch(/existing Ratel/i);
+    expect(selectOptions).toEqual(["add-missing-only", "replace-from-agent", "cancel"]);
     const ratelUser = JSON.parse(fs.files.get(RATEL_USER) as string);
     expect(ratelUser.mcpServers.fs).toEqual({ type: "stdio", command: "incoming" });
   });
@@ -377,10 +387,16 @@ describe("runImport", () => {
         },
       }),
     );
-    const { prompts } = conflictStrategyPrompts("replace-selected", ["user:other"]);
+    const { prompts, selectOptions } = conflictStrategyPrompts("replace-selected", ["user:other"]);
     const { ctx } = ctxOf(fs, prompts, false);
     await runImport(ctx, { bin: BIN });
 
+    expect(selectOptions).toEqual([
+      "add-missing-only",
+      "replace-selected",
+      "replace-from-agent",
+      "cancel",
+    ]);
     const ratelUser = JSON.parse(fs.files.get(RATEL_USER) as string);
     expect(ratelUser.mcpServers.fs).toEqual({ type: "stdio", command: "existing-fs" });
     expect(ratelUser.mcpServers.other).toEqual({ type: "stdio", command: "incoming-other" });
@@ -545,7 +561,7 @@ describe("runImport", () => {
     expect(logs.join("\n")).toMatch(/ratel-mcp backup undo/);
   });
 
-  it("declining Stage B leaves Ratel configs in place and Claude untouched, with an undo+link hint", async () => {
+  it("declining Claude Code config changes leaves Ratel configs in place and Claude untouched, with an undo+link hint", async () => {
     const fs = new MemFs();
     fs.files.set(
       HOME_CLAUDE,
@@ -559,13 +575,13 @@ describe("runImport", () => {
     const { ctx, logs } = ctxOf(fs, decliningStageB(), false);
     await runImport(ctx, { bin: BIN });
 
-    // Stage A applied: Ratel global has the entries.
+    // Ratel config changes applied: Ratel global has the entries.
     expect(fs.files.has(RATEL_USER)).toBe(true);
     const ratelUser = JSON.parse(fs.files.get(RATEL_USER) as string);
     expect(ratelUser.mcpServers.fs).toBeDefined();
     expect(ratelUser.mcpServers.other).toBeDefined();
 
-    // Stage B declined: Claude is untouched.
+    // Claude Code config changes declined: Claude is untouched.
     const claude = JSON.parse(fs.files.get(HOME_CLAUDE) as string);
     expect(claude.mcpServers["ratel-mcp"]).toBeUndefined();
     expect(claude.mcpServers.fs).toBeDefined();
@@ -599,7 +615,7 @@ describe("runImport", () => {
     expect(claude.mcpServers.fs).toBeUndefined();
   });
 
-  it("after declining Stage B, re-running offers Stage B again (Stage A is a no-op)", async () => {
+  it("after declining Claude Code config changes, re-running offers them again", async () => {
     const fs = new MemFs();
     fs.files.set(
       HOME_CLAUDE,
@@ -611,7 +627,7 @@ describe("runImport", () => {
     await runImport(ctx, { bin: BIN });
     expect(JSON.parse(fs.files.get(HOME_CLAUDE) as string).mcpServers["ratel-mcp"]).toBeUndefined();
 
-    // Re-run: this time accept both stages.
+    // Re-run: this time accept both change groups.
     const { ctx: ctx2 } = ctxOf(fs, autoConfirm(), false);
     await runImport(ctx2, { bin: BIN });
     expect(JSON.parse(fs.files.get(HOME_CLAUDE) as string).mcpServers["ratel-mcp"]).toBeDefined();

--- a/src/cli/handlers/import.test.ts
+++ b/src/cli/handlers/import.test.ts
@@ -462,6 +462,48 @@ describe("runImport", () => {
     expect(ratelUser.mcpServers.other).toEqual({ type: "stdio", command: "existing-other" });
   });
 
+  it("rejects replace-selected conflict strategy with --yes", async () => {
+    const fs = new MemFs();
+    fs.files.set(
+      HOME_CLAUDE,
+      JSON.stringify({
+        mcpServers: { fs: { type: "stdio", command: "incoming", description: "incoming fs" } },
+      }),
+    );
+    fs.files.set(
+      RATEL_USER,
+      JSON.stringify({
+        mcpServers: { fs: { type: "stdio", command: "existing" } },
+      }),
+    );
+    const { ctx } = ctxOf(fs, autoConfirm(), false);
+
+    await expect(
+      runImport(ctx, { bin: BIN, yes: true, conflictStrategy: "replace-selected" }),
+    ).rejects.toThrow(/replace-selected cannot be combined with --yes or --dry-run/);
+  });
+
+  it("rejects replace-selected conflict strategy with --dry-run", async () => {
+    const fs = new MemFs();
+    fs.files.set(
+      HOME_CLAUDE,
+      JSON.stringify({
+        mcpServers: { fs: { type: "stdio", command: "incoming", description: "incoming fs" } },
+      }),
+    );
+    fs.files.set(
+      RATEL_USER,
+      JSON.stringify({
+        mcpServers: { fs: { type: "stdio", command: "existing" } },
+      }),
+    );
+    const { ctx } = ctxOf(fs, autoConfirm(), false);
+
+    await expect(
+      runImport(ctx, { bin: BIN, dryRun: true, conflictStrategy: "replace-selected" }),
+    ).rejects.toThrow(/replace-selected cannot be combined with --yes or --dry-run/);
+  });
+
   it("canceling at the conflict prompt exits before writes or backups", async () => {
     const fs = new MemFs();
     fs.files.set(

--- a/src/cli/handlers/import.test.ts
+++ b/src/cli/handlers/import.test.ts
@@ -78,6 +78,9 @@ function autoConfirm(): PromptAdapter {
     async confirm() {
       return true;
     },
+    async select(opts) {
+      return opts.initialValue ?? opts.options[0].value;
+    },
     async multiselect(opts) {
       return opts.options.map((o) => o.value) as unknown as never;
     },
@@ -101,6 +104,35 @@ function selectingPrompts(selected: string[]): PromptAdapter {
         .map((n) => map.get(n))
         .filter((x): x is string => typeof x === "string");
       return tags as unknown as never;
+    },
+  };
+}
+
+function conflictStrategyPrompts(
+  strategy: "add-missing-only" | "replace-selected" | "replace-from-agent" | "cancel",
+  selectedConflictKeys: string[] = [],
+): {
+  prompts: PromptAdapter;
+  conflictMessages: string[];
+} {
+  const conflictMessages: string[] = [];
+  return {
+    conflictMessages,
+    prompts: {
+      ...autoConfirm(),
+      note(message, title) {
+        if (title === "Conflicts") conflictMessages.push(message);
+      },
+      async select() {
+        return strategy;
+      },
+      async multiselect(opts) {
+        if (opts.message.includes("conflicts")) {
+          const available = new Set(opts.options.map((o) => o.value as string));
+          return selectedConflictKeys.filter((k) => available.has(k)) as unknown as never;
+        }
+        return opts.options.map((o) => o.value) as unknown as never;
+      },
     },
   };
 }
@@ -299,6 +331,162 @@ describe("runImport", () => {
     await runImport(ctx, { bin: BIN, yes: true });
     expect(confirmCalled).toBe(false);
     expect(fs.files.has(RATEL_USER)).toBe(true);
+  });
+
+  it("interactive conflict prompt defaults to keeping Ratel unless replace is selected", async () => {
+    const fs = new MemFs();
+    fs.files.set(
+      HOME_CLAUDE,
+      JSON.stringify({
+        mcpServers: { fs: { type: "stdio", command: "incoming" } },
+      }),
+    );
+    fs.files.set(
+      RATEL_USER,
+      JSON.stringify({
+        mcpServers: { fs: { type: "stdio", command: "existing" } },
+      }),
+    );
+    const { prompts, conflictMessages } = conflictStrategyPrompts("replace-from-agent");
+    const { ctx } = ctxOf(fs, prompts, false);
+    await runImport(ctx, { bin: BIN });
+
+    expect(conflictMessages.join("\n")).toMatch(/source agent/i);
+    expect(conflictMessages.join("\n")).toMatch(/existing Ratel/i);
+    const ratelUser = JSON.parse(fs.files.get(RATEL_USER) as string);
+    expect(ratelUser.mcpServers.fs).toEqual({ type: "stdio", command: "incoming" });
+  });
+
+  it("interactive conflict prompt can replace only selected conflicts", async () => {
+    const fs = new MemFs();
+    fs.files.set(
+      HOME_CLAUDE,
+      JSON.stringify({
+        mcpServers: {
+          fs: { type: "stdio", command: "incoming-fs" },
+          other: { type: "stdio", command: "incoming-other" },
+        },
+      }),
+    );
+    fs.files.set(
+      RATEL_USER,
+      JSON.stringify({
+        mcpServers: {
+          fs: { type: "stdio", command: "existing-fs" },
+          other: { type: "stdio", command: "existing-other" },
+        },
+      }),
+    );
+    const { prompts } = conflictStrategyPrompts("replace-selected", ["user:other"]);
+    const { ctx } = ctxOf(fs, prompts, false);
+    await runImport(ctx, { bin: BIN });
+
+    const ratelUser = JSON.parse(fs.files.get(RATEL_USER) as string);
+    expect(ratelUser.mcpServers.fs).toEqual({ type: "stdio", command: "existing-fs" });
+    expect(ratelUser.mcpServers.other).toEqual({ type: "stdio", command: "incoming-other" });
+  });
+
+  it("explicit replace-from-agent conflict strategy skips the strategy prompt", async () => {
+    const fs = new MemFs();
+    fs.files.set(
+      HOME_CLAUDE,
+      JSON.stringify({
+        mcpServers: { fs: { type: "stdio", command: "incoming" } },
+      }),
+    );
+    fs.files.set(
+      RATEL_USER,
+      JSON.stringify({
+        mcpServers: { fs: { type: "stdio", command: "existing" } },
+      }),
+    );
+    let selectCalled = false;
+    const prompts: PromptAdapter = {
+      ...autoConfirm(),
+      async select() {
+        selectCalled = true;
+        return "add-missing-only";
+      },
+    };
+    const { ctx } = ctxOf(fs, prompts, false);
+    await runImport(ctx, { bin: BIN, conflictStrategy: "replace-from-agent" });
+
+    expect(selectCalled).toBe(false);
+    const ratelUser = JSON.parse(fs.files.get(RATEL_USER) as string);
+    expect(ratelUser.mcpServers.fs).toEqual({ type: "stdio", command: "incoming" });
+  });
+
+  it("explicit replace-selected conflict strategy still prompts for the conflicts to replace", async () => {
+    const fs = new MemFs();
+    fs.files.set(
+      HOME_CLAUDE,
+      JSON.stringify({
+        mcpServers: {
+          fs: { type: "stdio", command: "incoming-fs" },
+          other: { type: "stdio", command: "incoming-other" },
+        },
+      }),
+    );
+    fs.files.set(
+      RATEL_USER,
+      JSON.stringify({
+        mcpServers: {
+          fs: { type: "stdio", command: "existing-fs" },
+          other: { type: "stdio", command: "existing-other" },
+        },
+      }),
+    );
+    let selectCalled = false;
+    let multiselectCalled = false;
+    const prompts: PromptAdapter = {
+      ...autoConfirm(),
+      async select() {
+        selectCalled = true;
+        return "add-missing-only";
+      },
+      async multiselect(opts) {
+        if (opts.message.includes("conflicts")) {
+          multiselectCalled = true;
+          return ["user:fs"] as unknown as never;
+        }
+        return opts.options.map((o) => o.value) as unknown as never;
+      },
+    };
+    const { ctx } = ctxOf(fs, prompts, false);
+    await runImport(ctx, { bin: BIN, conflictStrategy: "replace-selected" });
+
+    expect(selectCalled).toBe(false);
+    expect(multiselectCalled).toBe(true);
+    const ratelUser = JSON.parse(fs.files.get(RATEL_USER) as string);
+    expect(ratelUser.mcpServers.fs).toEqual({ type: "stdio", command: "incoming-fs" });
+    expect(ratelUser.mcpServers.other).toEqual({ type: "stdio", command: "existing-other" });
+  });
+
+  it("canceling at the conflict prompt exits before writes or backups", async () => {
+    const fs = new MemFs();
+    fs.files.set(
+      HOME_CLAUDE,
+      JSON.stringify({
+        mcpServers: { fs: { type: "stdio", command: "incoming" } },
+      }),
+    );
+    fs.files.set(
+      RATEL_USER,
+      JSON.stringify({
+        mcpServers: { fs: { type: "stdio", command: "existing" } },
+      }),
+    );
+    const { prompts } = conflictStrategyPrompts("cancel");
+    const { ctx } = ctxOf(fs, prompts, false);
+    await runImport(ctx, { bin: BIN });
+
+    const ratelUser = JSON.parse(fs.files.get(RATEL_USER) as string);
+    expect(ratelUser.mcpServers.fs).toEqual({ type: "stdio", command: "existing" });
+    expect(JSON.parse(fs.files.get(HOME_CLAUDE) as string).mcpServers.fs).toBeDefined();
+    const backupKeys = Array.from(fs.files.keys()).filter((k) =>
+      k.startsWith("/home/u/.ratel/backups/"),
+    );
+    expect(backupKeys).toEqual([]);
   });
 
   it("logs an undo hint if executor fails mid-flight", async () => {

--- a/src/cli/handlers/import.test.ts
+++ b/src/cli/handlers/import.test.ts
@@ -124,7 +124,7 @@ function conflictStrategyPrompts(
     prompts: {
       ...autoConfirm(),
       note(message, title) {
-        if (title === "Conflicts") conflictMessages.push(message);
+        if (title === "Ratel import conflicts") conflictMessages.push(message);
       },
       async select(opts) {
         selectOptions.splice(
@@ -135,7 +135,7 @@ function conflictStrategyPrompts(
         return strategy;
       },
       async multiselect(opts) {
-        if (opts.message.includes("conflicts")) {
+        if (opts.message.includes("Ratel entries")) {
           const available = new Set(opts.options.map((o) => o.value as string));
           return selectedConflictKeys.filter((k) => available.has(k)) as unknown as never;
         }
@@ -360,8 +360,8 @@ describe("runImport", () => {
     const { ctx } = ctxOf(fs, prompts, false);
     await runImport(ctx, { bin: BIN });
 
-    expect(conflictMessages.join("\n")).toMatch(/source agent/i);
-    expect(conflictMessages.join("\n")).toMatch(/existing Ratel/i);
+    expect(conflictMessages.join("\n")).toMatch(/Claude Code definition/i);
+    expect(conflictMessages.join("\n")).toMatch(/Existing Ratel definition/i);
     expect(selectOptions).toEqual(["add-missing-only", "replace-from-agent", "cancel"]);
     const ratelUser = JSON.parse(fs.files.get(RATEL_USER) as string);
     expect(ratelUser.mcpServers.fs).toEqual({ type: "stdio", command: "incoming" });
@@ -461,7 +461,7 @@ describe("runImport", () => {
         return "add-missing-only";
       },
       async multiselect(opts) {
-        if (opts.message.includes("conflicts")) {
+        if (opts.message.includes("Ratel entries")) {
           multiselectCalled = true;
           return ["user:fs"] as unknown as never;
         }

--- a/src/cli/handlers/import.test.ts
+++ b/src/cli/handlers/import.test.ts
@@ -542,7 +542,7 @@ describe("runImport", () => {
     fs.failNextWriteAt = HOME_CLAUDE;
     const { ctx, logs } = ctxOf(fs, autoConfirm(), false);
     await expect(runImport(ctx, { bin: BIN, yes: true })).rejects.toThrow();
-    expect(logs.join("\n")).toMatch(/undo/);
+    expect(logs.join("\n")).toMatch(/ratel-mcp backup undo/);
   });
 
   it("declining Stage B leaves Ratel configs in place and Claude untouched, with an undo+link hint", async () => {

--- a/src/cli/handlers/import.ts
+++ b/src/cli/handlers/import.ts
@@ -119,10 +119,9 @@ export async function runImport(
     return null;
   }
 
-  // Stage A — Ratel writes
   let stageAManifest: BackupManifest | null = null;
   if (plan.ratelChanges.length > 0) {
-    ctx.prompts.note(renderDiff(plan.ratelChanges), "Stage A · Ratel config writes");
+    ctx.prompts.note(renderDiff(plan.ratelChanges), "Ratel config changes");
     if (!opts.yes) {
       const ok = await ctx.prompts.confirm({
         message: `Apply ${plan.ratelChanges.length} Ratel config change(s)?`,
@@ -136,13 +135,12 @@ export async function runImport(
     stageAManifest = await tryExecute(ctx, plan.ratelChanges, "import");
   }
 
-  // Stage B — Claude rewrites
   if (plan.claudeChanges.length === 0) {
     ctx.prompts.outro("import complete · no Claude changes needed");
     return stageAManifest;
   }
 
-  ctx.prompts.note(renderClaudeStage(plan), "Stage B · Claude config rewrites");
+  ctx.prompts.note(renderClaudeStage(plan), "Claude Code config changes");
   if (!opts.yes) {
     const ok = await ctx.prompts.confirm({
       message: `Replace ${plan.claudeChanges.length} Claude entr${
@@ -152,9 +150,9 @@ export async function runImport(
     });
     if (ctx.prompts.isCancel(ok) || ok === false) {
       ctx.log(
-        "Stage B skipped. Run `ratel-mcp link` (or re-run `ratel-mcp import`) to point Claude at Ratel later.",
+        "Claude Code config changes skipped. Run `ratel-mcp link` (or re-run `ratel-mcp import`) to point Claude at Ratel later.",
       );
-      ctx.prompts.outro("Stage A applied · Stage B deferred");
+      ctx.prompts.outro("Ratel config changes applied · Claude Code config changes skipped");
       return stageAManifest;
     }
   }
@@ -186,30 +184,12 @@ async function resolveConflictStrategy(
   }
   if (opts.yes) return { conflictStrategy: "add-missing-only" };
   const picked = await ctx.prompts.select<ImportConflictStrategy | "cancel">({
-    message: "How should conflicting MCP server names be handled?",
+    message:
+      plan.summary.conflicts.length === 1
+        ? "How should this conflicting MCP server name be handled?"
+        : "How should conflicting MCP server names be handled?",
     initialValue: "add-missing-only",
-    options: [
-      {
-        value: "add-missing-only",
-        label: "Add missing only",
-        hint: "Keep existing Ratel entries and import non-conflicting entries.",
-      },
-      {
-        value: "replace-selected",
-        label: "Replace selected conflicts",
-        hint: "Choose which conflicting Ratel entries to overwrite.",
-      },
-      {
-        value: "replace-from-agent",
-        label: "Replace conflicts from agent",
-        hint: "Overwrite conflicting Ratel entries with Claude Code entries.",
-      },
-      {
-        value: "cancel",
-        label: "Cancel",
-        hint: "Exit before writing files.",
-      },
-    ],
+    options: conflictStrategyOptions(plan.summary.conflicts.length),
   });
   if (ctx.prompts.isCancel(picked) || picked === "cancel") return null;
   return resolveSelectedConflicts(ctx, plan, picked as ImportConflictStrategy);
@@ -234,6 +214,47 @@ async function resolveSelectedConflicts(
   });
   if (ctx.prompts.isCancel(selected)) return null;
   return { conflictStrategy, replaceConflicts: new Set(selected as string[]) };
+}
+
+function conflictStrategyOptions(conflictCount: number) {
+  const options: Array<{
+    value: ImportConflictStrategy | "cancel";
+    label: string;
+    hint: string;
+  }> = [
+    {
+      value: "add-missing-only",
+      label: conflictCount === 1 ? "Keep existing Ratel entry" : "Keep existing Ratel entries",
+      hint:
+        conflictCount === 1
+          ? "Keep the existing Ratel entry and import non-conflicting entries."
+          : "Keep existing Ratel entries and import non-conflicting entries.",
+    },
+  ];
+  if (conflictCount > 1) {
+    options.push({
+      value: "replace-selected",
+      label: "Replace selected conflicts",
+      hint: "Choose which conflicting Ratel entries to overwrite.",
+    });
+  }
+  options.push(
+    {
+      value: "replace-from-agent",
+      label:
+        conflictCount === 1 ? "Replace from Claude Code" : "Replace conflicts from Claude Code",
+      hint:
+        conflictCount === 1
+          ? "Overwrite the conflicting Ratel entry with the Claude Code entry."
+          : "Overwrite conflicting Ratel entries with Claude Code entries.",
+    },
+    {
+      value: "cancel",
+      label: "Cancel",
+      hint: "Exit before writing files.",
+    },
+  );
+  return options;
 }
 
 function collectCandidates(

--- a/src/cli/handlers/import.ts
+++ b/src/cli/handlers/import.ts
@@ -1,4 +1,5 @@
 import type { RatelConfig, ServerEntry } from "../../lib/index.js";
+import { ArgError } from "../args.js";
 import type { BackupManifest } from "../backup.js";
 import { type ClaudeConfigDoc, type ClaudeScope, readClaudeConfig } from "../claude.js";
 import { ratelConfigPath } from "../hierarchy.js";
@@ -172,6 +173,11 @@ async function resolveConflictStrategy(
   if (plan.summary.conflicts.length === 0) return { conflictStrategy: "add-missing-only" };
   ctx.prompts.note(renderConflicts(plan.summary.conflicts), "Conflicts");
   if (opts.conflictStrategy) {
+    if (opts.conflictStrategy === "replace-selected" && (opts.yes || opts.dryRun)) {
+      throw new ArgError(
+        "--conflict-strategy replace-selected cannot be combined with --yes or --dry-run",
+      );
+    }
     return resolveSelectedConflicts(ctx, plan, opts.conflictStrategy);
   }
   if (opts.dryRun) {

--- a/src/cli/handlers/import.ts
+++ b/src/cli/handlers/import.ts
@@ -160,7 +160,7 @@ export async function runImport(
   }
 
   const stageBManifest = await tryExecute(ctx, plan.claudeChanges, "import");
-  ctx.prompts.note(`Backup created. Run \`ratel-mcp undo\` to revert.`, "Done");
+  ctx.prompts.note(`Backup created. Run \`ratel-mcp backup undo\` to revert.`, "Done");
   ctx.prompts.outro("import complete · restart Claude to pick up the new MCP entry");
   return stageBManifest;
 }
@@ -348,7 +348,9 @@ async function tryExecute(
     return await executePlan(changes, { fs: ctx.fs, env: ctx.env, action });
   } catch (err) {
     ctx.log(`error during execution: ${(err as Error).message}`);
-    ctx.log(`partial backup may exist under ~/.ratel/backups/. Run \`ratel-mcp undo\` to revert.`);
+    ctx.log(
+      `partial backup may exist under ~/.ratel/backups/. Run \`ratel-mcp backup undo\` to revert.`,
+    );
     throw err;
   }
 }

--- a/src/cli/handlers/import.ts
+++ b/src/cli/handlers/import.ts
@@ -2,7 +2,14 @@ import type { RatelConfig, ServerEntry } from "../../lib/index.js";
 import type { BackupManifest } from "../backup.js";
 import { type ClaudeConfigDoc, type ClaudeScope, readClaudeConfig } from "../claude.js";
 import { ratelConfigPath } from "../hierarchy.js";
-import { buildImportPlan, type FileChange, type ImportPlan } from "../import-plan.js";
+import {
+  buildImportPlan,
+  conflictKey,
+  type FileChange,
+  type ImportConflict,
+  type ImportConflictStrategy,
+  type ImportPlan,
+} from "../import-plan.js";
 import { readJson } from "../io.js";
 import { locateRatelBin, type ResolvedBin } from "../locate-bin.js";
 import { executePlan } from "../plan-exec.js";
@@ -14,6 +21,7 @@ export type ProbeFn = (name: string, entry: ServerEntry) => Promise<string | und
 export interface ImportFlowOptions {
   yes?: boolean;
   dryRun?: boolean;
+  conflictStrategy?: ImportConflictStrategy;
   bin?: ResolvedBin;
   envVar?: string;
   whichResult?: string;
@@ -26,6 +34,11 @@ interface Candidate {
   name: string;
   scope: ClaudeScope;
   hasDescription: boolean;
+}
+
+interface ConflictResolution {
+  conflictStrategy: ImportConflictStrategy;
+  replaceConflicts?: Set<string>;
 }
 
 export async function runImport(
@@ -67,22 +80,28 @@ export async function runImport(
 
   await captureDescriptions(ctx, selection, claudeUser, claudeProject, claudeLocal, opts);
 
-  const plan = buildImportPlan(
-    {
-      claudeUser,
-      claudeProject,
-      claudeLocal,
-      ratelUser,
-      ratelProject,
-      ratelLocal,
-      bin,
-      ratelUserPath,
-      ratelProjectPath,
-      ratelLocalPath,
-      projectRoot: ctx.env.projectRoot,
-    },
-    { selection: new Set(selection.map((c) => c.name)) },
-  );
+  const planInputs = {
+    claudeUser,
+    claudeProject,
+    claudeLocal,
+    ratelUser,
+    ratelProject,
+    ratelLocal,
+    bin,
+    ratelUserPath,
+    ratelProjectPath,
+    ratelLocalPath,
+    projectRoot: ctx.env.projectRoot,
+  };
+  const planOptions = { selection: new Set(selection.map((c) => c.name)) };
+  const initialPlan = buildImportPlan(planInputs, planOptions);
+  const conflictResolution = await resolveConflictStrategy(ctx, initialPlan, opts);
+  if (conflictResolution === null) {
+    ctx.prompts.cancel("import cancelled (no writes)");
+    return null;
+  }
+
+  const plan = buildImportPlan(planInputs, { ...planOptions, ...conflictResolution });
 
   ctx.prompts.note(renderSummary(plan), "Summary");
 
@@ -143,6 +162,72 @@ export async function runImport(
   ctx.prompts.note(`Backup created. Run \`ratel-mcp undo\` to revert.`, "Done");
   ctx.prompts.outro("import complete · restart Claude to pick up the new MCP entry");
   return stageBManifest;
+}
+
+async function resolveConflictStrategy(
+  ctx: HandlerCtx,
+  plan: ImportPlan,
+  opts: ImportFlowOptions,
+): Promise<ConflictResolution | null> {
+  if (plan.summary.conflicts.length === 0) return { conflictStrategy: "add-missing-only" };
+  ctx.prompts.note(renderConflicts(plan.summary.conflicts), "Conflicts");
+  if (opts.conflictStrategy) {
+    return resolveSelectedConflicts(ctx, plan, opts.conflictStrategy);
+  }
+  if (opts.dryRun) {
+    ctx.prompts.note("Conflict strategy: Add missing only", "Dry run");
+    return { conflictStrategy: "add-missing-only" };
+  }
+  if (opts.yes) return { conflictStrategy: "add-missing-only" };
+  const picked = await ctx.prompts.select<ImportConflictStrategy | "cancel">({
+    message: "How should conflicting MCP server names be handled?",
+    initialValue: "add-missing-only",
+    options: [
+      {
+        value: "add-missing-only",
+        label: "Add missing only",
+        hint: "Keep existing Ratel entries and import non-conflicting entries.",
+      },
+      {
+        value: "replace-selected",
+        label: "Replace selected conflicts",
+        hint: "Choose which conflicting Ratel entries to overwrite.",
+      },
+      {
+        value: "replace-from-agent",
+        label: "Replace conflicts from agent",
+        hint: "Overwrite conflicting Ratel entries with Claude Code entries.",
+      },
+      {
+        value: "cancel",
+        label: "Cancel",
+        hint: "Exit before writing files.",
+      },
+    ],
+  });
+  if (ctx.prompts.isCancel(picked) || picked === "cancel") return null;
+  return resolveSelectedConflicts(ctx, plan, picked as ImportConflictStrategy);
+}
+
+async function resolveSelectedConflicts(
+  ctx: HandlerCtx,
+  plan: ImportPlan,
+  conflictStrategy: ImportConflictStrategy,
+): Promise<ConflictResolution | null> {
+  if (conflictStrategy !== "replace-selected") return { conflictStrategy };
+
+  const selected = await ctx.prompts.multiselect<string>({
+    message: "Pick conflicts to replace from Claude Code",
+    required: false,
+    options: plan.summary.conflicts.map((c) => ({
+      value: conflictKey(c.scope, c.name),
+      label: `${c.name} [${c.scope}]`,
+      hint: `${summarizeEntry(c.existing)} -> ${summarizeEntry(c.incoming)}`,
+    })),
+    initialValues: [],
+  });
+  if (ctx.prompts.isCancel(selected)) return null;
+  return { conflictStrategy, replaceConflicts: new Set(selected as string[]) };
 }
 
 function collectCandidates(
@@ -309,6 +394,14 @@ function renderSummary(plan: ImportPlan): string {
       lines.push(`  - ${s.name} (${s.scope}): ${s.reason}`);
     }
   }
+  if (plan.summary.conflicts.length > 0) {
+    lines.push("");
+    lines.push(
+      `Conflicts: ${plan.summary.conflicts.length} (${renderConflictStrategyName(
+        plan.summary.conflictStrategy,
+      )})`,
+    );
+  }
   if (plan.summary.overwrittenRatelEntries.length > 0) {
     lines.push("");
     lines.push(
@@ -318,6 +411,33 @@ function renderSummary(plan: ImportPlan): string {
     );
   }
   return lines.length > 0 ? lines.join("\n") : "(no changes)";
+}
+
+function renderConflicts(conflicts: readonly ImportConflict[]): string {
+  return conflicts
+    .map((c) =>
+      [
+        `- ${c.name} (${c.scope})`,
+        `  source agent: ${summarizeEntry(c.incoming)}`,
+        `  existing Ratel: ${summarizeEntry(c.existing)}`,
+      ].join("\n"),
+    )
+    .join("\n");
+}
+
+function summarizeEntry(entry: ServerEntry): string {
+  if (entry.type === "http" || entry.type === "sse") {
+    return `${entry.type} ${entry.url ?? "(missing url)"}`;
+  }
+  const command = entry.command ?? "(missing command)";
+  const args = entry.args && entry.args.length > 0 ? ` ${entry.args.join(" ")}` : "";
+  return `${entry.type ?? "stdio"} ${command}${args}`;
+}
+
+function renderConflictStrategyName(strategy: ImportConflictStrategy): string {
+  if (strategy === "replace-from-agent") return "replace conflicts from agent";
+  if (strategy === "replace-selected") return "replace selected conflicts";
+  return "add missing only";
 }
 
 function renderDiff(changes: readonly FileChange[]): string {

--- a/src/cli/handlers/import.ts
+++ b/src/cli/handlers/import.ts
@@ -143,9 +143,7 @@ export async function runImport(
   ctx.prompts.note(renderClaudeStage(plan), "Claude Code config changes");
   if (!opts.yes) {
     const ok = await ctx.prompts.confirm({
-      message: `Replace ${plan.claudeChanges.length} Claude entr${
-        plan.claudeChanges.length === 1 ? "y" : "ies"
-      } with the ratel-mcp entry?`,
+      message: "Replace Claude Code MCP entries now managed by Ratel with the ratel-mcp entry?",
       initialValue: true,
     });
     if (ctx.prompts.isCancel(ok) || ok === false) {
@@ -169,7 +167,7 @@ async function resolveConflictStrategy(
   opts: ImportFlowOptions,
 ): Promise<ConflictResolution | null> {
   if (plan.summary.conflicts.length === 0) return { conflictStrategy: "add-missing-only" };
-  ctx.prompts.note(renderConflicts(plan.summary.conflicts), "Conflicts");
+  ctx.prompts.note(renderConflicts(plan.summary.conflicts), "Ratel import conflicts");
   if (opts.conflictStrategy) {
     if (opts.conflictStrategy === "replace-selected" && (opts.yes || opts.dryRun)) {
       throw new ArgError(
@@ -179,15 +177,15 @@ async function resolveConflictStrategy(
     return resolveSelectedConflicts(ctx, plan, opts.conflictStrategy);
   }
   if (opts.dryRun) {
-    ctx.prompts.note("Conflict strategy: Add missing only", "Dry run");
+    ctx.prompts.note("Ratel conflict strategy: keep existing Ratel definitions", "Dry run");
     return { conflictStrategy: "add-missing-only" };
   }
   if (opts.yes) return { conflictStrategy: "add-missing-only" };
   const picked = await ctx.prompts.select<ImportConflictStrategy | "cancel">({
     message:
       plan.summary.conflicts.length === 1
-        ? "How should this conflicting MCP server name be handled?"
-        : "How should conflicting MCP server names be handled?",
+        ? "This name already exists in Ratel. What should Ratel contain?"
+        : "These names already exist in Ratel. What should Ratel contain?",
     initialValue: "add-missing-only",
     options: conflictStrategyOptions(plan.summary.conflicts.length),
   });
@@ -203,7 +201,7 @@ async function resolveSelectedConflicts(
   if (conflictStrategy !== "replace-selected") return { conflictStrategy };
 
   const selected = await ctx.prompts.multiselect<string>({
-    message: "Pick conflicts to replace from Claude Code",
+    message: "Pick Ratel entries to replace from Claude Code",
     required: false,
     options: plan.summary.conflicts.map((c) => ({
       value: conflictKey(c.scope, c.name),
@@ -224,29 +222,32 @@ function conflictStrategyOptions(conflictCount: number) {
   }> = [
     {
       value: "add-missing-only",
-      label: conflictCount === 1 ? "Keep existing Ratel entry" : "Keep existing Ratel entries",
+      label:
+        conflictCount === 1 ? "Keep existing Ratel definition" : "Keep existing Ratel definitions",
       hint:
         conflictCount === 1
-          ? "Keep the existing Ratel entry and import non-conflicting entries."
-          : "Keep existing Ratel entries and import non-conflicting entries.",
+          ? "Do not import the conflicting Claude Code definition."
+          : "Do not import the conflicting Claude Code definitions.",
     },
   ];
   if (conflictCount > 1) {
     options.push({
       value: "replace-selected",
-      label: "Replace selected conflicts",
-      hint: "Choose which conflicting Ratel entries to overwrite.",
+      label: "Replace selected Ratel definitions",
+      hint: "Choose which existing Ratel definitions to overwrite with Claude Code definitions.",
     });
   }
   options.push(
     {
       value: "replace-from-agent",
       label:
-        conflictCount === 1 ? "Replace from Claude Code" : "Replace conflicts from Claude Code",
+        conflictCount === 1
+          ? "Replace Ratel definition from Claude Code"
+          : "Replace all Ratel definitions from Claude Code",
       hint:
         conflictCount === 1
-          ? "Overwrite the conflicting Ratel entry with the Claude Code entry."
-          : "Overwrite conflicting Ratel entries with Claude Code entries.",
+          ? "Overwrite the existing Ratel definition with the Claude Code definition."
+          : "Overwrite each existing Ratel definition with its Claude Code definition.",
     },
     {
       value: "cancel",
@@ -418,7 +419,7 @@ function renderSummary(plan: ImportPlan): string {
   }
   if (plan.summary.skipped.length > 0) {
     lines.push("");
-    lines.push("Skipped (will stay in their current Claude config):");
+    lines.push("Not copied into Ratel:");
     for (const s of plan.summary.skipped) {
       lines.push(`  - ${s.name} (${s.scope}): ${s.reason}`);
     }
@@ -426,7 +427,7 @@ function renderSummary(plan: ImportPlan): string {
   if (plan.summary.conflicts.length > 0) {
     lines.push("");
     lines.push(
-      `Conflicts: ${plan.summary.conflicts.length} (${renderConflictStrategyName(
+      `Ratel import conflicts: ${plan.summary.conflicts.length} (${renderConflictStrategyName(
         plan.summary.conflictStrategy,
       )})`,
     );
@@ -447,8 +448,8 @@ function renderConflicts(conflicts: readonly ImportConflict[]): string {
     .map((c) =>
       [
         `- ${c.name} (${c.scope})`,
-        `  source agent: ${summarizeEntry(c.incoming)}`,
-        `  existing Ratel: ${summarizeEntry(c.existing)}`,
+        `  Claude Code definition: ${summarizeEntry(c.incoming)}`,
+        `  Existing Ratel definition: ${summarizeEntry(c.existing)}`,
       ].join("\n"),
     )
     .join("\n");
@@ -464,9 +465,9 @@ function summarizeEntry(entry: ServerEntry): string {
 }
 
 function renderConflictStrategyName(strategy: ImportConflictStrategy): string {
-  if (strategy === "replace-from-agent") return "replace conflicts from agent";
-  if (strategy === "replace-selected") return "replace selected conflicts";
-  return "add missing only";
+  if (strategy === "replace-from-agent") return "replace all Ratel definitions from Claude Code";
+  if (strategy === "replace-selected") return "replace selected Ratel definitions";
+  return "keep existing Ratel definitions";
 }
 
 function renderDiff(changes: readonly FileChange[]): string {
@@ -481,9 +482,13 @@ function renderDiff(changes: readonly FileChange[]): string {
 function renderClaudeStage(plan: ImportPlan): string {
   const lines: string[] = [];
   lines.push(renderDiff(plan.claudeChanges));
+  lines.push("");
+  lines.push(
+    "Claude Code MCP entries now managed by Ratel will be replaced by a single ratel-mcp entry. Other Claude Code MCP entries are preserved.",
+  );
   if (plan.summary.skipped.length > 0) {
     lines.push("");
-    lines.push("Entries that will remain in Claude as-is:");
+    lines.push("Not copied into Ratel:");
     for (const s of plan.summary.skipped) {
       lines.push(`  - ${s.name} (${s.scope})`);
     }

--- a/src/cli/handlers/import.ts
+++ b/src/cli/handlers/import.ts
@@ -42,6 +42,10 @@ interface ConflictResolution {
   replaceConflicts?: Set<string>;
 }
 
+type ConflictResolutionResult =
+  | { kind: "resolved"; resolution: ConflictResolution }
+  | { kind: "cancelled" };
+
 export async function runImport(
   ctx: HandlerCtx,
   opts: ImportFlowOptions = {},
@@ -97,12 +101,12 @@ export async function runImport(
   const planOptions = { selection: new Set(selection.map((c) => c.name)) };
   const initialPlan = buildImportPlan(planInputs, planOptions);
   const conflictResolution = await resolveConflictStrategy(ctx, initialPlan, opts);
-  if (conflictResolution === null) {
+  if (conflictResolution.kind === "cancelled") {
     ctx.prompts.cancel("import cancelled (no writes)");
     return null;
   }
 
-  const plan = buildImportPlan(planInputs, { ...planOptions, ...conflictResolution });
+  const plan = buildImportPlan(planInputs, { ...planOptions, ...conflictResolution.resolution });
 
   ctx.prompts.note(renderSummary(plan), "Summary");
 
@@ -165,8 +169,10 @@ async function resolveConflictStrategy(
   ctx: HandlerCtx,
   plan: ImportPlan,
   opts: ImportFlowOptions,
-): Promise<ConflictResolution | null> {
-  if (plan.summary.conflicts.length === 0) return { conflictStrategy: "add-missing-only" };
+): Promise<ConflictResolutionResult> {
+  if (plan.summary.conflicts.length === 0) {
+    return { kind: "resolved", resolution: { conflictStrategy: "add-missing-only" } };
+  }
   ctx.prompts.note(renderConflicts(plan.summary.conflicts), "Ratel import conflicts");
   if (opts.conflictStrategy) {
     if (opts.conflictStrategy === "replace-selected" && (opts.yes || opts.dryRun)) {
@@ -178,9 +184,9 @@ async function resolveConflictStrategy(
   }
   if (opts.dryRun) {
     ctx.prompts.note("Ratel conflict strategy: keep existing Ratel definitions", "Dry run");
-    return { conflictStrategy: "add-missing-only" };
+    return { kind: "resolved", resolution: { conflictStrategy: "add-missing-only" } };
   }
-  if (opts.yes) return { conflictStrategy: "add-missing-only" };
+  if (opts.yes) return { kind: "resolved", resolution: { conflictStrategy: "add-missing-only" } };
   const picked = await ctx.prompts.select<ImportConflictStrategy | "cancel">({
     message:
       plan.summary.conflicts.length === 1
@@ -189,7 +195,7 @@ async function resolveConflictStrategy(
     initialValue: "add-missing-only",
     options: conflictStrategyOptions(plan.summary.conflicts.length),
   });
-  if (ctx.prompts.isCancel(picked) || picked === "cancel") return null;
+  if (ctx.prompts.isCancel(picked) || picked === "cancel") return { kind: "cancelled" };
   return resolveSelectedConflicts(ctx, plan, picked as ImportConflictStrategy);
 }
 
@@ -197,8 +203,10 @@ async function resolveSelectedConflicts(
   ctx: HandlerCtx,
   plan: ImportPlan,
   conflictStrategy: ImportConflictStrategy,
-): Promise<ConflictResolution | null> {
-  if (conflictStrategy !== "replace-selected") return { conflictStrategy };
+): Promise<ConflictResolutionResult> {
+  if (conflictStrategy !== "replace-selected") {
+    return { kind: "resolved", resolution: { conflictStrategy } };
+  }
 
   const selected = await ctx.prompts.multiselect<string>({
     message: "Pick Ratel entries to replace from Claude Code",
@@ -210,8 +218,11 @@ async function resolveSelectedConflicts(
     })),
     initialValues: [],
   });
-  if (ctx.prompts.isCancel(selected)) return null;
-  return { conflictStrategy, replaceConflicts: new Set(selected as string[]) };
+  if (ctx.prompts.isCancel(selected)) return { kind: "cancelled" };
+  return {
+    kind: "resolved",
+    resolution: { conflictStrategy, replaceConflicts: new Set(selected as string[]) },
+  };
 }
 
 function conflictStrategyOptions(conflictCount: number) {

--- a/src/cli/handlers/link.ts
+++ b/src/cli/handlers/link.ts
@@ -87,9 +87,7 @@ export async function runLink(
 
   if (!opts.yes) {
     const ok = await ctx.prompts.confirm({
-      message: `Replace ${plan.claudeChanges.length} Claude entr${
-        plan.claudeChanges.length === 1 ? "y" : "ies"
-      } with the ratel-mcp entry?`,
+      message: "Replace Claude Code MCP entries now managed by Ratel with the ratel-mcp entry?",
       initialValue: true,
     });
     if (ctx.prompts.isCancel(ok) || ok === false) {
@@ -151,7 +149,12 @@ async function whichRatelBin(): Promise<string | undefined> {
 }
 
 function renderClaudeStage(plan: ReturnType<typeof buildImportPlan>): string {
-  return plan.claudeChanges
-    .map((c) => `write ${c.path}${c.before === null ? " (new file)" : ""}`)
-    .join("\n");
+  const lines = plan.claudeChanges.map(
+    (c) => `write ${c.path}${c.before === null ? " (new file)" : ""}`,
+  );
+  lines.push("");
+  lines.push(
+    "Claude Code MCP entries now managed by Ratel will be replaced by a single ratel-mcp entry. Other Claude Code MCP entries are preserved.",
+  );
+  return lines.join("\n");
 }

--- a/src/cli/handlers/link.ts
+++ b/src/cli/handlers/link.ts
@@ -103,7 +103,7 @@ export async function runLink(
     env: ctx.env,
     action: "link",
   });
-  ctx.prompts.note(`Backup created. Run \`ratel-mcp undo\` to revert.`, "Done");
+  ctx.prompts.note(`Backup created. Run \`ratel-mcp backup undo\` to revert.`, "Done");
   ctx.prompts.outro("link complete · restart Claude to pick up the new MCP entry");
   return manifest;
 }

--- a/src/cli/handlers/mcp.ts
+++ b/src/cli/handlers/mcp.ts
@@ -1,4 +1,5 @@
 import { ArgError } from "../args.js";
+import type { ImportConflictStrategy } from "../import-plan.js";
 import { runAdd } from "./add.js";
 import { runEdit } from "./edit.js";
 import { runMcpGet } from "./get.js";
@@ -46,6 +47,7 @@ export async function runMcp(ctx: HandlerCtx): Promise<void> {
       await runImport(ctx, {
         yes: flags.yes === true,
         dryRun: flags["dry-run"] === true,
+        conflictStrategy: resolveImportConflictStrategy(flags["conflict-strategy"]),
       });
       return;
     case "link":
@@ -57,4 +59,23 @@ export async function runMcp(ctx: HandlerCtx): Promise<void> {
     default:
       throw new ArgError(`unknown mcp verb: ${verb}`);
   }
+}
+
+function resolveImportConflictStrategy(value: unknown): ImportConflictStrategy | undefined {
+  if (value === undefined || value === false) return undefined;
+  if (typeof value !== "string") {
+    throw new ArgError(
+      "--conflict-strategy must be one of add-missing-only|replace-selected|replace-from-agent",
+    );
+  }
+  if (
+    value !== "add-missing-only" &&
+    value !== "replace-selected" &&
+    value !== "replace-from-agent"
+  ) {
+    throw new ArgError(
+      `--conflict-strategy must be one of add-missing-only|replace-selected|replace-from-agent, got "${value}"`,
+    );
+  }
+  return value;
 }

--- a/src/cli/import-plan.test.ts
+++ b/src/cli/import-plan.test.ts
@@ -232,6 +232,39 @@ describe("buildImportPlan", () => {
     ]);
   });
 
+  it("does not prompt a conflict when the existing Ratel entry is equivalent to the Claude entry", () => {
+    const incoming = {
+      command: "echo",
+      args: ["fs"],
+      env: { B: "2", A: "1" },
+    } as ServerEntry;
+    const existingRatelEntry: ServerEntry = {
+      type: "stdio",
+      env: { A: "1", B: "2" },
+      args: ["fs"],
+      command: "echo",
+    };
+    const plan = buildImportPlan(
+      emptyInputs({
+        claudeUser: claudeDoc("user", { fs: incoming }),
+        ratelUser: { mcpServers: { fs: existingRatelEntry } },
+      }),
+    );
+
+    expect(findWrite(plan, RATEL_USER)).toBeUndefined();
+    expect(plan.summary.conflicts).toEqual([]);
+    expect(plan.summary.skipped).toEqual([]);
+    expect(plan.summary.movedFromUser).toEqual(["fs"]);
+    const claudeUser = parseAfter(plan, HOME_CLAUDE);
+    expect(claudeUser.mcpServers).toEqual({
+      "ratel-mcp": {
+        type: "stdio",
+        command: "ratel-mcp",
+        args: ["serve", "--config", RATEL_USER],
+      },
+    });
+  });
+
   it("replaces Ratel entries on conflicts when requested", () => {
     const existingRatelEntry: ServerEntry = { type: "stdio", command: "kept" };
     const plan = buildImportPlan(

--- a/src/cli/import-plan.test.ts
+++ b/src/cli/import-plan.test.ts
@@ -211,7 +211,7 @@ describe("buildImportPlan", () => {
     expect(findWrite(plan, RATEL_USER)).toBeUndefined();
   });
 
-  it("logs collisions when an entry exists both in Claude and the existing Ratel target (Ratel wins)", () => {
+  it("keeps Ratel entries on conflicts by default and exposes structured conflict data", () => {
     const existingRatelEntry: ServerEntry = { type: "stdio", command: "kept" };
     const plan = buildImportPlan(
       emptyInputs({
@@ -226,6 +226,54 @@ describe("buildImportPlan", () => {
     expect(plan.summary.skipped).toEqual(
       expect.arrayContaining([expect.objectContaining({ name: "fs", scope: "user" })]),
     );
+    expect(plan.summary.conflictStrategy).toBe("add-missing-only");
+    expect(plan.summary.conflicts).toEqual([
+      { name: "fs", scope: "user", incoming: FS_ENTRY, existing: existingRatelEntry },
+    ]);
+  });
+
+  it("replaces Ratel entries on conflicts when requested", () => {
+    const existingRatelEntry: ServerEntry = { type: "stdio", command: "kept" };
+    const plan = buildImportPlan(
+      emptyInputs({
+        claudeUser: claudeDoc("user", { fs: FS_ENTRY, other: REMOTE_ENTRY }),
+        ratelUser: { mcpServers: { fs: existingRatelEntry } },
+      }),
+      { conflictStrategy: "replace-from-agent" },
+    );
+
+    const ratelUser = parseAfter(plan, RATEL_USER);
+    expect(ratelUser.mcpServers.fs).toEqual(FS_ENTRY);
+    expect(ratelUser.mcpServers.other).toEqual(REMOTE_ENTRY);
+    expect(plan.summary.skipped).toEqual([]);
+    expect(plan.summary.conflictStrategy).toBe("replace-from-agent");
+    expect(plan.summary.conflicts).toEqual([
+      { name: "fs", scope: "user", incoming: FS_ENTRY, existing: existingRatelEntry },
+    ]);
+  });
+
+  it("replaces only selected conflicts when requested", () => {
+    const existingFs: ServerEntry = { type: "stdio", command: "kept-fs" };
+    const existingRemote: ServerEntry = { type: "http", url: "https://kept" };
+    const plan = buildImportPlan(
+      emptyInputs({
+        claudeUser: claudeDoc("user", { fs: FS_ENTRY, remote: REMOTE_ENTRY }),
+        ratelUser: { mcpServers: { fs: existingFs, remote: existingRemote } },
+      }),
+      { conflictStrategy: "replace-selected", replaceConflicts: ["user:remote"] },
+    );
+
+    const ratelUser = parseAfter(plan, RATEL_USER);
+    expect(ratelUser.mcpServers.fs).toEqual(existingFs);
+    expect(ratelUser.mcpServers.remote).toEqual(REMOTE_ENTRY);
+    expect(plan.summary.skipped).toEqual([
+      { name: "fs", scope: "user", reason: "conflicts with existing Ratel user config" },
+    ]);
+    expect(plan.summary.conflictStrategy).toBe("replace-selected");
+    expect(plan.summary.conflicts.map((c) => `${c.scope}:${c.name}`).sort()).toEqual([
+      "user:fs",
+      "user:remote",
+    ]);
   });
 
   it("does not emit a ratel-mcp entry into a Claude scope that had no MCPs", () => {

--- a/src/cli/import-plan.ts
+++ b/src/cli/import-plan.ts
@@ -295,6 +295,10 @@ function applyConflictStrategy(
   const out: Record<string, ServerEntry> = ratel ? { ...ratel.mcpServers } : {};
   for (const name of bundle.movableNames.slice()) {
     if (out[name]) {
+      if (entriesEquivalent(out[name], bundle.movableEntries[name])) {
+        bundle.movableEntries[name] = out[name];
+        continue;
+      }
       conflicts.push({ name, scope, incoming: bundle.movableEntries[name], existing: out[name] });
       const shouldReplace =
         strategy === "replace-from-agent" ||
@@ -317,6 +321,30 @@ function applyConflictStrategy(
 
 export function conflictKey(scope: ClaudeScope, name: string): string {
   return `${scope}:${name}`;
+}
+
+function entriesEquivalent(a: ServerEntry, b: ServerEntry): boolean {
+  return canonicalJson(normalizeEntry(a)) === canonicalJson(normalizeEntry(b));
+}
+
+function normalizeEntry(entry: ServerEntry): Record<string, unknown> {
+  const out: Record<string, unknown> = { ...entry };
+  if (out.type === undefined) out.type = "stdio";
+  return out;
+}
+
+function canonicalJson(value: unknown): string {
+  return JSON.stringify(sortJsonValue(value));
+}
+
+function sortJsonValue(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(sortJsonValue);
+  if (!isPlainObject(value)) return value;
+  const out: Record<string, unknown> = {};
+  for (const key of Object.keys(value).sort()) {
+    out[key] = sortJsonValue(value[key]);
+  }
+  return out;
 }
 
 function makeRatelEntry(bin: ResolvedBin, configArgs: string[]): ServerEntry {

--- a/src/cli/import-plan.ts
+++ b/src/cli/import-plan.ts
@@ -30,6 +30,15 @@ export interface SkippedEntry {
   reason: string;
 }
 
+export interface ImportConflict {
+  name: string;
+  scope: ClaudeScope;
+  incoming: ServerEntry;
+  existing: ServerEntry;
+}
+
+export type ImportConflictStrategy = "add-missing-only" | "replace-from-agent" | "replace-selected";
+
 export interface ImportPlan {
   ratelChanges: FileChange[];
   claudeChanges: FileChange[];
@@ -38,6 +47,8 @@ export interface ImportPlan {
     movedFromProject: string[];
     movedFromLocal: string[];
     skipped: SkippedEntry[];
+    conflicts: ImportConflict[];
+    conflictStrategy: ImportConflictStrategy;
     ratelEntryArgsByScope: Partial<Record<ClaudeScope, string[]>>;
     overwrittenRatelEntries: ClaudeScope[];
   };
@@ -45,6 +56,8 @@ export interface ImportPlan {
 
 export interface BuildImportPlanOptions {
   selection?: ReadonlySet<string> | readonly string[];
+  conflictStrategy?: ImportConflictStrategy;
+  replaceConflicts?: ReadonlySet<string> | readonly string[];
 }
 
 const RATEL_NAME = "ratel-mcp";
@@ -76,7 +89,10 @@ export function buildImportPlan(
   options: BuildImportPlanOptions = {},
 ): ImportPlan {
   const skipped: SkippedEntry[] = [];
+  const conflicts: ImportConflict[] = [];
   const selection = normalizeSelection(options.selection);
+  const conflictStrategy = options.conflictStrategy ?? "add-missing-only";
+  const replaceConflicts = normalizeSelection(options.replaceConflicts);
 
   const g = bundleClaudeScope(inputs.claudeUser);
   const p = bundleClaudeScope(inputs.claudeProject);
@@ -129,13 +145,37 @@ export function buildImportPlan(
   const claudeRewriteP = p.movableNames.slice();
   const claudeRewriteL = l.movableNames.slice();
 
-  // Apply Ratel-wins on collisions.
-  const ratelUserNew = applyRatelWins(inputs.ratelUser, g, "user", skipped);
+  // Apply conflict policy on collisions.
+  const ratelUserNew = applyConflictStrategy(
+    inputs.ratelUser,
+    g,
+    "user",
+    skipped,
+    conflicts,
+    conflictStrategy,
+    replaceConflicts,
+  );
   const ratelProjectNew = inputs.ratelProjectPath
-    ? applyRatelWins(inputs.ratelProject, p, "project", skipped)
+    ? applyConflictStrategy(
+        inputs.ratelProject,
+        p,
+        "project",
+        skipped,
+        conflicts,
+        conflictStrategy,
+        replaceConflicts,
+      )
     : null;
   const ratelLocalNew = inputs.ratelLocalPath
-    ? applyRatelWins(inputs.ratelLocal, l, "local", skipped)
+    ? applyConflictStrategy(
+        inputs.ratelLocal,
+        l,
+        "local",
+        skipped,
+        conflicts,
+        conflictStrategy,
+        replaceConflicts,
+      )
     : null;
 
   // Compute ratel-mcp entry per scope: gated on the Claude-rewrite snapshot.
@@ -216,6 +256,8 @@ export function buildImportPlan(
       movedFromProject: p.movableNames.slice(),
       movedFromLocal: l.movableNames.slice(),
       skipped,
+      conflicts,
+      conflictStrategy,
       ratelEntryArgsByScope,
       overwrittenRatelEntries,
     },
@@ -241,27 +283,40 @@ function filterBundle(bundle: ScopeBundle, selection: ReadonlySet<string>): void
   }
 }
 
-function applyRatelWins(
+function applyConflictStrategy(
   ratel: RatelConfig | null,
   bundle: ScopeBundle,
   scope: ClaudeScope,
   skipped: SkippedEntry[],
+  conflicts: ImportConflict[],
+  strategy: ImportConflictStrategy,
+  replaceConflicts: ReadonlySet<string> | null,
 ): RatelConfig | null {
   const out: Record<string, ServerEntry> = ratel ? { ...ratel.mcpServers } : {};
   for (const name of bundle.movableNames.slice()) {
     if (out[name]) {
-      skipped.push({
-        name,
-        scope,
-        reason: `already present in Ratel ${scope} config`,
-      });
-      removeFromBundle(bundle, name);
-      continue;
+      conflicts.push({ name, scope, incoming: bundle.movableEntries[name], existing: out[name] });
+      const shouldReplace =
+        strategy === "replace-from-agent" ||
+        (strategy === "replace-selected" && replaceConflicts?.has(conflictKey(scope, name)));
+      if (!shouldReplace) {
+        skipped.push({
+          name,
+          scope,
+          reason: `conflicts with existing Ratel ${scope} config`,
+        });
+        removeFromBundle(bundle, name);
+        continue;
+      }
     }
     out[name] = bundle.movableEntries[name];
   }
   if (!ratel && Object.keys(out).length === 0) return null;
   return { mcpServers: out };
+}
+
+export function conflictKey(scope: ClaudeScope, name: string): string {
+  return `${scope}:${name}`;
 }
 
 function makeRatelEntry(bin: ResolvedBin, configArgs: string[]): ServerEntry {


### PR DESCRIPTION
## Summary

- Detect import conflicts before writing MCP config changes.
- Show clearer prompts and wording when conflicts need a decision.
- Point recovery hints at the backup command and cover the new flows with tests.