### PR TITLE
Keep auth-needed upstreams in aggregate

### DIFF
--- a/src/lib/gateway.test.ts
+++ b/src/lib/gateway.test.ts
@@ -298,6 +298,49 @@ describe("buildGatewayFromConfig", () => {
     await ok.server.close();
   });
 
+  it.each([
+    Object.assign(new Error("request failed"), { status: 401 }),
+    Object.assign(new Error("request failed"), { statusCode: 403 }),
+    Object.assign(new Error("request failed"), { response: { status: 401 } }),
+    new Error("401 Unauthorized"),
+    Object.assign(new Error("request failed"), { code: "ERR_UNAUTHORIZED" }),
+  ])("flags HTTP upstreams as needsAuth when boot register throws an auth-shaped error %#", async (authError) => {
+    const logs: string[] = [];
+
+    const handle = await buildGatewayFromConfig(
+      {
+        mcpServers: {
+          linear: {
+            type: "http",
+            url: "https://mcp.linear.example/mcp",
+            description: "Linear workspace tools",
+          },
+        },
+      },
+      {
+        transportFactory: () => ({
+          async start() {
+            throw authError;
+          },
+          async send() {},
+          async close() {},
+        }),
+        logger: (m) => logs.push(m),
+      },
+    );
+
+    expect(handle.upstreamServers).toEqual([
+      {
+        name: "linear",
+        description: "Linear workspace tools",
+        needsAuth: true,
+      },
+    ]);
+    expect(logs.join("\n")).toMatch(/linear requires authorization/);
+
+    await handle.close();
+  });
+
   describe("OAuth boot path", () => {
     let oauthDir: string;
     beforeEach(async () => {

--- a/src/lib/gateway.ts
+++ b/src/lib/gateway.ts
@@ -52,12 +52,32 @@ const AUTH_SHAPED_ERROR_PATTERNS: ReadonlyArray<RegExp> = [
   /prepareTokenRequest/i,
   /authorizationCode is required/i,
   /invalid_grant/i,
+  /\b(401|403|unauthori[sz]ed|forbidden)\b/i,
 ];
 
 function isAuthShapedError(err: unknown): boolean {
   const msg = (err as { message?: unknown } | null)?.message;
   if (typeof msg !== "string") return false;
   return AUTH_SHAPED_ERROR_PATTERNS.some((re) => re.test(msg));
+}
+
+function isAuthRequiredError(err: unknown): boolean {
+  if (isUnauthorized(err) || isAuthShapedError(err)) return true;
+
+  const status = getAuthStatus(err);
+  if (status === 401 || status === 403) return true;
+
+  const code = (err as { code?: unknown } | null)?.code;
+  return code === 401 || code === 403 || code === "Unauthorized" || code === "ERR_UNAUTHORIZED";
+}
+
+function getAuthStatus(err: unknown): unknown {
+  const shaped = err as {
+    status?: unknown;
+    statusCode?: unknown;
+    response?: { status?: unknown };
+  } | null;
+  return shaped?.status ?? shaped?.statusCode ?? shaped?.response?.status;
 }
 
 export interface GatewayHandle {
@@ -120,7 +140,7 @@ export async function buildGatewayFromConfig(
       if (handle.serverInstructions) info.instructions = handle.serverInstructions;
       upstreamServers.push(info);
     } catch (err) {
-      if (isUnauthorized(err) || (isHttpOrSse(entry) && isAuthShapedError(err))) {
+      if (isHttpOrSse(entry) && isAuthRequiredError(err)) {
         markNeedsAuth(upstreamServers, name, entry);
         catalog.recordEvent({ type: "auth_needs", upstream: name });
         log(
@@ -252,9 +272,14 @@ function markNeedsAuth(
   name: string,
   entry: ServerEntry,
 ): void {
-  const info: UpstreamServerInfo = { name, needsAuth: true };
+  let info = upstreamServers.find((u) => u.name === name);
+  if (!info) {
+    info = { name };
+    upstreamServers.push(info);
+  }
+  info.needsAuth = true;
+  delete info.toolCount;
   if (entry.description) info.description = entry.description;
-  upstreamServers.push(info);
 }
 
 const defaultRefreshTokens: RefreshTokensFn = async (store) => {


### PR DESCRIPTION
## Summary

- Preserve upstream MCPs that still need auth when building aggregate config.
- Keep configured and auth-needed upstreams visible together instead of dropping pending entries.
- Add regression coverage for the aggregate gateway output.