### PR TITLE
Add top-level version flag

### DIFF
--- a/src/bin.ts
+++ b/src/bin.ts
@@ -1,10 +1,15 @@
 #!/usr/bin/env node
+import { createRequire } from "node:module";
 import { runCli } from "./cli/cli.js";
 import { defaultPromptAdapter } from "./cli/prompts.js";
+
+const require = createRequire(import.meta.url);
+const pkg = require("../package.json") as { version?: string };
 
 async function main() {
   const result = await runCli(process.argv.slice(2), {
     prompts: defaultPromptAdapter(),
+    cliVersion: pkg.version ?? "0.0.0",
   });
 
   if (!result.shutdown) return;

--- a/src/cli/args.test.ts
+++ b/src/cli/args.test.ts
@@ -17,6 +17,12 @@ describe("parseArgs — group/verb routing", () => {
     expect(parseArgs(["help"]).group).toBe("help");
   });
 
+  it("treats top-level version flags as the version group", () => {
+    expect(parseArgs(["--version"]).group).toBe("version");
+    expect(parseArgs(["-V"]).group).toBe("version");
+    expect(parseArgs(["version"]).group).toBe("version");
+  });
+
   it("recognizes the mcp group with no verb", () => {
     const r = parseArgs(["mcp"]);
     expect(r.group).toBe("mcp");

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -1,4 +1,4 @@
-export type Group = "mcp" | "backup" | "serve" | "ui" | "help";
+export type Group = "mcp" | "backup" | "serve" | "ui" | "help" | "version";
 
 export type McpVerb = "add" | "remove" | "list" | "get" | "edit" | "import" | "link" | "auth";
 
@@ -69,6 +69,9 @@ export function parseArgs(argv: string[]): ParsedArgs {
   const first = argv[0];
   if (first === "--help" || first === "-h" || first === "help") {
     return { group: "help", configPaths, rest, extras, flags };
+  }
+  if (first === "--version" || first === "-V" || first === "version") {
+    return { group: "version", configPaths, rest, extras, flags };
   }
 
   let group: Group;

--- a/src/cli/cli.test.ts
+++ b/src/cli/cli.test.ts
@@ -164,6 +164,12 @@ describe("runCli — help and routing", () => {
     expect(out).toMatch(/backup/);
   });
 
+  it("--version logs the injected package version", async () => {
+    const logs: string[] = [];
+    await runCli(["--version"], { cliVersion: "1.2.3", logger: (m) => logs.push(m) });
+    expect(logs).toEqual(["1.2.3"]);
+  });
+
   it("`ratel-mcp mcp` (no verb) logs the mcp group usage", async () => {
     const logs: string[] = [];
     await runCli(["mcp"], { logger: (m) => logs.push(m) });

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -24,6 +24,7 @@ export interface RunCliOptions {
   fs?: JsonFs & BackupFs;
   env?: HierarchyEnv;
   now?: () => Date;
+  cliVersion?: string;
 }
 
 export interface RunCliResult {
@@ -54,6 +55,11 @@ export async function runCli(argv: string[], options: RunCliOptions = {}): Promi
 
   if (parsed.group === "help") {
     log(TOP_USAGE);
+    return {};
+  }
+
+  if (parsed.group === "version") {
+    log(options.cliVersion ?? options.serverVersion ?? "0.0.0");
     return {};
   }
 


### PR DESCRIPTION
## Summary
- add top-level `--version`, `-V`, and `version` routing before group dispatch
- pass the published package version from `dist/bin.js` through `runCli`
- cover argument parsing and CLI output with focused tests

## Validation
- `npx --yes pnpm@10.33.0 vitest run src/cli/args.test.ts src/cli/cli.test.ts`
- `npx --yes pnpm@10.33.0 typecheck`
- `npx --yes pnpm@10.33.0 build`
- `npx --yes pnpm@10.33.0 test`
- `npx --yes pnpm@10.33.0 lint`
- `node dist/bin.js --version`
- `node dist/bin.js --help`
- `git diff --check`