### PR TITLE
feat(ui): emphasize Ratel-managed skills with a dedicated import flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this package are documented here. The format is based on [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/), and this package adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.1] - 2026-06-18
+
+### Changed
+- **Skills page (`ratel-mcp ui`) now emphasizes only Ratel-managed skills.** When no skills are managed it shows an empty state with an "Import skills" action instead of listing Claude Code / Codex skills inline. External skills are brought in through a dedicated, paginated import dialog, each row badged by source. The bulk "Manage all" button is replaced by "Import skills"; "Unmanage all", per-skill "Stop managing", and the "New skill" form are unchanged.
+
+### Added
+- **Skill import in Agent Setup (`ratel-mcp ui`).** Each agent gets a per-agent "Import skills" flow alongside the existing MCP import/link, plus an "N skills not managed by Ratel" hint on its card and detail page, mirroring the native-tools hint.
+
 ## [0.3.0] - 2026-06-17
 
 ### Added

--- a/apps/ratel-mcp/package.json
+++ b/apps/ratel-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ratel-ai/mcp-server",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "MCP server library + ratel-mcp CLI: expose a Ratel tool catalog as a Model Context Protocol server. Manage upstream MCP servers, OAuth, and Claude Code import from one binary.",
   "private": false,
   "type": "module",

--- a/packages/ui/src/components/import-skills-dialog.tsx
+++ b/packages/ui/src/components/import-skills-dialog.tsx
@@ -1,0 +1,200 @@
+import { useEffect, useState } from "react";
+import { useRatelApp } from "@/App";
+import { type SkillSource, SourceIcon } from "@/components/source-icon";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import type { SkillSummary } from "@/lib/skills";
+
+interface ImportSkillsDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** The unmanaged skills available to bring into Ratel. */
+  available: SkillSummary[];
+  /** Restrict the list to one agent's skills (Agent Setup). Omit to list all. */
+  source?: SkillSource;
+  /** Called after a successful import so the caller can refresh its lists. */
+  onImported: () => void | Promise<void>;
+}
+
+/** A skill name can live in both Claude Code and Codex, so a row is keyed by source. */
+function skillKey(skill: SkillSummary): string {
+  return `${skill.source}:${skill.id}`;
+}
+
+/** Rows per page; long skill lists page rather than scroll forever. */
+const PAGE_SIZE = 6;
+
+/**
+ * Bring unmanaged Claude Code / Codex skills into Ratel's managed folder. A
+ * single screen: pick skills, then import. There is no conflict step — a name
+ * already managed by Ratel is excluded from `available` upstream — so unlike the
+ * MCP import this stays a simple checkbox list.
+ */
+export function ImportSkillsDialog(props: ImportSkillsDialogProps) {
+  const { request, runAction, busy } = useRatelApp();
+  const skills = props.source
+    ? props.available.filter((skill) => skill.source === props.source)
+    : props.available;
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [page, setPage] = useState(0);
+
+  // Start each session with a clean slate; the user opts in per skill (or all).
+  useEffect(() => {
+    if (props.open) {
+      setSelected(new Set());
+      setPage(0);
+    }
+  }, [props.open]);
+
+  const chosen = skills.filter((skill) => selected.has(skillKey(skill)));
+  const allSelected = skills.length > 0 && chosen.length === skills.length;
+  const pageCount = Math.max(1, Math.ceil(skills.length / PAGE_SIZE));
+  const safePage = Math.min(page, pageCount - 1);
+  const pageStart = safePage * PAGE_SIZE;
+  const visible = skills.slice(pageStart, pageStart + PAGE_SIZE);
+
+  const toggle = (skill: SkillSummary) => {
+    setSelected((current) => {
+      const next = new Set(current);
+      const key = skillKey(skill);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+  };
+
+  const toggleAll = () => {
+    setSelected(allSelected ? new Set() : new Set(skills.map(skillKey)));
+  };
+
+  const submit = async () => {
+    if (chosen.length === 0) return;
+    // `activate` takes a single `source` to disambiguate a name present in both
+    // agents, so import each source group separately.
+    const idsBySource = new Map<SkillSource, string[]>();
+    for (const skill of chosen) {
+      const ids = idsBySource.get(skill.source) ?? [];
+      ids.push(skill.id);
+      idsBySource.set(skill.source, ids);
+    }
+    const label = `Now managing ${chosen.length} skill${chosen.length === 1 ? "" : "s"}`;
+    const ok = await runAction(label, async () => {
+      for (const [source, ids] of idsBySource) {
+        await request("/api/skills/activate", { method: "POST", body: { ids, source } });
+      }
+    });
+    if (ok) {
+      props.onOpenChange(false);
+      await props.onImported();
+    }
+  };
+
+  return (
+    <Dialog open={props.open} onOpenChange={props.onOpenChange}>
+      <DialogContent className="sm:max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>Import skills</DialogTitle>
+          <DialogDescription>
+            Bring skills from Claude Code and Codex into Ratel's managed folder so the gateway
+            serves them. Stop managing one later to return it to where it came from.
+          </DialogDescription>
+        </DialogHeader>
+
+        {skills.length === 0 ? (
+          <p className="py-6 text-center text-muted-foreground text-sm">
+            No external skills to import.
+          </p>
+        ) : (
+          <div className="grid gap-2">
+            <button
+              className="flex items-center gap-2 px-1 text-left text-muted-foreground text-xs hover:text-foreground"
+              onClick={toggleAll}
+              type="button"
+            >
+              <Checkbox checked={allSelected} className="pointer-events-none" tabIndex={-1} />
+              {allSelected ? "Deselect all" : "Select all"} ({skills.length})
+            </button>
+            <ul className="grid max-h-[55vh] gap-2 overflow-y-auto pr-1">
+              {visible.map((skill) => {
+                const isSelected = selected.has(skillKey(skill));
+                return (
+                  <li key={skillKey(skill)}>
+                    <button
+                      className={`flex w-full min-w-0 items-start gap-3 rounded-md border p-3 text-left transition-colors ${
+                        isSelected
+                          ? "border-brand-green bg-brand-green/10"
+                          : "border-border bg-card hover:bg-muted/35"
+                      }`}
+                      onClick={() => toggle(skill)}
+                      type="button"
+                    >
+                      <Checkbox
+                        checked={isSelected}
+                        className="pointer-events-none mt-0.5"
+                        tabIndex={-1}
+                      />
+                      <SourceIcon className="mt-0.5" source={skill.source} />
+                      <span className="min-w-0 flex-1">
+                        <strong className="block truncate font-medium">{skill.name}</strong>
+                        {skill.description && (
+                          <span className="mt-0.5 line-clamp-2 break-words text-muted-foreground text-sm">
+                            {skill.description}
+                          </span>
+                        )}
+                      </span>
+                    </button>
+                  </li>
+                );
+              })}
+            </ul>
+            {pageCount > 1 && (
+              <div className="flex items-center justify-between px-1 text-muted-foreground text-xs">
+                <span>
+                  {pageStart + 1}–{Math.min(pageStart + PAGE_SIZE, skills.length)} of{" "}
+                  {skills.length}
+                </span>
+                <div className="flex items-center gap-2">
+                  <Button
+                    disabled={safePage === 0}
+                    onClick={() => setPage(safePage - 1)}
+                    size="sm"
+                    variant="outline"
+                  >
+                    Prev
+                  </Button>
+                  <span>
+                    {safePage + 1} / {pageCount}
+                  </span>
+                  <Button
+                    disabled={safePage >= pageCount - 1}
+                    onClick={() => setPage(safePage + 1)}
+                    size="sm"
+                    variant="outline"
+                  >
+                    Next
+                  </Button>
+                </div>
+              </div>
+            )}
+          </div>
+        )}
+
+        <DialogFooter>
+          <DialogClose render={<Button size="sm" variant="outline" />}>Cancel</DialogClose>
+          <Button disabled={busy || chosen.length === 0} onClick={() => void submit()} size="sm">
+            {chosen.length > 0 ? `Import ${chosen.length}` : "Import"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/packages/ui/src/lib/skills.test.ts
+++ b/packages/ui/src/lib/skills.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { agentKindToSkillSource, availableSkillsForKind, type SkillSummary } from "./skills";
+
+describe("agentKindToSkillSource", () => {
+  it("maps claude-code to the claude skill source", () => {
+    expect(agentKindToSkillSource("claude-code")).toBe("claude");
+  });
+
+  it("maps codex to the codex skill source", () => {
+    expect(agentKindToSkillSource("codex")).toBe("codex");
+  });
+});
+
+describe("availableSkillsForKind", () => {
+  const skill = (id: string, source: SkillSummary["source"]): SkillSummary => ({
+    id,
+    name: id,
+    description: "",
+    tags: [],
+    source,
+  });
+  const available: SkillSummary[] = [
+    skill("a", "claude"),
+    skill("b", "codex"),
+    skill("c", "claude"),
+  ];
+
+  it("returns only the agent's own unmanaged skills", () => {
+    expect(availableSkillsForKind(available, "claude-code").map((s) => s.id)).toEqual(["a", "c"]);
+    expect(availableSkillsForKind(available, "codex").map((s) => s.id)).toEqual(["b"]);
+  });
+});

--- a/packages/ui/src/lib/skills.ts
+++ b/packages/ui/src/lib/skills.ts
@@ -1,0 +1,55 @@
+import type { JsonRequestInit } from "@/App";
+import type { SkillSource } from "@/components/source-icon";
+
+/** Agent harnesses Ratel can pull skills from (and link MCP gateways into). */
+export type AgentHostKind = "claude-code" | "codex";
+
+export interface SkillSummary {
+  id: string;
+  name: string;
+  description: string;
+  tags: string[];
+  /** Managed skills report their origin agent (or "ratel" when created here);
+   *  available skills report the agent whose folder they live in. */
+  source: SkillSource;
+}
+
+export interface SkillProblem {
+  id: string;
+  where: string;
+  reason: string;
+}
+
+export interface SkillsResponse {
+  managedDir: string;
+  nativeDir: string;
+  codexDir: string;
+  managed: SkillSummary[];
+  available: SkillSummary[];
+  problems: SkillProblem[];
+}
+
+/** Load managed + available skills from the gateway. */
+export function fetchSkills(
+  request: <T>(path: string, init?: JsonRequestInit) => Promise<T>,
+): Promise<SkillsResponse> {
+  return request<SkillsResponse>("/api/skills");
+}
+
+/**
+ * Map an Agent Setup host kind to the skill `source` used by `/api/skills`.
+ * The agent pages speak in host kinds ("claude-code"), while skills are tagged
+ * with the shorter agent source ("claude") — this is the one bit of glue.
+ */
+export function agentKindToSkillSource(kind: AgentHostKind): SkillSource {
+  return kind === "codex" ? "codex" : "claude";
+}
+
+/** Skills from one agent that Ratel does not yet manage. */
+export function availableSkillsForKind(
+  available: readonly SkillSummary[],
+  kind: AgentHostKind,
+): SkillSummary[] {
+  const source = agentKindToSkillSource(kind);
+  return available.filter((skill) => skill.source === source);
+}

--- a/packages/ui/src/pages/AgentSetupPage.tsx
+++ b/packages/ui/src/pages/AgentSetupPage.tsx
@@ -8,12 +8,14 @@ import {
   LinkIcon,
   RefreshCw,
   SearchIcon,
+  Sparkles,
   X,
 } from "lucide-react";
 import { AnimatePresence, motion } from "motion/react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import useMeasure from "react-use-measure";
 import { type BackupManifest, type JsonRequestInit, type ServerEntry, useRatelApp } from "@/App";
+import { ImportSkillsDialog } from "@/components/import-skills-dialog";
 import {
   PageHeader,
   PageHeaderActions,
@@ -41,6 +43,12 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import {
+  agentKindToSkillSource,
+  availableSkillsForKind,
+  fetchSkills,
+  type SkillSummary,
+} from "@/lib/skills";
 import { cn } from "@/lib/utils";
 
 type AgentHostKind = "claude-code" | "codex";
@@ -177,10 +185,34 @@ const POSTURE_COPY: Record<
 const CODEX_ICON_SRC = new URL("../assets/codex-color.svg", import.meta.url).href;
 const CLAUDE_CODE_ICON_SRC = new URL("../assets/claudecode-color.svg", import.meta.url).href;
 
+/**
+ * Load the unmanaged skills available across agents (those Ratel doesn't manage
+ * yet). Shared by the agent directory (for per-card counts) and the agent detail
+ * page (for the import section). Fail-soft to an empty list so a skills hiccup
+ * never blocks the MCP setup flows.
+ */
+function useAvailableSkills() {
+  const { request } = useRatelApp();
+  const [available, setAvailable] = useState<SkillSummary[]>([]);
+  const reload = useCallback(async () => {
+    try {
+      const data = await fetchSkills(request);
+      setAvailable(data.available);
+    } catch {
+      setAvailable([]);
+    }
+  }, [request]);
+  useEffect(() => {
+    void reload();
+  }, [reload]);
+  return { available, reload };
+}
+
 export function AgentSetupPage() {
   const { clearSetupIntent, config, openCommandMenu, refresh, request, setupIntent, token } =
     useRatelApp();
   const navigate = useNavigate();
+  const { available } = useAvailableSkills();
   const [hosts, setHosts] = useState<DetectedAgentHostSummary[]>([]);
   const [scanning, setScanning] = useState(false);
   const handledIntent = useRef<number | null>(null);
@@ -281,7 +313,12 @@ export function AgentSetupPage() {
       <section className="grid gap-3">
         <div className="grid gap-3 xl:grid-cols-2">
           {hosts.map((host) => (
-            <AgentDirectoryCard host={host} key={host.kind} onOpen={() => openAgent(host.kind)} />
+            <AgentDirectoryCard
+              host={host}
+              key={host.kind}
+              onOpen={() => openAgent(host.kind)}
+              unmanagedSkillCount={availableSkillsForKind(available, host.kind).length}
+            />
           ))}
         </div>
       </section>
@@ -294,6 +331,8 @@ export function AgentSetupPage() {
 export function AgentDetailPage(props: { kind: AgentHostKind; operation?: SetupFlow }) {
   const { openCommandMenu, refresh, request, token } = useRatelApp();
   const navigate = useNavigate();
+  const { available, reload: reloadSkills } = useAvailableSkills();
+  const agentAvailable = availableSkillsForKind(available, props.kind);
   const [hosts, setHosts] = useState<DetectedAgentHostSummary[]>([]);
   const [scanning, setScanning] = useState(false);
 
@@ -421,13 +460,23 @@ export function AgentDetailPage(props: { kind: AgentHostKind; operation?: SetupF
             </div>
             <DetailLabel>Status</DetailLabel>
             <LinkStatusBadge host={host} />
-            {missingRatelEntryNames(host).length > 0 ? (
+            {missingRatelEntryNames(host).length > 0 || agentAvailable.length > 0 ? (
               <>
                 <DetailLabel>Coverage</DetailLabel>
-                <p className="text-sm text-amber-700 dark:text-amber-400">
-                  {missingRatelEntryNames(host).length} native tool
-                  {missingRatelEntryNames(host).length === 1 ? "" : "s"} not in Ratel.
-                </p>
+                <div className="grid gap-1">
+                  {missingRatelEntryNames(host).length > 0 ? (
+                    <p className="text-sm text-amber-700 dark:text-amber-400">
+                      {missingRatelEntryNames(host).length} native tool
+                      {missingRatelEntryNames(host).length === 1 ? "" : "s"} not in Ratel.
+                    </p>
+                  ) : null}
+                  {agentAvailable.length > 0 ? (
+                    <p className="text-sm text-amber-700 dark:text-amber-400">
+                      {agentAvailable.length} skill{agentAvailable.length === 1 ? "" : "s"} not
+                      managed by Ratel.
+                    </p>
+                  ) : null}
+                </div>
               </>
             ) : null}
             <DetailLabel>Config</DetailLabel>
@@ -437,9 +486,11 @@ export function AgentDetailPage(props: { kind: AgentHostKind; operation?: SetupF
           </DetailGrid>
 
           <AgentOperationPanel
+            availableSkills={agentAvailable}
             host={host}
             hostKind={host.kind}
             onScanHosts={scanHosts}
+            onSkillsImported={reloadSkills}
             request={request}
           />
         </section>
@@ -487,7 +538,11 @@ function AgentPageSwitcher(props: {
   );
 }
 
-function AgentDirectoryCard(props: { host: DetectedAgentHostSummary; onOpen: () => void }) {
+function AgentDirectoryCard(props: {
+  host: DetectedAgentHostSummary;
+  onOpen: () => void;
+  unmanagedSkillCount: number;
+}) {
   const posture = POSTURE_COPY[props.host.posture];
   const primaryPath =
     props.host.scopes.find((scope) => scope.available)?.path ?? props.host.scopes[0]?.path;
@@ -513,6 +568,12 @@ function AgentDirectoryCard(props: { host: DetectedAgentHostSummary; onOpen: () 
               {missingRatelEntryNames(props.host).length === 1 ? "" : "s"} not in Ratel.
             </p>
           ) : null}
+          {props.unmanagedSkillCount > 0 ? (
+            <p className="mt-2 text-sm text-amber-700 dark:text-amber-400">
+              {props.unmanagedSkillCount} skill{props.unmanagedSkillCount === 1 ? "" : "s"} not
+              managed by Ratel.
+            </p>
+          ) : null}
           <p className="mt-3 truncate font-mono text-xs text-muted-foreground">
             {primaryPath ?? props.host.detection.reasons[0] ?? "Known paths unavailable"}
           </p>
@@ -523,15 +584,25 @@ function AgentDirectoryCard(props: { host: DetectedAgentHostSummary; onOpen: () 
 }
 
 function AgentOperationPanel(props: {
+  availableSkills: SkillSummary[];
   host: DetectedAgentHostSummary;
   hostKind: AgentHostKind;
   onScanHosts: () => Promise<void>;
+  onSkillsImported: () => void | Promise<void>;
   request: <T>(path: string, init?: JsonRequestInit) => Promise<T>;
 }) {
   const canImport = missingRatelEntryNames(props.host).length > 0;
   const canLink = props.host.posture !== "unavailable" && props.host.ratelEntryCount === 0;
+  const canImportSkills = props.availableSkills.length > 0;
   return (
     <section className="-mx-4 grid gap-5 border-border border-y bg-muted/10 px-4 py-5 sm:-mx-6 sm:px-6">
+      {canImportSkills ? (
+        <SkillImportSection
+          available={props.availableSkills}
+          onImported={props.onSkillsImported}
+          source={agentKindToSkillSource(props.hostKind)}
+        />
+      ) : null}
       {canImport ? (
         <SetupActionSection
           description="Copy native MCP entries into Ratel. After review, selected entries are removed from the agent config."
@@ -564,15 +635,52 @@ function AgentOperationPanel(props: {
           />
         </SetupActionSection>
       ) : null}
-      {!canImport && !canLink ? (
+      {!canImport && !canLink && !canImportSkills ? (
         <div>
           <h3 className="text-lg font-semibold tracking-tight">Nothing to do</h3>
           <p className="mt-1 text-sm text-muted-foreground">
-            This agent is linked, and all native entries are already in Ratel.
+            This agent is linked, all native entries are already in Ratel, and every skill is
+            managed.
           </p>
         </div>
       ) : null}
     </section>
+  );
+}
+
+function SkillImportSection(props: {
+  available: SkillSummary[];
+  onImported: () => void | Promise<void>;
+  source: ReturnType<typeof agentKindToSkillSource>;
+}) {
+  const [open, setOpen] = useState(false);
+  const count = props.available.length;
+  return (
+    <SetupActionSection
+      description="Bring this agent's skills into Ratel's managed folder so the gateway serves them."
+      icon={<Sparkles />}
+      title="Import skills"
+    >
+      <div className="grid gap-4 border border-border bg-background p-4 md:grid-cols-[minmax(0,1fr)_auto] md:items-center">
+        <div>
+          <h4 className="font-medium">
+            {count} skill{count === 1 ? "" : "s"} not managed by Ratel
+          </h4>
+          <p className="mt-1 text-sm text-muted-foreground">Choose which to manage with Ratel.</p>
+        </div>
+        <Button className="min-h-12 px-6 text-base md:min-w-40" onClick={() => setOpen(true)}>
+          <Sparkles />
+          Import skills
+        </Button>
+      </div>
+      <ImportSkillsDialog
+        available={props.available}
+        onImported={props.onImported}
+        onOpenChange={setOpen}
+        open={open}
+        source={props.source}
+      />
+    </SetupActionSection>
   );
 }
 

--- a/packages/ui/src/pages/SkillsPage.tsx
+++ b/packages/ui/src/pages/SkillsPage.tsx
@@ -1,7 +1,8 @@
 import { useNavigate } from "@tanstack/react-router";
-import { SearchIcon, Sparkles, TriangleAlert } from "lucide-react";
+import { Download, SearchIcon, Sparkles, TriangleAlert } from "lucide-react";
 import { type ReactNode, useCallback, useEffect, useState } from "react";
 import { skillPath, useRatelApp } from "@/App";
+import { ImportSkillsDialog } from "@/components/import-skills-dialog";
 import {
   PageHeader,
   PageHeaderActions,
@@ -27,31 +28,7 @@ import {
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
-
-interface SkillSummary {
-  id: string;
-  name: string;
-  description: string;
-  tags: string[];
-  /** Managed skills report their origin agent (or "ratel" when created here);
-   *  available skills report the agent whose folder they live in. */
-  source: SkillSource;
-}
-
-interface SkillProblem {
-  id: string;
-  where: string;
-  reason: string;
-}
-
-interface SkillsResponse {
-  managedDir: string;
-  nativeDir: string;
-  codexDir: string;
-  managed: SkillSummary[];
-  available: SkillSummary[];
-  problems: SkillProblem[];
-}
+import type { SkillSummary, SkillsResponse } from "@/lib/skills";
 
 type LoadState =
   | { status: "loading" }
@@ -62,6 +39,7 @@ export function SkillsPage() {
   const { openCommandMenu, request, runAction, busy, token } = useRatelApp();
   const navigate = useNavigate();
   const [state, setState] = useState<LoadState>({ status: "loading" });
+  const [importOpen, setImportOpen] = useState(false);
 
   const openSkill = (id: string) => {
     void navigate({ to: skillPath(id, token) } as never);
@@ -101,11 +79,11 @@ export function SkillsPage() {
   const managed = ready?.managed ?? [];
   const available = ready?.available ?? [];
   const problems = ready?.problems ?? [];
-  const canActivateAll = available.length > 0;
+  const canImport = available.length > 0;
   const canDeactivateAll = managed.length > 0;
 
   return (
-    <main className="grid w-full gap-4 px-4 py-5 sm:px-6">
+    <main className="flex w-full flex-1 flex-col gap-4 px-4 py-5 sm:px-6">
       <PageHeader className="sm:grid-cols-[minmax(0,1fr)_auto] sm:items-start">
         <PageHeaderContent>
           <PageHeaderBackRow>
@@ -125,28 +103,22 @@ export function SkillsPage() {
             </div>
           </PageHeaderBackRow>
           <PageHeaderDescription>
-            Reusable playbooks Ratel serves through the gateway. Skills from Claude Code (
-            <code className="font-mono text-xs">~/.claude/skills</code>) and Codex (
-            <code className="font-mono text-xs">~/.codex/skills</code>) can be brought into Ratel's
-            managed folder to serve them; stop managing one to return it to where it came from.
+            Reusable playbooks Ratel manages and serves through the gateway. Import skills from
+            Claude Code or Codex to manage them here; stop managing one to return it to where it
+            came from.
           </PageHeaderDescription>
         </PageHeaderContent>
         <PageHeaderActions className="hidden items-center sm:flex">
           <NewSkillDialog onCreated={load} />
-          {canActivateAll && (
+          {canImport && (
             <Button
               className="h-10"
-              disabled={busy}
-              onClick={() =>
-                void mutate(
-                  `Now managing ${available.length} skill${available.length === 1 ? "" : "s"}`,
-                  "/api/skills/activate",
-                )
-              }
+              onClick={() => setImportOpen(true)}
               size="sm"
               variant="outline"
             >
-              Manage all
+              <Download />
+              Import skills
             </Button>
           )}
           {canDeactivateAll && (
@@ -209,10 +181,22 @@ export function SkillsPage() {
         </section>
       )}
 
+      {ready && managed.length === 0 && available.length > 0 && (
+        <EmptyState
+          title="No skills managed by Ratel yet"
+          description="Import skills from Claude Code or Codex to serve them through the gateway."
+        >
+          <Button onClick={() => setImportOpen(true)} size="sm">
+            <Download />
+            Import skills
+          </Button>
+        </EmptyState>
+      )}
+
       {ready && managed.length === 0 && available.length === 0 && (
         <EmptyState
-          title="No skills found"
-          description="Add skills under ~/.claude/skills (Claude Code) or ~/.codex/skills (Codex), or create one in Ratel, and they'll show up here."
+          title="No skills managed by Ratel yet"
+          description="Add skills under ~/.claude/skills (Claude Code) or ~/.codex/skills (Codex), or create one in Ratel, then import them here."
         />
       )}
 
@@ -244,28 +228,12 @@ export function SkillsPage() {
         />
       )}
 
-      {ready && available.length > 0 && (
-        <SkillSection
-          title="Not managed"
-          caption="Available in Claude Code / Codex. Bring one into Ratel to serve it through the gateway."
-          onView={openSkill}
-          skills={available}
-          renderAction={(skill) => (
-            <Button
-              disabled={busy}
-              onClick={() =>
-                void mutate(`Now managing ${skill.name}`, "/api/skills/activate", {
-                  ids: [skill.id],
-                  source: skill.source,
-                })
-              }
-              size="sm"
-            >
-              Manage with Ratel
-            </Button>
-          )}
-        />
-      )}
+      <ImportSkillsDialog
+        available={available}
+        onImported={load}
+        onOpenChange={setImportOpen}
+        open={importOpen}
+      />
     </main>
   );
 }
@@ -363,7 +331,7 @@ function SkillSection(props: {
 
 function EmptyState(props: { title: string; description: string; children?: ReactNode }) {
   return (
-    <section className="-mx-4 grid min-h-72 place-items-center border-border border-y bg-muted/15 px-4 py-8 text-center sm:-mx-6 sm:px-6">
+    <section className="-mx-4 grid min-h-72 flex-1 place-items-center border-border border-y bg-muted/15 px-4 py-8 text-center sm:-mx-6 sm:px-6">
       <div className="grid max-w-md gap-3">
         <div className="mx-auto rounded-md bg-muted p-2 text-brand-green">
           <Sparkles className="size-5" />


### PR DESCRIPTION
## Context

Closes RAT-264. The Skills page rendered Claude Code / Codex skills inline the moment it opened, so it read like an external skill browser rather than _skills Ratel manages_. Per the Linear thread (Roberto + Marcello + Kayra), the page should emphasize only Ratel-managed skills, show an empty-state import CTA when none are managed, and move the external-skills list into a dedicated import flow — mirrored into Agent Setup like the MCP import.

## What changed

**Skills page → managed-only + import**
- Shows only "Managed by Ratel"; the inline "Not managed" section and "Manage all" are gone.
- Empty state **"No skills managed by Ratel yet"** + **Import skills** CTA (or the `~/.claude/skills` guidance when there's nothing to import). The empty-state panel now fills the full content height.
- Header gains an **Import skills** button; "Unmanage all", "New skill", per-row "Stop managing" are unchanged.

**Reusable `ImportSkillsDialog`** (`components/import-skills-dialog.tsx`)
- Lists external skills with source badges, **Select all**, and **pagination** (6/page); long descriptions wrap and clamp to 2 lines so the panel can't grow horizontally.
- Partitions the selection by source and calls `/api/skills/activate` per source (a name present in both agents stays disambiguated).
- Single component serves both callers — Skills page (all sources) and Agent Setup (one source).

**Agent Setup → skill hints + per-agent import**
- "N skills not managed by Ratel" on the agent cards and the detail **Coverage** row, mirroring the existing native-tools hint.
- A per-agent **Import skills** section alongside the MCP "Import native entries" / "Link Ratel gateway".

**Shared `lib/skills.ts`** — extracted skill types, `fetchSkills`, and the `agentKindToSkillSource` / `availableSkillsForKind` helpers (+ unit tests).

**Tools page** — unchanged; it already shows only managed MCPs with an "Import from agent" empty state.

## No backend changes
Everything derives from existing endpoints: `/api/skills` already tags `available` skills with `source`, and `/api/skills/activate` already accepts `{ ids, source }`.

## Test plan
- [x] `pnpm --filter @ratel-ai/mcp-ui typecheck`
- [x] `pnpm --filter @ratel-ai/mcp-ui lint` (Biome)
- [x] `pnpm --filter @ratel-ai/mcp-ui test` (helper unit tests)
- [x] Manual (Playwright) against a real config with 0 managed / 17 available:
  - Skills page → empty state + CTA, no inline external list
  - Import dialog → 17 skills, source badges, select-all → "Import 17", pagination 1–6/7–12/13–17, descriptions clamp to 2 lines; `review-ratel` listed once per agent
  - Agent cards → "15 skills not managed by Ratel" (Claude) / "2 skills…" (Codex); detail Coverage + source-filtered import section
  - Tools page unchanged
  - _No import was committed; real skills untouched._

🤖 Generated with [Claude Code](https://claude.com/claude-code)