### PR TITLE
Handle unsupported OAuth registration

### DIFF
--- a/apps/ratel-mcp/src/cli/handlers/mcp-auth.test.ts
+++ b/apps/ratel-mcp/src/cli/handlers/mcp-auth.test.ts
@@ -175,6 +175,7 @@ describe("runMcpAuth", () => {
             local: { type: "stdio", command: "x" },
             fresh: { type: "http", url: "https://fresh.example" },
             unconfigured: { type: "http", url: "https://no-tokens.example" },
+            unsupported: { type: "http", url: "https://unsupported.example" },
           },
         }),
       );
@@ -194,6 +195,15 @@ describe("runMcpAuth", () => {
           expires_at: Date.now() + 23 * 3600 * 1000,
         }),
       );
+      fs.files.set(
+        "/home/u/.ratel/oauth/unsupported.json",
+        JSON.stringify({
+          unsupported: {
+            reason: "OAuth client registration was rejected",
+            detected_at: new Date().toISOString(),
+          },
+        }),
+      );
 
       const runner = vi.fn();
       const logs: string[] = [];
@@ -207,6 +217,7 @@ describe("runMcpAuth", () => {
       expect(all).toMatch(/local\s+\[n\/a\]/);
       expect(all).toMatch(/fresh\s+\[ok\]/);
       expect(all).toMatch(/unconfigured\s+\[needs auth\]/);
+      expect(all).toMatch(/unsupported\s+\[unsupported\].*OAuth client registration was rejected/);
     });
   });
 

--- a/apps/ratel-mcp/src/cli/handlers/mcp-auth.ts
+++ b/apps/ratel-mcp/src/cli/handlers/mcp-auth.ts
@@ -52,9 +52,10 @@ function printResults(ctx: HandlerCtx, results: AuthFlowResult[]): void {
 interface StoredOAuth {
   tokens?: { access_token?: string; refresh_token?: string };
   expires_at?: number;
+  unsupported?: { reason?: string; detected_at?: string };
 }
 
-type CheckStatus = "n/a" | "needs auth" | "expired" | "ok";
+type CheckStatus = "n/a" | "needs auth" | "expired" | "ok" | "unsupported";
 
 async function printCheckReport(ctx: HandlerCtx, config: RatelConfig): Promise<void> {
   const lines: string[] = [];
@@ -76,6 +77,9 @@ async function checkUpstream(
   const path = join(ctx.env.homeDir, ".ratel", "oauth", `${name}.json`);
   const stored = await readJson<StoredOAuth>(ctx.fs, path);
   if (!stored?.tokens?.access_token) {
+    if (stored?.unsupported?.reason) {
+      return { status: "unsupported", detail: stored.unsupported.reason };
+    }
     return { status: "needs auth", detail: "no tokens stored" };
   }
   const expiresAt = typeof stored.expires_at === "number" ? stored.expires_at : undefined;

--- a/apps/ratel-mcp/src/cli/handlers/mcp-list.ts
+++ b/apps/ratel-mcp/src/cli/handlers/mcp-list.ts
@@ -10,11 +10,12 @@ import type { HandlerCtx } from "./types.js";
 
 const SCOPES: readonly RatelScope[] = ["user", "project", "local"];
 
-type AuthStatus = "n/a" | "needs auth" | "expired" | "ok";
+type AuthStatus = "n/a" | "needs auth" | "expired" | "ok" | "unsupported";
 
 interface StoredOAuth {
   tokens?: { access_token?: string };
   expires_at?: number;
+  unsupported?: { reason?: string; detected_at?: string };
 }
 
 export async function runMcpList(ctx: HandlerCtx): Promise<void> {
@@ -68,7 +69,10 @@ async function resolveAuthStatus(
   if (!ctx.env.homeDir) return "needs auth";
   const path = join(ctx.env.homeDir, ".ratel", "oauth", `${name}.json`);
   const stored = await readJson<StoredOAuth>(ctx.fs, path);
-  if (!stored?.tokens?.access_token) return "needs auth";
+  if (!stored?.tokens?.access_token) {
+    if (stored?.unsupported?.reason) return "unsupported";
+    return "needs auth";
+  }
   if (typeof stored.expires_at === "number" && stored.expires_at < Date.now()) {
     return "expired";
   }

--- a/apps/ratel-mcp/src/ui/routes.ts
+++ b/apps/ratel-mcp/src/ui/routes.ts
@@ -105,7 +105,10 @@ export async function authServer(ctx: HandlerCtx, name: string): Promise<ApiResp
   const { result, log } = await withCapture(ctx, (c) => authorizeServer(c, name));
   const resultLines = formatAuthResults(result);
   log.push(...resultLines);
-  const failedLines = resultLines.filter((_, index) => result[index]?.status === "failed");
+  const failedLines = resultLines.filter((_, index) => {
+    const status = result[index]?.status;
+    return status === "failed" || status === "unsupported";
+  });
   if (failedLines.length > 0) {
     throw new Error(failedLines.join("\n"));
   }

--- a/packages/core/src/lib/oauth/flow.test.ts
+++ b/packages/core/src/lib/oauth/flow.test.ts
@@ -109,6 +109,29 @@ describe("runAuthFlow", () => {
     expect(stripe?.needsAuth).toBe(true);
   });
 
+  it("returns unsupported rows without marking the upstream authorized", async () => {
+    const { catalog, upstreams, handles, configEntries } = setup();
+    const step: AuthStep = async () => ({
+      status: "unsupported",
+      reason: "OAuth client registration was rejected",
+    });
+
+    const results = await runAuthFlow({
+      catalog,
+      upstreams,
+      handles,
+      configEntries,
+      step,
+      opts: { name: "stripe" },
+    });
+
+    expect(results).toEqual([
+      { name: "stripe", status: "unsupported", reason: "OAuth client registration was rejected" },
+    ]);
+    expect(upstreams.find((u) => u.name === "stripe")?.needsAuth).toBe(true);
+    expect(handles.has("stripe")).toBe(false);
+  });
+
   it("treats step throws as failed rows", async () => {
     const { catalog, upstreams, handles, configEntries } = setup();
     const step: AuthStep = async (name) => {

--- a/packages/core/src/lib/oauth/flow.ts
+++ b/packages/core/src/lib/oauth/flow.ts
@@ -21,7 +21,7 @@ export interface AuthFlowOptions {
 
 export interface AuthFlowResult {
   name: string;
-  status: "authorized" | "skipped" | "failed";
+  status: "authorized" | "skipped" | "failed" | "unsupported";
   reason?: string;
   /** Which path produced this row (only meaningful when status === "authorized"). */
   mode?: AuthMode;
@@ -41,12 +41,17 @@ export interface AuthStepFailure {
   reason: string;
 }
 
+export interface AuthStepUnsupported {
+  status: "unsupported";
+  reason: string;
+}
+
 export interface AuthStepSkip {
   status: "skipped";
   reason: string;
 }
 
-export type AuthStepResult = AuthStepSuccess | AuthStepFailure | AuthStepSkip;
+export type AuthStepResult = AuthStepSuccess | AuthStepFailure | AuthStepSkip | AuthStepUnsupported;
 
 export interface AuthStepCtx {
   catalog: ToolCatalog;
@@ -193,6 +198,7 @@ export interface PkceFlowDeps {
   callbackFactory: typeof startOAuthCallback;
   logger: (m: string) => void;
   callbackTimeoutMs?: number;
+  fetch?: typeof fetch;
 }
 
 export type PkceFlowFn = (
@@ -284,6 +290,9 @@ const defaultRefreshTransportFactory = (
   );
 };
 
+const UNSUPPORTED_OAUTH_REASON =
+  "OAuth client registration was rejected by the authorization server. This MCP server may only allow approved MCP clients.";
+
 /** Interactive PKCE flow against a loopback callback server. */
 export async function runPkceFlow(
   name: string,
@@ -310,6 +319,7 @@ export async function runPkceFlow(
 
   try {
     const store = new RatelOAuthStore(storePath(name));
+    const oauthFetchTracker = createOAuthFetchTracker(store, deps.fetch ?? fetch);
     const provider = new RatelOAuthProvider({
       store,
       redirectUrl: cb.url,
@@ -327,7 +337,10 @@ export async function runPkceFlow(
     });
 
     const tx1 = wrapTransportWithSendMutex(
-      new StreamableHTTPClientTransport(new URL(entry.url), { authProvider: provider }),
+      new StreamableHTTPClientTransport(new URL(entry.url), {
+        authProvider: provider,
+        fetch: oauthFetchTracker.fetch,
+      }),
     );
     try {
       const handle = await registerMcpServer(ctx.catalog, { name, transport: tx1 });
@@ -335,6 +348,10 @@ export async function runPkceFlow(
     } catch (err) {
       if (!isUnauthorized(err)) {
         await safeClose(tx1);
+        if (oauthFetchTracker.isUnsupportedOAuth()) {
+          await markUnsupported(store);
+          return { status: "unsupported", reason: UNSUPPORTED_OAUTH_REASON };
+        }
         return { status: "failed", reason: (err as Error).message };
       }
     }
@@ -348,7 +365,10 @@ export async function runPkceFlow(
       return { status: "failed", reason: `${name}: ${(err as Error).message}` };
     }
 
-    const tx2 = new StreamableHTTPClientTransport(new URL(entry.url), { authProvider: provider });
+    const tx2 = new StreamableHTTPClientTransport(new URL(entry.url), {
+      authProvider: provider,
+      fetch: oauthFetchTracker.fetch,
+    });
     try {
       await tx2.finishAuth(code);
     } catch (err) {
@@ -361,7 +381,10 @@ export async function runPkceFlow(
     await safeClose(tx2);
 
     const tx3 = wrapTransportWithSendMutex(
-      new StreamableHTTPClientTransport(new URL(entry.url), { authProvider: provider }),
+      new StreamableHTTPClientTransport(new URL(entry.url), {
+        authProvider: provider,
+        fetch: oauthFetchTracker.fetch,
+      }),
     );
     try {
       const handle = await registerMcpServer(ctx.catalog, { name, transport: tx3 });
@@ -372,6 +395,79 @@ export async function runPkceFlow(
     }
   } finally {
     if (cb) await cb.close().catch(() => undefined);
+  }
+}
+
+function createOAuthFetchTracker(store: RatelOAuthStore, fetchImpl: typeof fetch) {
+  let unsupportedOAuth = false;
+  const trackedFetch: typeof fetch = async (input, init) => {
+    const method = requestMethod(input, init);
+    const url = requestUrl(input);
+    const response = await fetchImpl(input, init);
+    if (method === "POST" && response.status === 403) {
+      const registrationEndpoint = await currentRegistrationEndpoint(store);
+      if (registrationEndpoint && sameUrl(url, registrationEndpoint)) {
+        const body = await readJsonBody(response);
+        if (!isOAuthErrorResponse(body)) unsupportedOAuth = true;
+      }
+    }
+    return response;
+  };
+  return {
+    fetch: trackedFetch,
+    isUnsupportedOAuth: () => unsupportedOAuth,
+  };
+}
+
+async function markUnsupported(store: RatelOAuthStore): Promise<void> {
+  await store.save({
+    unsupported: {
+      reason: UNSUPPORTED_OAUTH_REASON,
+      detected_at: new Date().toISOString(),
+    },
+  });
+}
+
+async function currentRegistrationEndpoint(store: RatelOAuthStore): Promise<string | undefined> {
+  const metadata = (await store.load()).discovery_state?.authorizationServerMetadata as
+    | { registration_endpoint?: unknown }
+    | undefined;
+  return typeof metadata?.registration_endpoint === "string"
+    ? metadata.registration_endpoint
+    : undefined;
+}
+
+function requestMethod(input: Parameters<typeof fetch>[0], init: Parameters<typeof fetch>[1]) {
+  return (init?.method ?? (input instanceof Request ? input.method : "GET")).toUpperCase();
+}
+
+function requestUrl(input: Parameters<typeof fetch>[0]): string {
+  if (typeof input === "string") return input;
+  if (input instanceof URL) return String(input);
+  return input.url;
+}
+
+async function readJsonBody(response: Response): Promise<unknown> {
+  try {
+    return await response.clone().json();
+  } catch {
+    return undefined;
+  }
+}
+
+function isOAuthErrorResponse(body: unknown): boolean {
+  return (
+    typeof body === "object" &&
+    body !== null &&
+    typeof (body as { error?: unknown }).error === "string"
+  );
+}
+
+function sameUrl(actual: string, expected: string): boolean {
+  try {
+    return new URL(actual).href === new URL(expected).href;
+  } catch {
+    return actual === expected;
   }
 }
 

--- a/packages/core/src/lib/oauth/store.test.ts
+++ b/packages/core/src/lib/oauth/store.test.ts
@@ -66,6 +66,22 @@ describe("RatelOAuthStore", () => {
     expect(state.tokens?.access_token).toBe("atk");
   });
 
+  it("saveTokens clears a previous unsupported marker", async () => {
+    const store = newStore();
+    await store.save({
+      unsupported: {
+        reason: "OAuth client registration was rejected",
+        detected_at: new Date().toISOString(),
+      },
+    });
+    await store.save({
+      tokens: { access_token: "atk", token_type: "Bearer", expires_in: 60 },
+    });
+    const state = await store.load();
+    expect(state.tokens?.access_token).toBe("atk");
+    expect(state.unsupported).toBeUndefined();
+  });
+
   it("clear('tokens') drops tokens and expires_at but keeps client_information", async () => {
     const store = newStore();
     await store.save({

--- a/packages/core/src/lib/oauth/store.ts
+++ b/packages/core/src/lib/oauth/store.ts
@@ -12,6 +12,11 @@ import lockfile from "proper-lockfile";
 
 export type ClearScope = "all" | "tokens" | "client" | "verifier" | "discovery";
 
+export interface UnsupportedOAuthMarker {
+  reason: string;
+  detected_at: string;
+}
+
 export interface OAuthStoreState {
   tokens?: OAuthTokens;
   expires_at?: number;
@@ -19,6 +24,7 @@ export interface OAuthStoreState {
   code_verifier?: string;
   state?: string;
   discovery_state?: OAuthDiscoveryState;
+  unsupported?: UnsupportedOAuthMarker;
 }
 
 const DIR_MODE = 0o700;
@@ -91,6 +97,9 @@ export class RatelOAuthStore {
     if (parsed.discovery_state !== undefined) {
       state.discovery_state = parsed.discovery_state as OAuthDiscoveryState;
     }
+    if (isUnsupportedOAuthMarker(parsed.unsupported)) {
+      state.unsupported = parsed.unsupported;
+    }
     return state;
   }
 
@@ -101,6 +110,7 @@ export class RatelOAuthStore {
       if (partial.tokens !== undefined) {
         const validated = OAuthTokensSchema.parse(partial.tokens);
         next.tokens = validated;
+        delete next.unsupported;
         next.expires_at =
           typeof validated.expires_in === "number"
             ? Date.now() + validated.expires_in * 1000
@@ -163,4 +173,13 @@ export class RatelOAuthStore {
       // best-effort
     });
   }
+}
+
+function isUnsupportedOAuthMarker(value: unknown): value is UnsupportedOAuthMarker {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    typeof (value as { reason?: unknown }).reason === "string" &&
+    typeof (value as { detected_at?: unknown }).detected_at === "string"
+  );
 }

--- a/packages/core/src/operations.test.ts
+++ b/packages/core/src/operations.test.ts
@@ -97,6 +97,8 @@ describe("core operations — config state", () => {
           remote: { type: "http", url: "https://example.com/mcp" },
           expired: { type: "http", url: "https://expired.example/mcp" },
           ready: { type: "http", url: "https://ready.example/mcp" },
+          unsupported: { type: "http", url: "https://unsupported.example/mcp" },
+          recovered: { type: "http", url: "https://recovered.example/mcp" },
         },
       }),
     );
@@ -108,6 +110,25 @@ describe("core operations — config state", () => {
       `${HOME}/.ratel/oauth/ready.json`,
       JSON.stringify({ tokens: { access_token: "x" }, expires_at: Date.now() + 100000 }),
     );
+    fs.files.set(
+      `${HOME}/.ratel/oauth/unsupported.json`,
+      JSON.stringify({
+        unsupported: {
+          reason: "OAuth client registration was rejected",
+          detected_at: new Date().toISOString(),
+        },
+      }),
+    );
+    fs.files.set(
+      `${HOME}/.ratel/oauth/recovered.json`,
+      JSON.stringify({
+        tokens: { access_token: "x" },
+        unsupported: {
+          reason: "OAuth client registration was rejected",
+          detected_at: new Date().toISOString(),
+        },
+      }),
+    );
 
     const state = await getConfigState(ctx(fs));
     expect(state.scopes.user.available).toBe(true);
@@ -116,6 +137,8 @@ describe("core operations — config state", () => {
     expect(state.scopes.user.authStatus.remote).toBe("needs auth");
     expect(state.scopes.user.authStatus.expired).toBe("expired");
     expect(state.scopes.user.authStatus.ready).toBe("ok");
+    expect(state.scopes.user.authStatus.unsupported).toBe("unsupported");
+    expect(state.scopes.user.authStatus.recovered).toBe("ok");
   });
 });
 

--- a/packages/core/src/operations.ts
+++ b/packages/core/src/operations.ts
@@ -49,7 +49,7 @@ export interface CoreContext {
   log?: (message: string) => void;
 }
 
-export type AuthStatus = "n/a" | "needs auth" | "expired" | "ok";
+export type AuthStatus = "n/a" | "needs auth" | "expired" | "ok" | "unsupported";
 
 export interface ConfigScopeStateAvailable {
   available: true;
@@ -93,11 +93,15 @@ export async function resolveAuthStatus(
   if (entry.type !== "http" && entry.type !== "sse") return "n/a";
   if (!ctx.env.homeDir) return "needs auth";
   const path = join(ctx.env.homeDir, ".ratel", "oauth", `${name}.json`);
-  const stored = await readJson<{ tokens?: { access_token?: string }; expires_at?: number }>(
-    ctx.fs,
-    path,
-  );
-  if (!stored?.tokens?.access_token) return "needs auth";
+  const stored = await readJson<{
+    tokens?: { access_token?: string };
+    expires_at?: number;
+    unsupported?: { reason?: string; detected_at?: string };
+  }>(ctx.fs, path);
+  if (!stored?.tokens?.access_token) {
+    if (stored?.unsupported?.reason) return "unsupported";
+    return "needs auth";
+  }
   if (typeof stored.expires_at === "number" && stored.expires_at < Date.now()) {
     return "expired";
   }

--- a/packages/core/src/probe.ts
+++ b/packages/core/src/probe.ts
@@ -85,7 +85,7 @@ export interface AuthProbeOptions {
 }
 
 export interface AuthProbeResult {
-  status: "authorized" | "failed" | "skipped";
+  status: "authorized" | "failed" | "skipped" | "unsupported";
   reason?: string;
   /** `serverInstructions` from the upstream when the flow succeeds. */
   instructions?: string;

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -59,7 +59,7 @@ import { cn } from "@/lib/utils";
 import "./App.css";
 
 export type RatelScope = "user" | "project" | "local";
-export type AuthStatus = "n/a" | "needs auth" | "expired" | "ok";
+export type AuthStatus = "n/a" | "needs auth" | "expired" | "ok" | "unsupported";
 type AgentHostKind = "claude-code" | "codex";
 type AgentPosture = "unavailable" | "empty" | "not-linked" | "ratel-only" | "mixed";
 
@@ -254,6 +254,7 @@ export function AppShell() {
         return true;
       } catch (err) {
         notify((err as Error).message, "error");
+        await refresh();
         return false;
       } finally {
         setBusy(false);
@@ -753,6 +754,7 @@ export function useRatelApp() {
 export function authBadgeVariant(status?: AuthStatus) {
   if (status === "needs auth") return "warning" as const;
   if (status === "expired") return "muted" as const;
+  if (status === "unsupported") return "destructive" as const;
   return "outline" as const;
 }
 

--- a/packages/ui/src/components/ui/badge.tsx
+++ b/packages/ui/src/components/ui/badge.tsx
@@ -12,7 +12,7 @@ const badgeVariants = cva(
         default: "bg-primary text-primary-foreground [a]:hover:bg-primary/90",
         secondary: "bg-secondary text-secondary-foreground [a]:hover:bg-secondary/90",
         destructive:
-          "bg-destructive/10 text-destructive focus-visible:ring-destructive/20 dark:bg-destructive/20 dark:focus-visible:ring-destructive/40 [a]:hover:bg-destructive/20",
+          "border-destructive/30 bg-destructive/10 text-destructive focus-visible:ring-destructive/20 dark:border-destructive/40 dark:bg-destructive/20 dark:focus-visible:ring-destructive/40 [a]:hover:bg-destructive/20",
         warning:
           "border-amber-300/70 bg-amber-50 text-amber-900 focus-visible:ring-amber-500/20 dark:border-amber-400/40 dark:bg-amber-500/15 dark:text-amber-200",
         muted:

--- a/packages/ui/src/lib/tool-source-labels.ts
+++ b/packages/ui/src/lib/tool-source-labels.ts
@@ -13,6 +13,7 @@ export const AUTH_STATUS_LABELS: Record<AuthStatus, string> = {
   expired: "Expired",
   "n/a": "No auth",
   ok: "Ready",
+  unsupported: "Unsupported",
 };
 
 export function toolSourceTypeLabel(type: ToolSourceType) {

--- a/packages/ui/src/pages/ToolsPage.tsx
+++ b/packages/ui/src/pages/ToolsPage.tsx
@@ -464,7 +464,7 @@ function ToolSourceRow(props: {
   busy: boolean;
   entry: ServerEntry;
   name: string;
-  onAuthorize: () => Promise<unknown> | void;
+  onAuthorize: () => Promise<unknown> | undefined;
   onOpen: () => void;
 }) {
   const canAuthorize =
@@ -655,7 +655,9 @@ export function ToolSourceDetailPage(props: { name: string; scope: string }) {
   const code = JSON.stringify({ [props.name]: entry }, null, 2);
   const type = entryTypeOf(entry);
   const target = summaryOf(entry);
-  const canAuthorize = entry.type === "http" || entry.type === "sse";
+  const canAuthorize =
+    (entry.type === "http" || entry.type === "sse") &&
+    (authStatus === "needs auth" || authStatus === "expired");
   const editFormId = `tool-source-edit-${scope}-${props.name}`;
 
   const authorize = () =>
@@ -1422,7 +1424,7 @@ function AuthBadge({ status }: { status?: AuthStatus }) {
 function AuthStatusControl(props: {
   busy: boolean;
   canAuthorize: boolean;
-  onAuthorize: () => Promise<unknown> | void;
+  onAuthorize: () => Promise<unknown> | undefined;
   status?: AuthStatus;
 }) {
   const [authorizing, setAuthorizing] = useState(false);
@@ -1471,6 +1473,8 @@ function authControlTextClassName(status?: AuthStatus) {
     status === "needs auth" &&
       "border-amber-300/70 bg-amber-50 text-amber-900 dark:border-amber-400/40 dark:bg-amber-500/15 dark:text-amber-200",
     status === "expired" && "border-border bg-muted text-muted-foreground",
+    status === "unsupported" &&
+      "border-destructive/30 bg-destructive/10 text-destructive dark:bg-destructive/15",
     (!status || status === "n/a" || status === "ok") &&
       "border-border bg-background text-foreground",
   );


### PR DESCRIPTION
## Summary

- Classify OAuth Dynamic Client Registration `403` rejections as `unsupported` instead of generic auth failures.
- Persist an unsupported OAuth marker and surface it in core status, CLI output, API errors, and the Vite UI.
- Refresh UI config after failed auth attempts so the unsupported badge updates immediately.

## Context

Some remote MCP providers reject OAuth client registration before user authorization when the MCP client is not approved. This avoids showing raw SDK errors such as `Invalid OAuth error response...Forbidden` and gives users a clearer status.

Figma MCP is one motivating case. Public reporting says Figma will review public third-party integrations and MCP clients before they can access user data: https://www.techradar.com/pro/figma-is-making-its-ai-agents-smarter-and-more-connected-to-help-boost-your-designs

The implementation does not hardcode Figma; it detects the OAuth DCR rejection pattern.

## Validation

- `pnpm typecheck`
- `pnpm lint`
- `pnpm --filter @ratel-ai/mcp-core test -- src/lib/oauth/store.test.ts src/operations.test.ts src/lib/oauth/flow.test.ts`
- `pnpm --filter @ratel-ai/mcp-server exec vitest run src/cli/handlers/mcp-auth.test.ts`
- `pnpm --filter @ratel-ai/mcp-ui test`