### PR TITLE
license: relicense to MIT

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -17,7 +17,7 @@
       },
       "homepage": "https://github.com/ratel-ai/ratel-mcp",
       "repository": "https://github.com/ratel-ai/ratel-mcp",
-      "license": "Elastic-2.0",
+      "license": "MIT",
       "category": "Developer Tools",
       "tags": [
         "mcp",

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,4 +40,4 @@ RC-first is the convention: ship `X.Y.Z-rc.0` first (`--tag rc`), smoke it on a 
 
 ## License
 
-Contributions are licensed under the project's [Elastic License 2.0](LICENSE.md). By submitting a PR you agree your contribution is licensed accordingly.
+Contributions are licensed under the project's [MIT License](LICENSE.md). By submitting a PR you agree your contribution is licensed accordingly.

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 pietrozullo
+Copyright (c) 2025 Agentified
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
     <a href="https://www.npmjs.com/package/@ratel-ai/mcp-server"><img src="https://img.shields.io/npm/v/@ratel-ai/mcp-server?label=npm&color=cb3837" alt="npm" /></a>
     <a href="https://github.com/ratel-ai/ratel-mcp/stargazers"><img src="https://img.shields.io/github/stars/ratel-ai/ratel-mcp?style=social" alt="GitHub stars" /></a>
     <a href="https://discord.gg/hdKpx69NR"><img src="https://img.shields.io/discord/1478702964003705015?logo=discord&logoColor=white&color=7289da&label=discord" alt="Discord" /></a>
-    <a href="./LICENSE.md"><img src="https://img.shields.io/badge/license-ELv2-blue" alt="license" /></a>
+    <a href="./LICENSE.md"><img src="https://img.shields.io/badge/license-MIT-blue" alt="license" /></a>
   </p>
 </div>
 
@@ -289,7 +289,7 @@ CI runs all of the above on every PR.
 
 ## License
 
-**Elastic License 2.0**, with a grant making it free for OSI-approved open-source projects. Non-OSS / commercial production use requires a commercial license. See [LICENSE.md](LICENSE.md).
+**MIT**. Free to use, modify, and redistribute. See [LICENSE.md](LICENSE.md).
 
 ## Related
 

--- a/apps/ratel-mcp/package.json
+++ b/apps/ratel-mcp/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
-  "license": "SEE LICENSE IN LICENSE.md",
+  "license": "MIT",
   "author": "Agentified",
   "homepage": "https://github.com/ratel-ai/ratel-mcp",
   "repository": {

--- a/apps/ratel-mcp/plugin/.claude-plugin/plugin.json
+++ b/apps/ratel-mcp/plugin/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   },
   "homepage": "https://github.com/ratel-ai/ratel-mcp",
   "repository": "https://github.com/ratel-ai/ratel-mcp",
-  "license": "Elastic-2.0"
+  "license": "MIT"
 }

--- a/apps/ratel-mcp/plugin/.codex-plugin/plugin.json
+++ b/apps/ratel-mcp/plugin/.codex-plugin/plugin.json
@@ -9,7 +9,7 @@
   },
   "homepage": "https://github.com/ratel-ai/ratel-mcp",
   "repository": "https://github.com/ratel-ai/ratel-mcp",
-  "license": "Elastic-2.0",
+  "license": "MIT",
   "keywords": [
     "mcp",
     "model-context-protocol",


### PR DESCRIPTION
## Why

`LICENSE.md` is already **MIT**, but everything that *references* the license still said **Elastic License 2.0** — the README badge + License section, `CONTRIBUTING.md`, the Claude marketplace manifest, the published `@ratel-ai/mcp-server` package, and both plugin manifests. npm/marketplace consumers were being told Elastic 2.0. Now all MIT, matching `LICENSE.md`.

## What changed (tracked files only)

- `README.md` — badge `ELv2` → `MIT`, and the License section → MIT.
- `CONTRIBUTING.md` — contribution license → MIT.
- `.claude-plugin/marketplace.json` — `"Elastic-2.0"` → `"MIT"`.
- `apps/ratel-mcp/package.json` — `"SEE LICENSE IN LICENSE.md"` → `"MIT"`.
- `apps/ratel-mcp/plugin/.claude-plugin/plugin.json` and `.codex-plugin/plugin.json` — `"Elastic-2.0"` → `"MIT"`.

`git grep` for `elastic|elv2` over tracked files is now clean; all edited JSON re-parses.

## Note

`apps/ratel-mcp/{README,LICENSE}.md` are **gitignored**, generated from the repo root at publish time. The generated `LICENSE.md` is already MIT; the generated `README.md` picks up this change on the next publish (republish needed for the live npm page to refresh).

Part of relicensing the whole Ratel project to MIT (companion: ratel-ai/ratel#70).