### PR TITLE
feat: chat → intent-extraction pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,12 @@ node_modules/
 .ratel/
 tmp/
 
+# Python (claim-extractor sidecar venv + caches)
+.venv/
+__pycache__/
+*.pyc
+*.pyo
+
 # Build output
 dist/
 *.tsbuildinfo

--- a/apps/ratel-mcp/plugin/README.md
+++ b/apps/ratel-mcp/plugin/README.md
@@ -41,6 +41,18 @@ The logger bounds large values, redacts common secret-bearing fields, and does n
 
 Use the bundled `ratel-improve-tools` skill to summarize those logs and propose MCP catalog improvements.
 
+### Chat capture (intents)
+
+The plugin also wires `UserPromptSubmit` and `Stop` hooks to `hooks/capture-chat.mjs`, which records chat turns (and, on `Stop`, backfills assistant turns from the transcript) to:
+
+```text
+${RATEL_HOME:-$HOME/.ratel}/chat/<host>/<sessionId>.jsonl
+```
+
+Like the tool-usage logger, it is passive, fail-soft, and redacts obvious secrets. The Ratel **intent pipeline** reads this capture to extract what you keep trying to do, matches each intent against the skills Ratel manages, and surfaces the results — with an "Offer New Skills" action for gaps — in the **Intents** tab of `ratel-mcp ui`.
+
+Run an analysis manually with `ratel-mcp intents run` (or the UI's **Run now**), or let it fire on a cadence (every N messages / on idle), all configurable from **Intents → Settings**. Intent extraction runs through a swappable HTTP extractor — a local model sidecar, a Docker+GPU box, or a remote/cloud endpoint — see [`infra/claim-extractor`](../../../infra/claim-extractor/README.md).
+
 ## Codex Local Validation
 
 Add the repo root as a local Codex marketplace root:

--- a/apps/ratel-mcp/plugin/hooks/capture-chat.mjs
+++ b/apps/ratel-mcp/plugin/hooks/capture-chat.mjs
@@ -1,0 +1,223 @@
+import { appendFile, chmod, mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { randomUUID } from "node:crypto";
+
+// Captures chat turns so the Ratel intent runner can extract intents from them.
+// Two events:
+//   UserPromptSubmit → append the user's turn + bump the new-turn counter
+//   Stop             → flag the session idle + backfill assistant turns from the transcript
+//
+// Like the tool-usage logger, this hook is strictly passive and fail-soft: it
+// never prints output, never returns a decision, and swallows every error so it
+// cannot interfere with the host.
+
+const DIR_MODE = 0o700;
+const FILE_MODE = 0o600;
+const MAX_CONTENT = 16000;
+const REDACTIONS = [
+  /\b(sk-[A-Za-z0-9_-]{16,})\b/g,
+  /\b(Bearer)\s+[A-Za-z0-9._-]{12,}/gi,
+  /\b(xox[baprs]-[A-Za-z0-9-]{8,})\b/g,
+  /\b(gh[pousr]_[A-Za-z0-9]{20,})\b/g,
+];
+
+await main().catch(() => {
+  // Hooks must never interfere with the session they observe.
+});
+
+async function main() {
+  // Skip capture for Ratel's own nested `claude -p` calls (e.g. skill generation),
+  // so their prompts don't get recorded as chat and re-extracted as fake intents.
+  if (process.env.RATEL_SKIP_CAPTURE === "1") return;
+  // Respect the master switch: when analysis is disabled, don't record chat at all.
+  if (await isAnalysisDisabled()) return;
+  const eventName = process.argv[2] || "unknown";
+  const payload = parsePayload(await readStdin());
+  const sessionId = stringValue(firstPresent(payload, [["session_id"], ["sessionId"]]));
+  if (!sessionId) return;
+
+  const host = detectHost();
+  const cwd = stringValue(firstPresent(payload, [["cwd"], ["working_directory"], ["workingDirectory"]]));
+  const chatDir = join(resolveRatelDir(), "chat");
+
+  if (eventName === "UserPromptSubmit") {
+    await onUserPrompt({ payload, chatDir, host, sessionId, cwd });
+  } else if (eventName === "Stop") {
+    await onStop({ payload, chatDir, host, sessionId, cwd });
+  }
+}
+
+async function onUserPrompt({ payload, chatDir, host, sessionId, cwd }) {
+  const prompt = stringValue(firstPresent(payload, [["prompt"], ["user_prompt"], ["message"]]));
+  if (!prompt || prompt.trim().length === 0) return;
+  await appendTurn(chatDir, host, sessionId, { role: "user", content: clean(prompt) });
+  await updateState(chatDir, sessionId, (meta) => ({
+    ...meta,
+    sessionId,
+    host,
+    cwd: cwd ?? meta.cwd,
+    newTurnCount: (meta.newTurnCount ?? 0) + 1,
+    updatedAt: new Date().toISOString(),
+    idle: false,
+  }));
+}
+
+async function onStop({ payload, chatDir, host, sessionId, cwd }) {
+  const transcriptPath = stringValue(firstPresent(payload, [["transcript_path"], ["transcriptPath"]]));
+  let appended = 0;
+  let cursor = 0;
+  const startCursor = (await readState(chatDir)).sessions[sessionId]?.transcriptCursor ?? 0;
+  if (transcriptPath) {
+    const result = await backfillAssistant(chatDir, host, sessionId, transcriptPath, startCursor);
+    appended = result.appended;
+    cursor = result.cursor;
+  }
+  await updateState(chatDir, sessionId, (meta) => ({
+    ...meta,
+    sessionId,
+    host,
+    cwd: cwd ?? meta.cwd,
+    newTurnCount: (meta.newTurnCount ?? 0) + appended,
+    transcriptCursor: cursor || meta.transcriptCursor || startCursor,
+    updatedAt: new Date().toISOString(),
+    idle: true,
+  }));
+}
+
+// Read the transcript JSONL, skip lines already consumed, and append any new
+// assistant turns. User turns are captured via UserPromptSubmit, so they are
+// skipped here to avoid duplicates.
+async function backfillAssistant(chatDir, host, sessionId, transcriptPath, startCursor) {
+  let raw;
+  try {
+    raw = await readFile(transcriptPath, "utf8");
+  } catch {
+    return { appended: 0, cursor: startCursor };
+  }
+  const lines = raw.split("\n");
+  let appended = 0;
+  for (let i = startCursor; i < lines.length; i++) {
+    const line = lines[i].trim();
+    if (line.length === 0) continue;
+    let obj;
+    try {
+      obj = JSON.parse(line);
+    } catch {
+      continue;
+    }
+    const role = obj?.message?.role ?? obj?.role ?? obj?.type;
+    if (role !== "assistant") continue;
+    const text = extractText(obj?.message?.content ?? obj?.content);
+    if (!text || text.trim().length === 0) continue;
+    await appendTurn(chatDir, host, sessionId, { role: "assistant", content: clean(text) });
+    appended++;
+  }
+  return { appended, cursor: lines.length };
+}
+
+function extractText(content) {
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return "";
+  return content
+    .filter((b) => b && b.type === "text" && typeof b.text === "string")
+    .map((b) => b.text)
+    .join("\n");
+}
+
+async function appendTurn(chatDir, host, sessionId, turn) {
+  const dir = join(chatDir, host);
+  await mkdir(dir, { recursive: true, mode: DIR_MODE });
+  const file = join(dir, `${sessionId}.jsonl`);
+  const record = { ...turn, ts: new Date().toISOString() };
+  await appendFile(file, `${JSON.stringify(record)}\n`, { encoding: "utf8", mode: FILE_MODE });
+  await chmod(file, FILE_MODE).catch(() => undefined);
+}
+
+async function readState(chatDir) {
+  try {
+    const raw = await readFile(join(chatDir, "state.json"), "utf8");
+    const parsed = JSON.parse(raw);
+    if (parsed && typeof parsed === "object" && parsed.sessions) return parsed;
+  } catch {
+    // missing or malformed — start fresh
+  }
+  return { version: 1, sessions: {} };
+}
+
+async function updateState(chatDir, sessionId, update) {
+  const state = await readState(chatDir);
+  const next = {
+    version: 1,
+    sessions: { ...state.sessions, [sessionId]: update(state.sessions[sessionId] ?? {}) },
+  };
+  await mkdir(chatDir, { recursive: true, mode: DIR_MODE });
+  const path = join(chatDir, "state.json");
+  const tmp = `${path}.ratel-tmp-${randomUUID()}`;
+  await writeFile(tmp, `${JSON.stringify(next, null, 2)}\n`, { encoding: "utf8", mode: FILE_MODE });
+  await rename(tmp, path);
+  await chmod(path, FILE_MODE).catch(() => undefined);
+}
+
+function clean(text) {
+  let out = text.length > MAX_CONTENT ? `${text.slice(0, MAX_CONTENT)}[TRUNCATED]` : text;
+  for (const re of REDACTIONS) out = out.replace(re, "$1[REDACTED]");
+  return out;
+}
+
+function parsePayload(input) {
+  if (!input) return null;
+  try {
+    return JSON.parse(input);
+  } catch {
+    return null;
+  }
+}
+
+function firstPresent(value, paths) {
+  for (const path of paths) {
+    let current = value;
+    let ok = true;
+    for (const part of path) {
+      if (current === null || typeof current !== "object" || !(part in current)) {
+        ok = false;
+        break;
+      }
+      current = current[part];
+    }
+    if (ok && current !== undefined) return current;
+  }
+  return undefined;
+}
+
+function stringValue(value) {
+  return typeof value === "string" ? value : undefined;
+}
+
+function detectHost() {
+  if (process.env.PLUGIN_ROOT) return "codex";
+  if (process.env.CLAUDE_PLUGIN_ROOT) return "claude-code";
+  return "unknown";
+}
+
+function resolveRatelDir() {
+  return process.env.RATEL_HOME || join(homedir(), ".ratel");
+}
+
+// True only when the user has explicitly turned the analysis master switch off.
+async function isAnalysisDisabled() {
+  try {
+    const raw = await readFile(join(resolveRatelDir(), "config.json"), "utf8");
+    return JSON.parse(raw)?.analysis?.enabled === false;
+  } catch {
+    return false;
+  }
+}
+
+async function readStdin() {
+  const chunks = [];
+  for await (const chunk of process.stdin) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+  return Buffer.concat(chunks).toString("utf8").trim();
+}

--- a/apps/ratel-mcp/plugin/hooks/capture-chat.mjs
+++ b/apps/ratel-mcp/plugin/hooks/capture-chat.mjs
@@ -1,4 +1,4 @@
-import { appendFile, chmod, mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import { appendFile, chmod, mkdir, readFile, rename, rmdir, stat, unlink, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { randomUUID } from "node:crypto";
@@ -15,11 +15,47 @@ import { randomUUID } from "node:crypto";
 const DIR_MODE = 0o700;
 const FILE_MODE = 0o600;
 const MAX_CONTENT = 16000;
+
+// Lock tuning for the state.json filesystem mutex (mkdir is atomic on POSIX).
+const LOCK_RETRY_MS = 20; // base backoff between acquire attempts
+const LOCK_JITTER_MS = 15; // random jitter added to each backoff (avoids thundering herd)
+const LOCK_MAX_TRIES = 250; // generous acquisition budget (~5s worst case) before fallback
+const LOCK_STALE_MS = 10000; // steal locks older than this (crashed holder)
+
+// Secret redaction. Each entry redacts the value while preserving a labelled
+// prefix where one exists, so captured chat stays readable but never leaks
+// credentials. Order matters: structured/labelled patterns run before the
+// broad token patterns. Applied to every captured turn (user + assistant).
 const REDACTIONS = [
-  /\b(sk-[A-Za-z0-9_-]{16,})\b/g,
-  /\b(Bearer)\s+[A-Za-z0-9._-]{12,}/gi,
-  /\b(xox[baprs]-[A-Za-z0-9-]{8,})\b/g,
-  /\b(gh[pousr]_[A-Za-z0-9]{20,})\b/g,
+  // PEM private key blocks (any key type) — collapse the whole block.
+  {
+    re: /-----BEGIN (?:[A-Z0-9 ]*)PRIVATE KEY-----[\s\S]*?-----END (?:[A-Z0-9 ]*)PRIVATE KEY-----/g,
+    to: "[REDACTED_PRIVATE_KEY]",
+  },
+  // JWTs (three base64url segments).
+  { re: /\beyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\b/g, to: "[REDACTED_JWT]" },
+  // OpenAI-style keys.
+  { re: /\b(sk-[A-Za-z0-9_-]{16,})\b/g, to: "[REDACTED]" },
+  // Bearer tokens.
+  { re: /\b(Bearer)\s+[A-Za-z0-9._-]{12,}/gi, to: "$1 [REDACTED]" },
+  // Slack tokens.
+  { re: /\b(xox[baprs]-[A-Za-z0-9-]{8,})\b/g, to: "[REDACTED]" },
+  // GitHub tokens.
+  { re: /\b(gh[pousr]_[A-Za-z0-9]{20,})\b/g, to: "[REDACTED]" },
+  // AWS access key ids.
+  { re: /\bAKIA[0-9A-Z]{16}\b/g, to: "[REDACTED_AWS_KEY]" },
+  // Google API keys.
+  { re: /\bAIza[0-9A-Za-z\-_]{35}\b/g, to: "[REDACTED_GOOGLE_KEY]" },
+  // aws_secret_access_key assignments (=, :, or =>), quoted or bare.
+  {
+    re: /\b(aws_secret_access_key)(\s*[:=]>?\s*)(['"]?)[^\s'"]+\3/gi,
+    to: "$1$2$3[REDACTED]$3",
+  },
+  // Generic credential assignments (password/passwd/secret/token/api_key).
+  {
+    re: /\b(password|passwd|secret|token|api[_-]?key)(\s*[:=]>?\s*)(['"]?)[^\s'"]+\3/gi,
+    to: "$1$2$3[REDACTED]$3",
+  },
 ];
 
 await main().catch(() => {
@@ -51,7 +87,10 @@ async function main() {
 async function onUserPrompt({ payload, chatDir, host, sessionId, cwd }) {
   const prompt = stringValue(firstPresent(payload, [["prompt"], ["user_prompt"], ["message"]]));
   if (!prompt || prompt.trim().length === 0) return;
-  await appendTurn(chatDir, host, sessionId, { role: "user", content: clean(prompt) });
+  // Only bump the new-turn counter if the turn was actually persisted, so a
+  // failed write can't desync the count from the JSONL the core later reads.
+  const wrote = await appendTurn(chatDir, host, sessionId, { role: "user", content: clean(prompt) });
+  if (!wrote) return;
   await updateState(chatDir, sessionId, (meta) => ({
     ...meta,
     sessionId,
@@ -110,8 +149,8 @@ async function backfillAssistant(chatDir, host, sessionId, transcriptPath, start
     if (role !== "assistant") continue;
     const text = extractText(obj?.message?.content ?? obj?.content);
     if (!text || text.trim().length === 0) continue;
-    await appendTurn(chatDir, host, sessionId, { role: "assistant", content: clean(text) });
-    appended++;
+    const wrote = await appendTurn(chatDir, host, sessionId, { role: "assistant", content: clean(text) });
+    if (wrote) appended++;
   }
   return { appended, cursor: lines.length };
 }
@@ -125,15 +164,26 @@ function extractText(content) {
     .join("\n");
 }
 
+// Append a single turn to the session's JSONL log. Append-only writes to a
+// per-session file are inherently safe under concurrency (no read-modify-write),
+// so no lock is needed here. Fully fail-soft: a write failure must never throw
+// out of the hook. Returns true on success so callers can keep counts honest.
 async function appendTurn(chatDir, host, sessionId, turn) {
-  const dir = join(chatDir, host);
-  await mkdir(dir, { recursive: true, mode: DIR_MODE });
-  const file = join(dir, `${sessionId}.jsonl`);
-  const record = { ...turn, ts: new Date().toISOString() };
-  await appendFile(file, `${JSON.stringify(record)}\n`, { encoding: "utf8", mode: FILE_MODE });
-  await chmod(file, FILE_MODE).catch(() => undefined);
+  try {
+    const dir = join(chatDir, host);
+    await mkdir(dir, { recursive: true, mode: DIR_MODE });
+    const file = join(dir, `${sessionId}.jsonl`);
+    const record = { ...turn, ts: new Date().toISOString() };
+    await appendFile(file, `${JSON.stringify(record)}\n`, { encoding: "utf8", mode: FILE_MODE });
+    await chmod(file, FILE_MODE).catch(() => undefined);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
+// Recover gracefully from a missing/corrupt state.json: treat anything we can't
+// parse into the expected shape as an empty state rather than crashing.
 async function readState(chatDir) {
   try {
     const raw = await readFile(join(chatDir, "state.json"), "utf8");
@@ -145,23 +195,91 @@ async function readState(chatDir) {
   return { version: 1, sessions: {} };
 }
 
+// Serialize the whole read-modify-write of state.json across concurrent hook
+// subprocesses so parallel UserPromptSubmit/Stop events can't clobber each
+// other's counters. `update` runs INSIDE the lock against a fresh read, so
+// increments are always applied on top of other writers' results.
 async function updateState(chatDir, sessionId, update) {
-  const state = await readState(chatDir);
-  const next = {
-    version: 1,
-    sessions: { ...state.sessions, [sessionId]: update(state.sessions[sessionId] ?? {}) },
-  };
-  await mkdir(chatDir, { recursive: true, mode: DIR_MODE });
+  await mkdir(chatDir, { recursive: true, mode: DIR_MODE }).catch(() => undefined);
   const path = join(chatDir, "state.json");
+  const lockDir = `${path}.lock`;
+
+  const locked = await acquireLock(lockDir);
+  try {
+    const state = await readState(chatDir);
+    const next = {
+      version: 1,
+      sessions: { ...state.sessions, [sessionId]: update(state.sessions[sessionId] ?? {}) },
+    };
+    await atomicWriteState(path, next);
+  } finally {
+    // Only release a lock we actually own; if we fell back without one, leave
+    // any foreign lock alone for its owner / the stale-steal path.
+    if (locked) await rmdir(lockDir).catch(() => undefined);
+  }
+}
+
+// Atomic temp-file + rename write of state.json. Cleans up the temp file on any
+// failure so a crash can never leave `.ratel-tmp-*` litter behind.
+async function atomicWriteState(path, next) {
   const tmp = `${path}.ratel-tmp-${randomUUID()}`;
-  await writeFile(tmp, `${JSON.stringify(next, null, 2)}\n`, { encoding: "utf8", mode: FILE_MODE });
-  await rename(tmp, path);
-  await chmod(path, FILE_MODE).catch(() => undefined);
+  try {
+    await writeFile(tmp, `${JSON.stringify(next, null, 2)}\n`, { encoding: "utf8", mode: FILE_MODE });
+    await rename(tmp, path);
+    await chmod(path, FILE_MODE).catch(() => undefined);
+  } catch {
+    await unlink(tmp).catch(() => undefined);
+  }
+}
+
+// Acquire a filesystem mutex by creating a lock directory (mkdir is atomic on
+// POSIX). Retries with a short backoff, steals stale locks left by crashed
+// holders, and ultimately falls back to a best-effort write so the hook never
+// blocks or breaks the host agent.
+// Returns true if we own the lock, false if we proceeded without it.
+async function acquireLock(lockDir) {
+  for (let i = 0; i < LOCK_MAX_TRIES; i++) {
+    try {
+      await mkdir(lockDir, { mode: DIR_MODE });
+      return true;
+    } catch (err) {
+      if (err?.code !== "EEXIST") {
+        // Unexpected error (e.g. permissions) — give up on locking, write anyway.
+        return false;
+      }
+      if (await isLockStale(lockDir)) {
+        // Holder appears dead (lock dir is genuinely old): steal it, then retry.
+        await rmdir(lockDir).catch(() => undefined);
+        continue;
+      }
+      await sleep(LOCK_RETRY_MS + Math.floor(Math.random() * LOCK_JITTER_MS));
+    }
+  }
+  // Budget exhausted: proceed best-effort without the lock rather than block.
+  return false;
+}
+
+// A lock is "stale" only when its directory genuinely exists AND is older than
+// the threshold (its holder almost certainly crashed). If stat throws (e.g. the
+// lock vanished because its holder just released it), we must NOT treat it as
+// stale: doing so could rmdir a brand-new lock another writer just acquired,
+// letting two writers enter the critical section. Return false → plain retry.
+async function isLockStale(lockDir) {
+  try {
+    const info = await stat(lockDir);
+    return Date.now() - info.mtimeMs > LOCK_STALE_MS;
+  } catch {
+    return false;
+  }
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 function clean(text) {
   let out = text.length > MAX_CONTENT ? `${text.slice(0, MAX_CONTENT)}[TRUNCATED]` : text;
-  for (const re of REDACTIONS) out = out.replace(re, "$1[REDACTED]");
+  for (const { re, to } of REDACTIONS) out = out.replace(re, to);
   return out;
 }
 

--- a/apps/ratel-mcp/plugin/hooks/hooks.json
+++ b/apps/ratel-mcp/plugin/hooks/hooks.json
@@ -25,6 +25,32 @@
           }
         ]
       }
+    ],
+    "UserPromptSubmit": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/capture-chat.mjs\" UserPromptSubmit",
+            "statusMessage": "Capturing chat for Ratel intents",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/capture-chat.mjs\" Stop",
+            "statusMessage": "Capturing chat for Ratel intents",
+            "timeout": 15
+          }
+        ]
+      }
     ]
   }
 }

--- a/apps/ratel-mcp/src/cli/args.ts
+++ b/apps/ratel-mcp/src/cli/args.ts
@@ -1,4 +1,4 @@
-export type Group = "mcp" | "backup" | "skill" | "serve" | "ui" | "help" | "version";
+export type Group = "mcp" | "backup" | "skill" | "intents" | "serve" | "ui" | "help" | "version";
 
 export type McpVerb = "add" | "remove" | "list" | "get" | "edit" | "import" | "link" | "auth";
 
@@ -25,6 +25,10 @@ const MCP_VERBS: ReadonlySet<string> = new Set([
 ]);
 
 const BACKUP_VERBS: ReadonlySet<string> = new Set(["list"]);
+
+export type IntentsVerb = "run";
+
+const INTENTS_VERBS: ReadonlySet<string> = new Set(["run"]);
 
 const SKILL_VERBS: ReadonlySet<string> = new Set([
   "activate",
@@ -126,6 +130,17 @@ export function parseArgs(argv: string[]): ParsedArgs {
       const candidate = argv[1];
       if (!SKILL_VERBS.has(candidate)) {
         throw new ArgError(`unknown skill verb: ${candidate}`);
+      }
+      verb = candidate;
+      i = 2;
+    }
+  } else if (first === "intents") {
+    group = "intents";
+    i = 1;
+    if (argv.length > 1 && !argv[1].startsWith("-")) {
+      const candidate = argv[1];
+      if (!INTENTS_VERBS.has(candidate)) {
+        throw new ArgError(`unknown intents verb: ${candidate}`);
       }
       verb = candidate;
       i = 2;

--- a/apps/ratel-mcp/src/cli/cli.ts
+++ b/apps/ratel-mcp/src/cli/cli.ts
@@ -11,6 +11,7 @@ import {
 } from "@ratel-ai/mcp-core";
 import { ArgError, type ParsedArgs, parseArgs } from "./args.js";
 import { BACKUP_USAGE, runBackup } from "./handlers/backup.js";
+import { INTENTS_USAGE, runIntents } from "./handlers/intents.js";
 import { MCP_USAGE, runMcp } from "./handlers/mcp.js";
 import { runServe } from "./handlers/serve.js";
 import { runSkill, SKILL_USAGE } from "./handlers/skill.js";
@@ -44,6 +45,7 @@ Commands:
   mcp      manage MCP servers (add, remove, list, get, edit, import, link, auth)
   backup   manage backup snapshots (list)
   skill    move skills between Claude Code and Ratel (activate, deactivate, list)
+  intents  analyze captured chat into intents and match them to skills (run)
   ui       launch a local browser UI mirroring the CLI [--port N] [--no-open]
 
 Run \`ratel-mcp <group>\` for the verbs available in a group.`;
@@ -85,6 +87,11 @@ export async function runCli(argv: string[], options: RunCliOptions = {}): Promi
     return {};
   }
 
+  if (parsed.group === "intents" && parsed.verb === undefined) {
+    log(INTENTS_USAGE);
+    return {};
+  }
+
   if (parsed.group === "serve") {
     return runServe(parsed, options, log);
   }
@@ -113,6 +120,11 @@ export async function runCli(argv: string[], options: RunCliOptions = {}): Promi
 
   if (parsed.group === "skill") {
     await runSkill(ctx);
+    return {};
+  }
+
+  if (parsed.group === "intents") {
+    await runIntents(ctx);
     return {};
   }
 

--- a/apps/ratel-mcp/src/cli/handlers/intents.ts
+++ b/apps/ratel-mcp/src/cli/handlers/intents.ts
@@ -33,6 +33,7 @@ export async function runIntents(ctx: HandlerCtx): Promise<void> {
   const sessionId = stringFlag(ctx.argv.flags.session);
   const all = ctx.argv.flags.all === true;
 
+  const trigger = sessionId ? "session" : all ? "all" : onIdle ? "idle" : "manual";
   const result = await runAnalysis(
     {
       fs: ctx.fs,
@@ -40,10 +41,11 @@ export async function runIntents(ctx: HandlerCtx): Promise<void> {
       chatSource: runtime.chatSource,
       extractor: runtime.extractor,
       matchSkill: runtime.matchSkill,
+      extractorModel: runtime.analysis?.extractor?.model,
       now: () => new Date().toISOString(),
       log: ctx.log,
     },
-    { sessionId, all, everyNMessages, onIdle },
+    { sessionId, all, everyNMessages, onIdle, trigger },
   );
 
   if (result.analyzed.length === 0) {

--- a/apps/ratel-mcp/src/cli/handlers/intents.ts
+++ b/apps/ratel-mcp/src/cli/handlers/intents.ts
@@ -1,0 +1,70 @@
+import { resolveAnalysisRuntime } from "../../intents/context.js";
+import { DEFAULT_EVERY_N_MESSAGES, runAnalysis } from "../../intents/runner.js";
+import type { FlagValue } from "../args.js";
+import type { HandlerCtx } from "./types.js";
+
+export const INTENTS_USAGE = `usage: ratel-mcp intents <verb>
+
+Verbs:
+  run    analyze captured chat and extract intents, matching each against
+         Ratel-managed skills
+
+Flags:
+  --session <id>   analyze only this chat session
+  --all            analyze every session with captured turns
+  --every <n>      every-N-messages threshold (default from config, else ${DEFAULT_EVERY_N_MESSAGES})
+  --on-idle        also analyze sessions flagged idle by the Stop hook`;
+
+export async function runIntents(ctx: HandlerCtx): Promise<void> {
+  if (ctx.argv.verb !== "run") {
+    ctx.log(INTENTS_USAGE);
+    return;
+  }
+
+  const runtime = await resolveAnalysisRuntime(ctx.env, ctx.fs);
+  if (runtime.analysis?.enabled === false) {
+    ctx.log("intent analysis is disabled (enable it in the UI Settings or ~/.ratel/config.json)");
+    return;
+  }
+  const cadence = runtime.analysis?.cadence ?? {};
+  const everyNMessages =
+    numberFlag(ctx.argv.flags.every) ?? cadence.everyNMessages ?? DEFAULT_EVERY_N_MESSAGES;
+  const onIdle = ctx.argv.flags["on-idle"] === true || cadence.onIdle === true;
+  const sessionId = stringFlag(ctx.argv.flags.session);
+  const all = ctx.argv.flags.all === true;
+
+  const result = await runAnalysis(
+    {
+      fs: ctx.fs,
+      intentsDir: runtime.paths.intentsDir,
+      chatSource: runtime.chatSource,
+      extractor: runtime.extractor,
+      matchSkill: runtime.matchSkill,
+      now: () => new Date().toISOString(),
+      log: ctx.log,
+    },
+    { sessionId, all, everyNMessages, onIdle },
+  );
+
+  if (result.analyzed.length === 0) {
+    ctx.log("no sessions were due for analysis");
+    return;
+  }
+  ctx.log(
+    `analyzed ${result.analyzed.length} session(s): ` +
+      `${result.intentsFound} intents, ${result.gaps} gaps`,
+  );
+}
+
+function numberFlag(value: FlagValue | undefined): number | undefined {
+  if (typeof value !== "string") return undefined;
+  const n = Number(value);
+  if (!Number.isInteger(n) || n < 1) {
+    throw new Error("--every requires a positive integer");
+  }
+  return n;
+}
+
+function stringFlag(value: FlagValue | undefined): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}

--- a/apps/ratel-mcp/src/cli/skills/manage.test.ts
+++ b/apps/ratel-mcp/src/cli/skills/manage.test.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   activateSkills,
   deactivateSkills,
+  deleteManagedSkill,
   listManaged,
   type SkillManagePaths,
   SkillManifestError,
@@ -47,6 +48,34 @@ async function exists(path: string): Promise<boolean> {
     return false;
   }
 }
+
+describe("deleteManagedSkill", () => {
+  async function writeManagedSkill(name: string): Promise<void> {
+    const dir = join(paths.managedDir, name);
+    await mkdir(dir, { recursive: true });
+    await writeFile(join(dir, "SKILL.md"), `---\nname: ${name}\ndescription: d\n---\n# x`);
+  }
+
+  it("removes a Ratel-created skill folder (no manifest entry)", async () => {
+    await writeManagedSkill("my-skill");
+    const removed = await deleteManagedSkill(paths, "my-skill");
+    expect(removed).toBe(true);
+    expect(await exists(join(paths.managedDir, "my-skill", "SKILL.md"))).toBe(false);
+  });
+
+  it("drops the manifest entry for an activated skill it deletes", async () => {
+    await writeNativeSkill("api-design");
+    await activateSkills(paths, {});
+    expect((await listManaged(paths)).map((m) => m.id)).toContain("api-design");
+    await deleteManagedSkill(paths, "api-design");
+    expect((await listManaged(paths)).map((m) => m.id)).not.toContain("api-design");
+  });
+
+  it("returns false for an unknown skill and rejects unsafe ids", async () => {
+    expect(await deleteManagedSkill(paths, "ghost")).toBe(false);
+    await expect(deleteManagedSkill(paths, "../escape")).rejects.toThrow(/unsafe/);
+  });
+});
 
 describe("activateSkills", () => {
   it("moves native skills into the managed folder and records a manifest", async () => {

--- a/apps/ratel-mcp/src/cli/skills/manage.ts
+++ b/apps/ratel-mcp/src/cli/skills/manage.ts
@@ -225,6 +225,26 @@ export async function listManaged(paths: SkillManagePaths): Promise<ManagedEntry
   return (await readManifest(paths.manifestPath)).managed.filter(isValidEntry);
 }
 
+/**
+ * Permanently delete a Ratel-managed skill: remove its folder under the managed
+ * dir and drop any manifest entry. Unlike {@link deactivateSkills} (which moves
+ * it back to its agent), this is irreversible. Returns true if a folder existed.
+ */
+export async function deleteManagedSkill(paths: SkillManagePaths, id: string): Promise<boolean> {
+  if (!isSafeSkillId(id)) {
+    throw new Error(`unsafe skill id: ${String(id)}`);
+  }
+  const dir = join(paths.managedDir, id);
+  const existed = await exists(dir);
+  await rm(dir, { recursive: true, force: true });
+  const manifest = await readManifest(paths.manifestPath);
+  const managed = manifest.managed.filter((m) => !(isValidEntry(m) && m.id === id));
+  if (managed.length !== manifest.managed.length) {
+    await writeManifest(paths.manifestPath, { ...manifest, managed });
+  }
+  return existed;
+}
+
 async function skillDirNames(dir: string): Promise<string[]> {
   let entries: Dirent[];
   try {

--- a/apps/ratel-mcp/src/intents/context.ts
+++ b/apps/ratel-mcp/src/intents/context.ts
@@ -1,0 +1,72 @@
+import {
+  type AnalysisConfig,
+  type ChatSource,
+  createExtractor,
+  type HierarchyEnv,
+  HookChatSource,
+  type IntentExtractor,
+  type IntentsPaths,
+  intentsPaths,
+  type JsonFs,
+  parseConfig,
+  type RatelConfig,
+  ratelConfigPath,
+  resolveRatelDir,
+} from "@ratel-ai/mcp-core";
+import { resolveSkillDirs } from "../cli/skills/suggest.js";
+import { createSkillMatcher } from "./matcher.js";
+import type { SkillMatcher } from "./runner.js";
+
+/** The fully-wired pieces a run needs, assembled from config + the `.ratel` home. */
+export interface AnalysisRuntime {
+  analysis?: AnalysisConfig;
+  paths: IntentsPaths;
+  chatSource: ChatSource;
+  extractor: IntentExtractor;
+  matchSkill: SkillMatcher;
+  skillDirs: string[];
+}
+
+/**
+ * Build the analysis runtime from the user's config + `RATEL_HOME`. Shared by
+ * the `intents` CLI handler and the UI routes so the seam selection lives in one
+ * place.
+ */
+export async function resolveAnalysisRuntime(
+  env: HierarchyEnv,
+  fs: JsonFs,
+): Promise<AnalysisRuntime> {
+  const analysis = await loadUserAnalysis(env, fs);
+  const ratelDir = resolveRatelDir(process.env, env.homeDir);
+  const paths = intentsPaths(ratelDir);
+  const skillDirs = await resolveSkillDirs(env.homeDir);
+  const coverage = analysis?.coverage ?? {};
+  return {
+    analysis,
+    paths,
+    chatSource: new HookChatSource({ chatDir: paths.chatDir, fs }),
+    extractor: createExtractor(analysis),
+    matchSkill: createSkillMatcher({
+      dirs: skillDirs,
+      minScore: coverage.minScore,
+      relativeRatio: coverage.relativeRatio,
+      limit: coverage.maxSkills,
+    }),
+    skillDirs,
+  };
+}
+
+/** Read the `analysis` block from the user-scope Ratel config; undefined if absent/malformed. */
+export async function loadUserAnalysis(
+  env: HierarchyEnv,
+  fs: JsonFs,
+): Promise<AnalysisConfig | undefined> {
+  const raw = await fs.read(ratelConfigPath("user", env));
+  if (!raw) return undefined;
+  try {
+    const config: RatelConfig = parseConfig(JSON.parse(raw));
+    return config.analysis;
+  } catch {
+    return undefined;
+  }
+}

--- a/apps/ratel-mcp/src/intents/coverage.test.ts
+++ b/apps/ratel-mcp/src/intents/coverage.test.ts
@@ -1,0 +1,109 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  emptyIndex,
+  intentsPaths,
+  mergeIntoIndex,
+  nodeJsonFs,
+  readIntentsIndex,
+  type SessionIntents,
+  writeIntentsIndex,
+} from "@ratel-ai/mcp-core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { recomputeIntentCoverage } from "./coverage.js";
+
+let home: string;
+let intentsDir: string;
+const prevRatelHome = process.env.RATEL_HOME;
+const NOW = "2026-06-19T10:00:00.000Z";
+
+beforeEach(async () => {
+  home = await mkdtemp(join(tmpdir(), "ratel-cov-"));
+  process.env.RATEL_HOME = join(home, ".ratel");
+  intentsDir = intentsPaths(join(home, ".ratel")).intentsDir;
+});
+
+afterEach(async () => {
+  if (prevRatelHome === undefined) delete process.env.RATEL_HOME;
+  else process.env.RATEL_HOME = prevRatelHome;
+  await rm(home, { recursive: true, force: true });
+});
+
+function sessionWith(content: string, coverage: SessionIntents["intents"][number]["coverage"]) {
+  return {
+    sessionId: "s1",
+    host: "claude-code",
+    analyzedAt: NOW,
+    claims: [],
+    intents: [{ content, coverage }],
+  } satisfies SessionIntents;
+}
+
+async function seedSkill(name: string, description: string, tags: string[]) {
+  const dir = join(home, ".ratel", "skills", name);
+  await mkdir(dir, { recursive: true });
+  await writeFile(
+    join(dir, "SKILL.md"),
+    [
+      "---",
+      `name: ${name}`,
+      `description: ${description}`,
+      `tags: [${tags.join(", ")}]`,
+      "---",
+      "# x",
+    ].join("\n"),
+  );
+}
+
+describe("recomputeIntentCoverage", () => {
+  it("turns a gap into covered when a matching skill exists", async () => {
+    await writeIntentsIndex(
+      nodeJsonFs,
+      intentsDir,
+      mergeIntoIndex(
+        emptyIndex(),
+        sessionWith("write unit tests for the parser", { status: "gap" }),
+        NOW,
+      ),
+    );
+    await seedSkill("tdd-workflow", "Write unit tests first then implement", [
+      "write tests",
+      "tests",
+      "testing",
+    ]);
+
+    await recomputeIntentCoverage({ homeDir: home }, nodeJsonFs);
+
+    const index = await readIntentsIndex(nodeJsonFs, intentsDir);
+    expect(index.intents[0].coverage.status).toBe("covered");
+    expect(index.sessions[0].gapCount).toBe(0);
+  });
+
+  it("turns covered back into a gap when no skill matches (e.g. unmanaged)", async () => {
+    await writeIntentsIndex(
+      nodeJsonFs,
+      intentsDir,
+      mergeIntoIndex(
+        emptyIndex(),
+        sessionWith("provision a kubernetes cluster", {
+          status: "covered",
+          skills: [{ skillId: "k8s", score: 5 }],
+        }),
+        NOW,
+      ),
+    );
+    // No skills on disk → nothing matches.
+    await recomputeIntentCoverage({ homeDir: home }, nodeJsonFs);
+
+    const index = await readIntentsIndex(nodeJsonFs, intentsDir);
+    expect(index.intents[0].coverage.status).toBe("gap");
+    expect(index.sessions[0].gapCount).toBe(1);
+  });
+
+  it("is a no-op on an empty index", async () => {
+    await writeIntentsIndex(nodeJsonFs, intentsDir, emptyIndex());
+    await recomputeIntentCoverage({ homeDir: home }, nodeJsonFs);
+    expect((await readIntentsIndex(nodeJsonFs, intentsDir)).intents).toEqual([]);
+  });
+});

--- a/apps/ratel-mcp/src/intents/coverage.ts
+++ b/apps/ratel-mcp/src/intents/coverage.ts
@@ -1,0 +1,33 @@
+import type { HierarchyEnv, IntentCoverage, JsonFs } from "@ratel-ai/mcp-core";
+import { readIntentsIndex, writeIntentsIndex } from "@ratel-ai/mcp-core";
+import { resolveAnalysisRuntime } from "./context.js";
+
+/**
+ * Re-evaluate every stored intent's coverage against the *current* managed
+ * skills, without re-running the model. Cheap (BM25 only). Called whenever the
+ * managed-skill set changes — activating/creating a skill can turn a gap into a
+ * covered intent; deactivating/deleting one can turn a covered intent back into
+ * a gap. Per-session `gapCount`s are recomputed to match.
+ */
+export async function recomputeIntentCoverage(env: HierarchyEnv, fs: JsonFs): Promise<void> {
+  const runtime = await resolveAnalysisRuntime(env, fs);
+  const index = await readIntentsIndex(fs, runtime.paths.intentsDir);
+  if (index.intents.length === 0) return;
+
+  const intents = await Promise.all(
+    index.intents.map(async (intent) => {
+      const matches = await runtime.matchSkill(intent.content);
+      const coverage: IntentCoverage =
+        matches.length > 0 ? { status: "covered", skills: matches } : { status: "gap" };
+      return { ...intent, coverage };
+    }),
+  );
+
+  const sessions = index.sessions.map((s) => ({
+    ...s,
+    gapCount: intents.filter((i) => i.sessions.includes(s.sessionId) && i.coverage.status === "gap")
+      .length,
+  }));
+
+  await writeIntentsIndex(fs, runtime.paths.intentsDir, { ...index, intents, sessions });
+}

--- a/apps/ratel-mcp/src/intents/extraction-cache.test.ts
+++ b/apps/ratel-mcp/src/intents/extraction-cache.test.ts
@@ -1,0 +1,78 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { ChatTurn, ExtractionResult } from "@ratel-ai/mcp-core";
+import { nodeJsonFs } from "@ratel-ai/mcp-core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { cacheKey, createFsExtractionCache } from "./extraction-cache.js";
+
+const TURNS: ChatTurn[] = [
+  { role: "user", content: "add oauth login" },
+  { role: "assistant", content: "ok" },
+];
+
+const RESULT: ExtractionResult = {
+  claims: [{ subtype: "user_assertion", content: "wants oauth" }],
+  intents: [{ content: "add oauth login" }],
+};
+
+describe("cacheKey", () => {
+  it("is deterministic for identical inputs", () => {
+    expect(cacheKey(TURNS, "m1")).toBe(cacheKey(TURNS, "m1"));
+  });
+
+  it("is a 64-char hex sha256 digest", () => {
+    expect(cacheKey(TURNS, "m1")).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it("changes when the model id changes", () => {
+    expect(cacheKey(TURNS, "m1")).not.toBe(cacheKey(TURNS, "m2"));
+  });
+
+  it("distinguishes a missing model from a present one", () => {
+    expect(cacheKey(TURNS)).not.toBe(cacheKey(TURNS, "m1"));
+  });
+
+  it("changes when the turns change", () => {
+    const other: ChatTurn[] = [{ role: "user", content: "deploy app" }];
+    expect(cacheKey(TURNS, "m1")).not.toBe(cacheKey(other, "m1"));
+  });
+});
+
+describe("createFsExtractionCache", () => {
+  let intentsDir: string;
+
+  beforeEach(async () => {
+    intentsDir = await mkdtemp(join(tmpdir(), "ratel-cache-"));
+  });
+
+  afterEach(async () => {
+    await rm(intentsDir, { recursive: true, force: true });
+  });
+
+  it("returns null on a miss", async () => {
+    const cache = createFsExtractionCache(nodeJsonFs, intentsDir);
+    expect(await cache.get(cacheKey(TURNS, "m1"))).toBeNull();
+  });
+
+  it("round-trips a value through the filesystem", async () => {
+    const cache = createFsExtractionCache(nodeJsonFs, intentsDir);
+    const key = cacheKey(TURNS, "m1");
+    await cache.set(key, RESULT);
+    expect(await cache.get(key)).toEqual(RESULT);
+  });
+
+  it("stores entries under <intentsDir>/cache/<key>.json", async () => {
+    const cache = createFsExtractionCache(nodeJsonFs, intentsDir);
+    const key = cacheKey(TURNS, "m1");
+    await cache.set(key, RESULT);
+    expect(await nodeJsonFs.exists(join(intentsDir, "cache", `${key}.json`))).toBe(true);
+  });
+
+  it("returns null on a malformed cache file", async () => {
+    const cache = createFsExtractionCache(nodeJsonFs, intentsDir);
+    const key = cacheKey(TURNS, "m1");
+    await nodeJsonFs.writeAtomic(join(intentsDir, "cache", `${key}.json`), "{ not json");
+    expect(await cache.get(key)).toBeNull();
+  });
+});

--- a/apps/ratel-mcp/src/intents/extraction-cache.ts
+++ b/apps/ratel-mcp/src/intents/extraction-cache.ts
@@ -1,0 +1,57 @@
+import { createHash } from "node:crypto";
+import { join } from "node:path";
+import type { ChatTurn, ExtractionResult, JsonFs } from "@ratel-ai/mcp-core";
+
+/**
+ * A content-addressed cache for {@link ExtractionResult}s, keyed by the turns +
+ * model that produced them. Lets a run reuse a prior extraction instead of
+ * re-invoking the (slow, costly) extractor when neither the conversation nor the
+ * model has changed.
+ */
+export interface ExtractionCache {
+  /** The cached result for `key`, or null on a miss / malformed entry. */
+  get(key: string): Promise<ExtractionResult | null>;
+  /** Store `value` under `key` (atomic write). */
+  set(key: string, value: ExtractionResult): Promise<void>;
+}
+
+/**
+ * Deterministic cache key for an extraction: the sha256 of the stable JSON of
+ * `{ turns, model }`. Including the model id means switching models invalidates
+ * the cache for the same conversation.
+ */
+export function cacheKey(turns: ChatTurn[], model?: string): string {
+  const stable = JSON.stringify({
+    turns: turns.map((t) => ({ role: t.role, content: t.content, ts: t.ts })),
+    model: model ?? null,
+  });
+  return createHash("sha256").update(stable).digest("hex");
+}
+
+/** Path to one cache entry: `<intentsDir>/cache/<key>.json`. */
+function cacheEntryPath(intentsDir: string, key: string): string {
+  return join(intentsDir, "cache", `${key}.json`);
+}
+
+/**
+ * A filesystem-backed {@link ExtractionCache} storing each entry as a JSON file
+ * under `<intentsDir>/cache/`. Reads return null on miss or malformed content so
+ * a corrupt entry never breaks a run; writes are atomic.
+ */
+export function createFsExtractionCache(fs: JsonFs, intentsDir: string): ExtractionCache {
+  return {
+    async get(key) {
+      const raw = await fs.read(cacheEntryPath(intentsDir, key));
+      if (raw === null) return null;
+      try {
+        return JSON.parse(raw) as ExtractionResult;
+      } catch {
+        return null;
+      }
+    },
+    async set(key, value) {
+      const text = `${JSON.stringify(value, null, 2)}\n`;
+      await fs.writeAtomic(cacheEntryPath(intentsDir, key), text);
+    },
+  };
+}

--- a/apps/ratel-mcp/src/intents/extraction-cache.ts
+++ b/apps/ratel-mcp/src/intents/extraction-cache.ts
@@ -29,7 +29,7 @@ export function cacheKey(turns: ChatTurn[], model?: string): string {
 }
 
 /** Path to one cache entry: `<intentsDir>/cache/<key>.json`. */
-function cacheEntryPath(intentsDir: string, key: string): string {
+export function cacheEntryPath(intentsDir: string, key: string): string {
   return join(intentsDir, "cache", `${key}.json`);
 }
 

--- a/apps/ratel-mcp/src/intents/matcher.ts
+++ b/apps/ratel-mcp/src/intents/matcher.ts
@@ -1,0 +1,58 @@
+import { suggestSkills } from "../cli/skills/suggest.js";
+import type { SkillMatcher } from "./runner.js";
+
+/** Max skills reported as covering one intent. */
+const DEFAULT_COVERAGE_LIMIT = 4;
+/**
+ * Absolute BM25 floor: below this, a skill is too weak to count as covering at
+ * all. Set above the observed "noise floor" (~0.7, where a skill shares one
+ * common term with an unrelated intent) but below genuine matches (which score
+ * ~1.4+). Tunable.
+ */
+const DEFAULT_COVERAGE_MIN_SCORE = 1.0;
+/**
+ * Relative cutoff: keep only skills scoring within this fraction of the top
+ * match. BM25 magnitudes vary a lot by query, so an absolute floor alone either
+ * over- or under-reports; anchoring to the top match adapts per intent and trims
+ * the tangential long tail (a strong top keeps only similarly-strong peers).
+ */
+const RELATIVE_RATIO = 0.6;
+
+export interface SkillMatcherOptions {
+  /** Skill directories to rank against (resolve with `resolveSkillDirs`). */
+  dirs: string[];
+  /** Max skills returned per intent (default 4). */
+  limit?: number;
+  /** Absolute BM25 floor below which a skill never counts as covering. */
+  minScore?: number;
+  /** Keep only skills within this fraction (0–1) of the top match (default 0.6). */
+  relativeRatio?: number;
+}
+
+/**
+ * Build a {@link SkillMatcher} backed by Ratel's skill-suggestion engine
+ * (`SkillCatalog.search`, BM25) — the same index the gateway's capability search
+ * uses. Returns the ranked list of skills covering an intent (best first):
+ * matches above an absolute floor AND within {@link RELATIVE_RATIO} of the top
+ * match. Empty list = a gap, which is what "Offer New Skills" keys off.
+ */
+export function createSkillMatcher(opts: SkillMatcherOptions): SkillMatcher {
+  const floor = opts.minScore ?? DEFAULT_COVERAGE_MIN_SCORE;
+  const limit = opts.limit ?? DEFAULT_COVERAGE_LIMIT;
+  const ratio = opts.relativeRatio ?? RELATIVE_RATIO;
+  return async (text, cwd) => {
+    const hits = await suggestSkills({
+      prompt: text,
+      dirs: opts.dirs,
+      cwd,
+      limit: limit + 2,
+      minScore: floor,
+    });
+    if (hits.length === 0) return [];
+    const cutoff = Math.max(floor, hits[0].score * ratio);
+    return hits
+      .filter((h) => h.score >= cutoff)
+      .slice(0, limit)
+      .map((h) => ({ skillId: h.skillId, score: h.score }));
+  };
+}

--- a/apps/ratel-mcp/src/intents/runner.test.ts
+++ b/apps/ratel-mcp/src/intents/runner.test.ts
@@ -1,0 +1,189 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  HookChatSource,
+  intentsPaths,
+  NaiveIntentExtractor,
+  nodeJsonFs,
+  readChatState,
+  readIntentsIndex,
+  readSessionIntents,
+  sessionTurnsPath,
+  writeChatState,
+} from "@ratel-ai/mcp-core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createSkillMatcher } from "./matcher.js";
+import { runAnalysis, type SkillMatcher, selectDueSessions } from "./runner.js";
+
+let ratelDir: string;
+let chatDir: string;
+let intentsDir: string;
+const NOW = "2026-06-19T10:00:00.000Z";
+
+beforeEach(async () => {
+  ratelDir = await mkdtemp(join(tmpdir(), "ratel-runner-"));
+  const paths = intentsPaths(ratelDir);
+  chatDir = paths.chatDir;
+  intentsDir = paths.intentsDir;
+});
+
+afterEach(async () => {
+  await rm(ratelDir, { recursive: true, force: true });
+});
+
+async function seedSession(
+  host: string,
+  sessionId: string,
+  meta: { newTurnCount: number; idle?: boolean; cwd?: string },
+  turns: Array<{ role: string; content: string }>,
+): Promise<void> {
+  const lines = turns.map((t) => JSON.stringify(t)).join("\n");
+  await nodeJsonFs.writeAtomic(sessionTurnsPath(chatDir, host, sessionId), `${lines}\n`);
+  const state = await readChatState(nodeJsonFs, chatDir);
+  state.sessions[sessionId] = { sessionId, host, ...meta };
+  await writeChatState(nodeJsonFs, chatDir, state);
+}
+
+/** A deterministic matcher: "write tests" is covered; everything else is a gap. */
+const stubMatcher: SkillMatcher = async (text) =>
+  /test/i.test(text) ? [{ skillId: "tdd", score: 4.2 }] : [];
+
+function deps(matchSkill: SkillMatcher) {
+  return {
+    fs: nodeJsonFs,
+    intentsDir,
+    chatSource: new HookChatSource({ chatDir, fs: nodeJsonFs }),
+    extractor: new NaiveIntentExtractor(),
+    matchSkill,
+    now: () => NOW,
+  };
+}
+
+describe("selectDueSessions", () => {
+  const sessions = [
+    { sessionId: "a", host: "claude-code", newTurnCount: 12 },
+    { sessionId: "b", host: "claude-code", newTurnCount: 1, idle: true },
+    { sessionId: "c", host: "codex", newTurnCount: 0 },
+  ];
+
+  it("picks an explicit session id", () => {
+    expect(selectDueSessions(sessions, { sessionId: "c" }, 10).map((s) => s.sessionId)).toEqual([
+      "c",
+    ]);
+  });
+
+  it("picks all when all=true", () => {
+    expect(selectDueSessions(sessions, { all: true }, 10)).toHaveLength(3);
+  });
+
+  it("picks sessions over the threshold", () => {
+    expect(selectDueSessions(sessions, {}, 10).map((s) => s.sessionId)).toEqual(["a"]);
+  });
+
+  it("includes idle sessions only when onIdle is set", () => {
+    expect(selectDueSessions(sessions, { onIdle: true }, 10).map((s) => s.sessionId)).toEqual([
+      "a",
+      "b",
+    ]);
+  });
+});
+
+describe("runAnalysis", () => {
+  it("extracts, annotates coverage, persists, and resets state for a due session", async () => {
+    await seedSession("claude-code", "s1", { newTurnCount: 12 }, [
+      { role: "user", content: "Add OAuth login to my app" },
+      { role: "assistant", content: "ok" },
+      { role: "user", content: "Now write tests for it" },
+    ]);
+
+    const result = await runAnalysis(deps(stubMatcher), { everyNMessages: 10 });
+
+    expect(result.analyzed).toEqual(["s1"]);
+    expect(result.intentsFound).toBe(2);
+    expect(result.gaps).toBe(1);
+
+    const session = await readSessionIntents(nodeJsonFs, intentsDir, "s1");
+    expect(session?.intents.map((i) => i.coverage.status)).toEqual(["gap", "covered"]);
+
+    const index = await readIntentsIndex(nodeJsonFs, intentsDir);
+    expect(index.intents).toHaveLength(2);
+    expect(index.sessions[0]).toMatchObject({ sessionId: "s1", intentCount: 2, gapCount: 1 });
+
+    // state reset: the new-turn counter is cleared and lastAnalyzedAt stamped
+    const state = await readChatState(nodeJsonFs, chatDir);
+    expect(state.sessions.s1.newTurnCount).toBe(0);
+    expect(state.sessions.s1.lastAnalyzedAt).toBe(NOW);
+  });
+
+  it("skips sessions below the threshold", async () => {
+    await seedSession("claude-code", "s1", { newTurnCount: 2 }, [{ role: "user", content: "hi" }]);
+    const result = await runAnalysis(deps(stubMatcher), { everyNMessages: 10 });
+    expect(result.analyzed).toEqual([]);
+  });
+
+  it("analyzes an idle session when onIdle is set", async () => {
+    await seedSession("codex", "s2", { newTurnCount: 0, idle: true }, [
+      { role: "user", content: "deploy my app" },
+    ]);
+    const result = await runAnalysis(deps(stubMatcher), { everyNMessages: 10, onIdle: true });
+    expect(result.analyzed).toEqual(["s2"]);
+  });
+});
+
+describe("createSkillMatcher (integration with suggestSkills)", () => {
+  it("reports covered for a clear lexical match and a gap otherwise", async () => {
+    const skillsDir = join(ratelDir, "skills");
+    await mkdir(join(skillsDir, "tdd-workflow"), { recursive: true });
+    await writeFile(
+      join(skillsDir, "tdd-workflow", "SKILL.md"),
+      [
+        "---",
+        "name: tdd-workflow",
+        "description: Write unit tests first then implement to pass them",
+        "tags: [tests, testing, tdd, unit tests]",
+        "---",
+        "# TDD",
+        "Write a failing test, make it pass, refactor.",
+      ].join("\n"),
+    );
+
+    // Explicit floor so this exercises the matcher logic, not the production default.
+    const match = createSkillMatcher({ dirs: [skillsDir], minScore: 0.5 });
+    const covered = await match("write unit tests for my module");
+    expect(covered.map((m) => m.skillId)).toContain("tdd-workflow");
+    const gap = await match("provision a kubernetes cluster on bare metal");
+    expect(gap).toEqual([]);
+  });
+});
+
+describe("end-to-end with the real matcher", () => {
+  it("flags an uncovered intent as a gap and a covered one as covered", async () => {
+    const skillsDir = join(ratelDir, "skills");
+    await mkdir(join(skillsDir, "tdd-workflow"), { recursive: true });
+    await writeFile(
+      join(skillsDir, "tdd-workflow", "SKILL.md"),
+      [
+        "---",
+        "name: tdd-workflow",
+        "description: Write unit tests first then implement",
+        "tags: [tests, testing, write tests]",
+        "---",
+        "# TDD",
+      ].join("\n"),
+    );
+    await seedSession("claude-code", "s9", { newTurnCount: 50 }, [
+      { role: "user", content: "write tests for the parser" },
+      { role: "user", content: "set up a grafana dashboard with prometheus" },
+    ]);
+
+    await runAnalysis(deps(createSkillMatcher({ dirs: [skillsDir], minScore: 0.5 })), {
+      all: true,
+    });
+
+    const index = await readIntentsIndex(nodeJsonFs, intentsDir);
+    const byContent = Object.fromEntries(index.intents.map((i) => [i.content, i.coverage.status]));
+    expect(byContent["write tests for the parser"]).toBe("covered");
+    expect(byContent["set up a grafana dashboard with prometheus"]).toBe("gap");
+  });
+});

--- a/apps/ratel-mcp/src/intents/runner.test.ts
+++ b/apps/ratel-mcp/src/intents/runner.test.ts
@@ -1,6 +1,7 @@
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import type { ChatTurn, ExtractionResult, IntentExtractor } from "@ratel-ai/mcp-core";
 import {
   HookChatSource,
   intentsPaths,
@@ -8,13 +9,15 @@ import {
   nodeJsonFs,
   readChatState,
   readIntentsIndex,
+  readRunLog,
   readSessionIntents,
   sessionTurnsPath,
   writeChatState,
 } from "@ratel-ai/mcp-core";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cacheKey, createFsExtractionCache } from "./extraction-cache.js";
 import { createSkillMatcher } from "./matcher.js";
-import { runAnalysis, type SkillMatcher, selectDueSessions } from "./runner.js";
+import { applyRecencyWindow, runAnalysis, type SkillMatcher, selectDueSessions } from "./runner.js";
 
 let ratelDir: string;
 let chatDir: string;
@@ -89,6 +92,36 @@ describe("selectDueSessions", () => {
   });
 });
 
+describe("applyRecencyWindow", () => {
+  const now = () => "2026-06-22T12:00:00.000Z";
+  const due = [
+    {
+      sessionId: "fresh",
+      host: "claude-code",
+      newTurnCount: 12,
+      updatedAt: "2026-06-22T10:00:00.000Z",
+    },
+    {
+      sessionId: "stale",
+      host: "claude-code",
+      newTurnCount: 12,
+      updatedAt: "2026-06-20T10:00:00.000Z",
+    },
+    { sessionId: "unknown", host: "claude-code", newTurnCount: 12 },
+  ];
+
+  it("keeps only sessions updated within the window (unknown updatedAt kept)", () => {
+    const kept = applyRecencyWindow(due, { recentHours: 5 }, now).map((s) => s.sessionId);
+    expect(kept).toEqual(["fresh", "unknown"]);
+  });
+
+  it("is a no-op without recentHours, or for explicit sessionId/all", () => {
+    expect(applyRecencyWindow(due, {}, now)).toHaveLength(3);
+    expect(applyRecencyWindow(due, { recentHours: 5, all: true }, now)).toHaveLength(3);
+    expect(applyRecencyWindow(due, { recentHours: 5, sessionId: "stale" }, now)).toHaveLength(3);
+  });
+});
+
 describe("runAnalysis", () => {
   it("extracts, annotates coverage, persists, and resets state for a due session", async () => {
     await seedSession("claude-code", "s1", { newTurnCount: 12 }, [
@@ -128,6 +161,160 @@ describe("runAnalysis", () => {
     ]);
     const result = await runAnalysis(deps(stubMatcher), { everyNMessages: 10, onIdle: true });
     expect(result.analyzed).toEqual(["s2"]);
+  });
+});
+
+describe("runAnalysis reliability, caching, durability, telemetry", () => {
+  /** A spy extractor that always returns one intent (deterministic). */
+  function spyExtractor(): IntentExtractor & { extract: ReturnType<typeof vi.fn> } {
+    const result: ExtractionResult = {
+      claims: [],
+      intents: [{ content: "add oauth login" }],
+    };
+    return {
+      extract: vi.fn(async (_turns: ChatTurn[]) => result),
+    };
+  }
+
+  function depsWith(
+    overrides: Partial<ReturnType<typeof deps>> & { extractor?: IntentExtractor },
+  ): ReturnType<typeof deps> {
+    return { ...deps(stubMatcher), ...overrides };
+  }
+
+  it("records a failing session in errors and continues the batch", async () => {
+    await seedSession("claude-code", "s1", { newTurnCount: 12 }, [
+      { role: "user", content: "boom" },
+    ]);
+    await seedSession("claude-code", "s2", { newTurnCount: 12 }, [
+      { role: "user", content: "Now write tests for it" },
+    ]);
+
+    const failing: IntentExtractor = {
+      async extract(turns) {
+        if (turns.some((t) => t.content === "boom")) {
+          throw new Error("extractor exploded");
+        }
+        return { claims: [], intents: [{ content: "write tests" }] };
+      },
+    };
+
+    const result = await runAnalysis(depsWith({ extractor: failing }), { all: true });
+
+    expect(result.analyzed).toEqual(["s2"]);
+    expect(result.errors).toEqual([{ sessionId: "s1", message: "extractor exploded" }]);
+    // the healthy session still persisted
+    expect(await readSessionIntents(nodeJsonFs, intentsDir, "s2")).not.toBeNull();
+  });
+
+  it("uses the cache on a hit and skips the extractor", async () => {
+    await seedSession("claude-code", "s1", { newTurnCount: 12 }, [
+      { role: "user", content: "Add OAuth login" },
+    ]);
+    const extractor = spyExtractor();
+    const cache = createFsExtractionCache(nodeJsonFs, intentsDir);
+    const turns = await new HookChatSource({ chatDir, fs: nodeJsonFs }).readSession("s1");
+    await cache.set(cacheKey(turns, "model-x"), { claims: [], intents: [{ content: "cached" }] });
+
+    await runAnalysis(depsWith({ extractor, cache, extractorModel: "model-x" }), { all: true });
+
+    expect(extractor.extract).not.toHaveBeenCalled();
+    const session = await readSessionIntents(nodeJsonFs, intentsDir, "s1");
+    expect(session?.intents.map((i) => i.content)).toEqual(["cached"]);
+  });
+
+  it("bypassCache forces a fresh extraction even when a cache entry exists", async () => {
+    await seedSession("claude-code", "s1", { newTurnCount: 12 }, [
+      { role: "user", content: "Add OAuth login" },
+    ]);
+    const extractor = spyExtractor();
+    const cache = createFsExtractionCache(nodeJsonFs, intentsDir);
+    const turns = await new HookChatSource({ chatDir, fs: nodeJsonFs }).readSession("s1");
+    await cache.set(cacheKey(turns, "model-x"), { claims: [], intents: [{ content: "stale" }] });
+
+    await runAnalysis(depsWith({ extractor, cache, extractorModel: "model-x" }), {
+      all: true,
+      bypassCache: true,
+    });
+
+    expect(extractor.extract).toHaveBeenCalledTimes(1);
+    const session = await readSessionIntents(nodeJsonFs, intentsDir, "s1");
+    // fresh extraction (not the stale cached value), and the cache is refreshed
+    expect(session?.intents.map((i) => i.content)).toEqual(["add oauth login"]);
+  });
+
+  it("calls the extractor once on a miss and populates the cache", async () => {
+    await seedSession("claude-code", "s1", { newTurnCount: 12 }, [
+      { role: "user", content: "Add OAuth login" },
+    ]);
+    const extractor = spyExtractor();
+    const cache = createFsExtractionCache(nodeJsonFs, intentsDir);
+
+    await runAnalysis(depsWith({ extractor, cache, extractorModel: "model-x" }), { all: true });
+
+    expect(extractor.extract).toHaveBeenCalledTimes(1);
+    const turns = await new HookChatSource({ chatDir, fs: nodeJsonFs }).readSession("s1");
+    expect(await cache.get(cacheKey(turns, "model-x"))).toEqual({
+      claims: [],
+      intents: [{ content: "add oauth login" }],
+    });
+  });
+
+  it("rebuilds the durable index from session files after a run", async () => {
+    await seedSession("claude-code", "s1", { newTurnCount: 50 }, [
+      { role: "user", content: "write tests for the parser" },
+    ]);
+    await seedSession("claude-code", "s2", { newTurnCount: 50 }, [
+      { role: "user", content: "write tests for the parser" },
+      { role: "user", content: "deploy to production" },
+    ]);
+
+    await runAnalysis(deps(stubMatcher), { all: true });
+
+    const index = await readIntentsIndex(nodeJsonFs, intentsDir);
+    // de-dup: shared intent appears once, ranked first (seen in two sessions)
+    const contents = index.intents.map((i) => i.content);
+    expect(contents).toContain("write tests for the parser");
+    expect(contents).toContain("deploy to production");
+    const shared = index.intents.find((i) => i.content === "write tests for the parser");
+    expect(shared?.sessions.sort()).toEqual(["s1", "s2"]);
+  });
+
+  it("appends exactly one run log entry with correct totals and per-session outcomes", async () => {
+    await seedSession("claude-code", "ok1", { newTurnCount: 12 }, [
+      { role: "user", content: "Now write tests for it" },
+    ]);
+    await seedSession("claude-code", "bad1", { newTurnCount: 12 }, [
+      { role: "user", content: "boom" },
+    ]);
+
+    const failing: IntentExtractor = {
+      async extract(turns) {
+        if (turns.some((t) => t.content === "boom")) throw new Error("nope");
+        return { claims: [], intents: [{ content: "write tests" }] };
+      },
+    };
+    let clock = 1000;
+    const monotonic = () => {
+      clock += 5;
+      return clock;
+    };
+
+    await runAnalysis(depsWith({ extractor: failing, monotonic, extractorModel: "m1" }), {
+      all: true,
+      trigger: "all",
+    });
+
+    const log = await readRunLog(nodeJsonFs, intentsDir);
+    expect(log).toHaveLength(1);
+    const entry = log[0];
+    expect(entry.trigger).toBe("all");
+    expect(entry.model).toBe("m1");
+    expect(entry.totalIntents).toBe(1);
+    expect(entry.totalGaps).toBe(0);
+    const byId = Object.fromEntries(entry.sessions.map((s) => [s.sessionId, s]));
+    expect(byId.ok1).toMatchObject({ ok: true, intents: 1, gaps: 0, cacheHit: false });
+    expect(byId.bad1).toMatchObject({ ok: false, error: "nope", cacheHit: false });
   });
 });
 

--- a/apps/ratel-mcp/src/intents/runner.test.ts
+++ b/apps/ratel-mcp/src/intents/runner.test.ts
@@ -90,6 +90,16 @@ describe("selectDueSessions", () => {
       "b",
     ]);
   });
+
+  it("includes a flagged session even with no new turns and onIdle off", () => {
+    // After "clear all" re-arms a session, a plain run must pick it up so intents
+    // regenerate (otherwise the bookkeeping reads "analyzed" and the run skips it).
+    const flagged = [
+      { sessionId: "c", host: "codex", newTurnCount: 0 },
+      { sessionId: "d", host: "codex", newTurnCount: 0, needsReanalysis: true },
+    ];
+    expect(selectDueSessions(flagged, {}, 10).map((s) => s.sessionId)).toEqual(["d"]);
+  });
 });
 
 describe("applyRecencyWindow", () => {

--- a/apps/ratel-mcp/src/intents/runner.ts
+++ b/apps/ratel-mcp/src/intents/runner.ts
@@ -1,0 +1,132 @@
+import {
+  type ChatSessionMeta,
+  type ChatSource,
+  type IntentCoverage,
+  type IntentExtractor,
+  type JsonFs,
+  mergeIntoIndex,
+  readIntentsIndex,
+  type SessionIntents,
+  type StoredIntent,
+  writeIntentsIndex,
+  writeSessionIntents,
+} from "@ratel-ai/mcp-core";
+
+/** Default every-N-messages threshold when the config omits one. */
+export const DEFAULT_EVERY_N_MESSAGES = 10;
+
+export interface SkillMatch {
+  skillId: string;
+  score: number;
+}
+
+/** Resolve which managed skills cover an intent (BM25-ranked, best first; empty = a gap). */
+export type SkillMatcher = (intentText: string, cwd?: string) => Promise<SkillMatch[]>;
+
+export interface AnalysisRunnerDeps {
+  fs: JsonFs;
+  intentsDir: string;
+  chatSource: ChatSource;
+  extractor: IntentExtractor;
+  matchSkill: SkillMatcher;
+  /** ISO-timestamp provider (injected so runs are deterministic in tests). */
+  now: () => string;
+  log?: (message: string) => void;
+}
+
+export interface RunAnalysisOptions {
+  /** Analyze only this session (the manual/idle-hook path). */
+  sessionId?: string;
+  /** Analyze every session that has captured turns (manual "run all"). */
+  all?: boolean;
+  /** Threshold trigger: analyze sessions with at least this many new turns. */
+  everyNMessages?: number;
+  /** Also analyze sessions the capture layer flagged idle. */
+  onIdle?: boolean;
+}
+
+export interface RunAnalysisResult {
+  analyzed: string[];
+  skipped: string[];
+  intentsFound: number;
+  gaps: number;
+}
+
+/**
+ * The single unit every trigger (manual button/CLI, idle Stop hook, every-N
+ * threshold) calls. Selects the due sessions, extracts intents via the
+ * configured {@link IntentExtractor}, annotates each with skill coverage,
+ * persists the per-session result + cumulative index, and marks the session
+ * analyzed so its new-turn counter resets.
+ */
+export async function runAnalysis(
+  deps: AnalysisRunnerDeps,
+  opts: RunAnalysisOptions = {},
+): Promise<RunAnalysisResult> {
+  const everyN = opts.everyNMessages ?? DEFAULT_EVERY_N_MESSAGES;
+  const sessions = await deps.chatSource.listSessions();
+  const due = selectDueSessions(sessions, opts, everyN);
+
+  const result: RunAnalysisResult = { analyzed: [], skipped: [], intentsFound: 0, gaps: 0 };
+
+  for (const meta of due) {
+    const turns = await deps.chatSource.readSession(meta.sessionId);
+    if (turns.length === 0) {
+      result.skipped.push(meta.sessionId);
+      continue;
+    }
+
+    const { claims, intents } = await deps.extractor.extract(turns);
+    const storedIntents: StoredIntent[] = [];
+    for (const intent of intents) {
+      const matches = await deps.matchSkill(intent.content, meta.cwd);
+      const coverage: IntentCoverage =
+        matches.length > 0 ? { status: "covered", skills: matches } : { status: "gap" };
+      const stored: StoredIntent = { content: intent.content, coverage };
+      if (intent.evidences) stored.evidences = intent.evidences;
+      storedIntents.push(stored);
+    }
+
+    const now = deps.now();
+    const session: SessionIntents = {
+      sessionId: meta.sessionId,
+      host: meta.host,
+      cwd: meta.cwd,
+      analyzedAt: now,
+      claims,
+      intents: storedIntents,
+    };
+
+    await writeSessionIntents(deps.fs, deps.intentsDir, session);
+    const index = await readIntentsIndex(deps.fs, deps.intentsDir);
+    await writeIntentsIndex(deps.fs, deps.intentsDir, mergeIntoIndex(index, session, now));
+    await deps.chatSource.markAnalyzed?.(meta.sessionId, now);
+
+    result.analyzed.push(meta.sessionId);
+    result.intentsFound += storedIntents.length;
+    result.gaps += storedIntents.filter((i) => i.coverage.status === "gap").length;
+    deps.log?.(
+      `[ratel] analyzed ${meta.sessionId}: ${storedIntents.length} intents, ` +
+        `${storedIntents.filter((i) => i.coverage.status === "gap").length} gaps`,
+    );
+  }
+
+  return result;
+}
+
+/** Pick the sessions a run should process for the given trigger. */
+export function selectDueSessions(
+  sessions: ChatSessionMeta[],
+  opts: RunAnalysisOptions,
+  everyN: number,
+): ChatSessionMeta[] {
+  if (opts.sessionId) {
+    return sessions.filter((s) => s.sessionId === opts.sessionId);
+  }
+  if (opts.all) {
+    return sessions;
+  }
+  return sessions.filter(
+    (s) => s.newTurnCount >= everyN || (Boolean(opts.onIdle) && s.idle === true),
+  );
+}

--- a/apps/ratel-mcp/src/intents/runner.ts
+++ b/apps/ratel-mcp/src/intents/runner.ts
@@ -1,19 +1,28 @@
+import { randomUUID } from "node:crypto";
 import {
+  appendRunLog,
   type ChatSessionMeta,
   type ChatSource,
+  type ChatTurn,
   type IntentCoverage,
   type IntentExtractor,
   type JsonFs,
-  mergeIntoIndex,
-  readIntentsIndex,
+  type RunLogEntry,
+  type RunLogSessionEntry,
+  readAllSessionIntents,
+  rebuildIndex,
   type SessionIntents,
   type StoredIntent,
   writeIntentsIndex,
   writeSessionIntents,
 } from "@ratel-ai/mcp-core";
+import { cacheKey, createFsExtractionCache, type ExtractionCache } from "./extraction-cache.js";
 
 /** Default every-N-messages threshold when the config omits one. */
 export const DEFAULT_EVERY_N_MESSAGES = 10;
+
+/** Default trigger label recorded in run telemetry when callers omit one. */
+const DEFAULT_TRIGGER = "manual";
 
 export interface SkillMatch {
   skillId: string;
@@ -31,6 +40,12 @@ export interface AnalysisRunnerDeps {
   matchSkill: SkillMatcher;
   /** ISO-timestamp provider (injected so runs are deterministic in tests). */
   now: () => string;
+  /** Model id of the configured extractor; folded into the cache key so a model change invalidates it. */
+  extractorModel?: string;
+  /** Extraction cache; defaults to a filesystem cache under `<intentsDir>/cache/`. */
+  cache?: ExtractionCache;
+  /** Monotonic millisecond clock for per-session latency (injected for deterministic tests). */
+  monotonic?: () => number;
   log?: (message: string) => void;
 }
 
@@ -43,6 +58,15 @@ export interface RunAnalysisOptions {
   everyNMessages?: number;
   /** Also analyze sessions the capture layer flagged idle. */
   onIdle?: boolean;
+  /**
+   * Limit the threshold/idle batch to sessions active within this many hours.
+   * Ignored when `sessionId` or `all` is set (those are explicit). Omitted = no limit.
+   */
+  recentHours?: number;
+  /** Force fresh extraction, ignoring (but still refreshing) the extraction cache. */
+  bypassCache?: boolean;
+  /** Telemetry label for this run (e.g. "manual" | "idle" | "cadence" | "all" | "session"). */
+  trigger?: string;
 }
 
 export interface RunAnalysisResult {
@@ -50,24 +74,49 @@ export interface RunAnalysisResult {
   skipped: string[];
   intentsFound: number;
   gaps: number;
+  /** Sessions whose analysis threw; the batch continues past each failure. */
+  errors: Array<{ sessionId: string; message: string }>;
+}
+
+/** Internal per-session outcome, used to build both the result and the run log. */
+interface SessionOutcome {
+  entry: RunLogSessionEntry;
+  intents: number;
+  gaps: number;
+  ok: boolean;
 }
 
 /**
  * The single unit every trigger (manual button/CLI, idle Stop hook, every-N
  * threshold) calls. Selects the due sessions, extracts intents via the
- * configured {@link IntentExtractor}, annotates each with skill coverage,
- * persists the per-session result + cumulative index, and marks the session
- * analyzed so its new-turn counter resets.
+ * configured {@link IntentExtractor} (reusing cached extractions when the turns
+ * and model are unchanged), annotates each with skill coverage, persists the
+ * per-session result, rebuilds the cumulative index from disk so partial
+ * progress is durable, and marks the session analyzed so its new-turn counter
+ * resets. One failing session never aborts the batch — its error is recorded and
+ * the run continues. A single {@link RunLogEntry} is appended for the whole run.
  */
 export async function runAnalysis(
   deps: AnalysisRunnerDeps,
   opts: RunAnalysisOptions = {},
 ): Promise<RunAnalysisResult> {
   const everyN = opts.everyNMessages ?? DEFAULT_EVERY_N_MESSAGES;
-  const sessions = await deps.chatSource.listSessions();
-  const due = selectDueSessions(sessions, opts, everyN);
+  const trigger = opts.trigger ?? DEFAULT_TRIGGER;
+  const cache = deps.cache ?? createFsExtractionCache(deps.fs, deps.intentsDir);
+  const monotonic = deps.monotonic ?? (() => Date.now());
 
-  const result: RunAnalysisResult = { analyzed: [], skipped: [], intentsFound: 0, gaps: 0 };
+  const sessions = await deps.chatSource.listSessions();
+  const due = applyRecencyWindow(selectDueSessions(sessions, opts, everyN), opts, deps.now);
+
+  const result: RunAnalysisResult = {
+    analyzed: [],
+    skipped: [],
+    intentsFound: 0,
+    gaps: 0,
+    errors: [],
+  };
+  const logEntries: RunLogSessionEntry[] = [];
+  const runStarted = monotonic();
 
   for (const meta of due) {
     const turns = await deps.chatSource.readSession(meta.sessionId);
@@ -76,42 +125,148 @@ export async function runAnalysis(
       continue;
     }
 
-    const { claims, intents } = await deps.extractor.extract(turns);
-    const storedIntents: StoredIntent[] = [];
-    for (const intent of intents) {
-      const matches = await deps.matchSkill(intent.content, meta.cwd);
-      const coverage: IntentCoverage =
-        matches.length > 0 ? { status: "covered", skills: matches } : { status: "gap" };
-      const stored: StoredIntent = { content: intent.content, coverage };
-      if (intent.evidences) stored.evidences = intent.evidences;
-      storedIntents.push(stored);
+    const outcome = await analyzeSession(deps, cache, monotonic, meta, turns, opts.bypassCache);
+    logEntries.push(outcome.entry);
+
+    if (outcome.ok) {
+      result.analyzed.push(meta.sessionId);
+      result.intentsFound += outcome.intents;
+      result.gaps += outcome.gaps;
+    } else if (outcome.entry.error) {
+      result.errors.push({ sessionId: meta.sessionId, message: outcome.entry.error });
+    }
+  }
+
+  await appendRunEntry(deps, {
+    runId: randomUUID(),
+    at: deps.now(),
+    trigger,
+    model: deps.extractorModel,
+    durationMs: monotonic() - runStarted,
+    totalIntents: result.intentsFound,
+    totalGaps: result.gaps,
+    sessions: logEntries,
+  });
+
+  return result;
+}
+
+/**
+ * Analyze one session end-to-end (extract → match → persist → rebuild index →
+ * mark analyzed), wrapped so a failure is captured rather than thrown. Returns
+ * the per-session telemetry entry plus the counts the caller folds into totals.
+ */
+async function analyzeSession(
+  deps: AnalysisRunnerDeps,
+  cache: ExtractionCache,
+  monotonic: () => number,
+  meta: ChatSessionMeta,
+  turns: ChatTurn[],
+  bypassCache = false,
+): Promise<SessionOutcome> {
+  const started = monotonic();
+  let cacheHit = false;
+  try {
+    const key = cacheKey(turns, deps.extractorModel);
+    let extraction = bypassCache ? null : await cache.get(key);
+    if (extraction) {
+      cacheHit = true;
+    } else {
+      extraction = await deps.extractor.extract(turns);
+      await cache.set(key, extraction);
     }
 
+    const storedIntents = await annotateIntents(deps, extraction.intents, meta.cwd);
     const now = deps.now();
     const session: SessionIntents = {
       sessionId: meta.sessionId,
       host: meta.host,
       cwd: meta.cwd,
       analyzedAt: now,
-      claims,
+      claims: extraction.claims,
       intents: storedIntents,
     };
 
     await writeSessionIntents(deps.fs, deps.intentsDir, session);
-    const index = await readIntentsIndex(deps.fs, deps.intentsDir);
-    await writeIntentsIndex(deps.fs, deps.intentsDir, mergeIntoIndex(index, session, now));
+    await rebuildDurableIndex(deps);
     await deps.chatSource.markAnalyzed?.(meta.sessionId, now);
 
-    result.analyzed.push(meta.sessionId);
-    result.intentsFound += storedIntents.length;
-    result.gaps += storedIntents.filter((i) => i.coverage.status === "gap").length;
-    deps.log?.(
-      `[ratel] analyzed ${meta.sessionId}: ${storedIntents.length} intents, ` +
-        `${storedIntents.filter((i) => i.coverage.status === "gap").length} gaps`,
-    );
-  }
+    const gaps = storedIntents.filter((i) => i.coverage.status === "gap").length;
+    deps.log?.(`[ratel] analyzed ${meta.sessionId}: ${storedIntents.length} intents, ${gaps} gaps`);
 
-  return result;
+    return {
+      ok: true,
+      intents: storedIntents.length,
+      gaps,
+      entry: {
+        sessionId: meta.sessionId,
+        host: meta.host,
+        ok: true,
+        intents: storedIntents.length,
+        gaps,
+        turns: turns.length,
+        latencyMs: monotonic() - started,
+        cacheHit,
+      },
+    };
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : String(error);
+    deps.log?.(`[ratel] analysis failed for ${meta.sessionId}: ${message}`);
+    return {
+      ok: false,
+      intents: 0,
+      gaps: 0,
+      entry: {
+        sessionId: meta.sessionId,
+        host: meta.host,
+        ok: false,
+        error: message,
+        intents: 0,
+        gaps: 0,
+        turns: turns.length,
+        latencyMs: monotonic() - started,
+        cacheHit,
+      },
+    };
+  }
+}
+
+/** Annotate each extracted intent with managed-skill coverage. */
+async function annotateIntents(
+  deps: AnalysisRunnerDeps,
+  intents: Array<{ content: string; evidences?: string[] }>,
+  cwd?: string,
+): Promise<StoredIntent[]> {
+  const stored: StoredIntent[] = [];
+  for (const intent of intents) {
+    const matches = await deps.matchSkill(intent.content, cwd);
+    const coverage: IntentCoverage =
+      matches.length > 0 ? { status: "covered", skills: matches } : { status: "gap" };
+    const entry: StoredIntent = { content: intent.content, coverage };
+    if (intent.evidences) entry.evidences = intent.evidences;
+    stored.push(entry);
+  }
+  return stored;
+}
+
+/**
+ * Rebuild the whole index from the per-session files on disk and persist it.
+ * Derive-from-source (instead of read-modify-write) means partial progress is
+ * always visible and the index can never drift from the session files.
+ */
+async function rebuildDurableIndex(deps: AnalysisRunnerDeps): Promise<void> {
+  const sessions = await readAllSessionIntents(deps.fs, deps.intentsDir);
+  await writeIntentsIndex(deps.fs, deps.intentsDir, rebuildIndex(sessions));
+}
+
+/** Append the run telemetry entry; telemetry failures must never break a run. */
+async function appendRunEntry(deps: AnalysisRunnerDeps, entry: RunLogEntry): Promise<void> {
+  try {
+    await appendRunLog(deps.fs, deps.intentsDir, entry);
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : String(error);
+    deps.log?.(`[ratel] failed to record run telemetry: ${message}`);
+  }
 }
 
 /** Pick the sessions a run should process for the given trigger. */
@@ -129,4 +284,25 @@ export function selectDueSessions(
   return sessions.filter(
     (s) => s.newTurnCount >= everyN || (Boolean(opts.onIdle) && s.idle === true),
   );
+}
+
+/**
+ * Drop sessions not active within `opts.recentHours` so a bulk run doesn't churn
+ * through every old chat. Skipped when `recentHours` is unset, or for the explicit
+ * `sessionId`/`all` paths. A session with no `updatedAt` is kept (can't judge it).
+ */
+export function applyRecencyWindow(
+  due: ChatSessionMeta[],
+  opts: RunAnalysisOptions,
+  now: () => string,
+): ChatSessionMeta[] {
+  if (!opts.recentHours || opts.recentHours <= 0 || opts.sessionId || opts.all) return due;
+  const nowMs = Date.parse(now());
+  if (Number.isNaN(nowMs)) return due;
+  const cutoff = nowMs - opts.recentHours * 3_600_000;
+  return due.filter((s) => {
+    if (!s.updatedAt) return true;
+    const t = Date.parse(s.updatedAt);
+    return Number.isNaN(t) || t >= cutoff;
+  });
 }

--- a/apps/ratel-mcp/src/intents/runner.ts
+++ b/apps/ratel-mcp/src/intents/runner.ts
@@ -282,7 +282,10 @@ export function selectDueSessions(
     return sessions;
   }
   return sessions.filter(
-    (s) => s.newTurnCount >= everyN || (Boolean(opts.onIdle) && s.idle === true),
+    (s) =>
+      s.newTurnCount >= everyN ||
+      s.needsReanalysis === true ||
+      (Boolean(opts.onIdle) && s.idle === true),
   );
 }
 

--- a/apps/ratel-mcp/src/intents/scheduler.test.ts
+++ b/apps/ratel-mcp/src/intents/scheduler.test.ts
@@ -1,0 +1,133 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { startCadenceScheduler } from "./scheduler.js";
+
+describe("startCadenceScheduler", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  it("fires the tick once per interval", async () => {
+    const tick = vi.fn().mockResolvedValue(undefined);
+    const scheduler = startCadenceScheduler({ tick, intervalMs: 1_000 });
+
+    expect(tick).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(tick).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(tick).toHaveBeenCalledTimes(2);
+
+    scheduler.stop();
+  });
+
+  it("defaults to a 60s interval", async () => {
+    const tick = vi.fn().mockResolvedValue(undefined);
+    const scheduler = startCadenceScheduler({ tick });
+
+    await vi.advanceTimersByTimeAsync(59_000);
+    expect(tick).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(tick).toHaveBeenCalledTimes(1);
+
+    scheduler.stop();
+  });
+
+  it("skips a firing while the previous tick is still in flight (no overlap)", async () => {
+    let resolveTick: (() => void) | undefined;
+    const tick = vi.fn().mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveTick = resolve;
+        }),
+    );
+    const scheduler = startCadenceScheduler({ tick, intervalMs: 1_000 });
+
+    // First firing starts a tick that never resolves yet.
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(tick).toHaveBeenCalledTimes(1);
+
+    // Two more firings happen while the first tick is still pending -> skipped.
+    await vi.advanceTimersByTimeAsync(2_000);
+    expect(tick).toHaveBeenCalledTimes(1);
+
+    // Let the in-flight tick finish.
+    resolveTick?.();
+    await vi.advanceTimersByTimeAsync(0);
+
+    // Next firing runs a fresh tick.
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(tick).toHaveBeenCalledTimes(2);
+
+    scheduler.stop();
+  });
+
+  it("catches a throwing tick (onError called) and keeps the schedule alive", async () => {
+    const error = new Error("boom");
+    const tick = vi.fn().mockRejectedValue(error);
+    const onError = vi.fn();
+    const scheduler = startCadenceScheduler({ tick, intervalMs: 1_000, onError });
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(tick).toHaveBeenCalledTimes(1);
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError).toHaveBeenCalledWith(error);
+
+    // Schedule continues despite the error.
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(tick).toHaveBeenCalledTimes(2);
+    expect(onError).toHaveBeenCalledTimes(2);
+
+    scheduler.stop();
+  });
+
+  it("swallows tick errors when no onError is provided", async () => {
+    const tick = vi.fn().mockRejectedValue(new Error("boom"));
+    const scheduler = startCadenceScheduler({ tick, intervalMs: 1_000 });
+
+    // No onError handler: errors must be swallowed. If they propagated, this
+    // await would reject and fail the test.
+    await vi.advanceTimersByTimeAsync(2_000);
+    expect(tick).toHaveBeenCalledTimes(2);
+
+    scheduler.stop();
+  });
+
+  it("stop() halts further ticks", async () => {
+    const tick = vi.fn().mockResolvedValue(undefined);
+    const scheduler = startCadenceScheduler({ tick, intervalMs: 1_000 });
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(tick).toHaveBeenCalledTimes(1);
+
+    scheduler.stop();
+
+    await vi.advanceTimersByTimeAsync(5_000);
+    expect(tick).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses injectable timer seams", () => {
+    const clearIntervalFn = vi.fn();
+    const handle = { id: "timer" } as unknown as ReturnType<typeof setInterval>;
+    const setIntervalFn = vi.fn().mockReturnValue(handle) as unknown as typeof setInterval;
+
+    const scheduler = startCadenceScheduler({
+      tick: vi.fn().mockResolvedValue(undefined),
+      intervalMs: 2_000,
+      setIntervalFn,
+      clearIntervalFn: clearIntervalFn as unknown as typeof clearInterval,
+    });
+
+    expect(setIntervalFn).toHaveBeenCalledTimes(1);
+    expect((setIntervalFn as unknown as ReturnType<typeof vi.fn>).mock.calls[0][1]).toBe(2_000);
+
+    scheduler.stop();
+    expect(clearIntervalFn).toHaveBeenCalledWith(handle);
+  });
+});

--- a/apps/ratel-mcp/src/intents/scheduler.ts
+++ b/apps/ratel-mcp/src/intents/scheduler.ts
@@ -1,0 +1,50 @@
+/**
+ * A tiny, pure-timing cadence scheduler. It periodically invokes a `tick`
+ * callback, guarantees ticks never overlap, and survives tick failures so the
+ * loop keeps firing. It intentionally knows nothing about config or core — the
+ * caller supplies the work via `tick`.
+ */
+export interface CadenceScheduler {
+  stop(): void;
+}
+
+export interface CadenceSchedulerOptions {
+  /** Called on each tick to do the work (read config + maybe run analysis). Must resolve. */
+  tick: () => Promise<void>;
+  /** Poll interval in ms (default 60_000). */
+  intervalMs?: number;
+  /** Injectable timer seam for tests. */
+  setIntervalFn?: typeof setInterval;
+  clearIntervalFn?: typeof clearInterval;
+  /** Swallow + report tick errors so the loop never dies. */
+  onError?: (err: unknown) => void;
+}
+
+const DEFAULT_INTERVAL_MS = 60_000;
+
+export function startCadenceScheduler(opts: CadenceSchedulerOptions): CadenceScheduler {
+  const intervalMs = opts.intervalMs ?? DEFAULT_INTERVAL_MS;
+  const setIntervalFn = opts.setIntervalFn ?? setInterval;
+  const clearIntervalFn = opts.clearIntervalFn ?? clearInterval;
+  const onError = opts.onError ?? (() => {});
+
+  let running = false;
+
+  const timer = setIntervalFn(() => {
+    // Skip this firing if the previous tick is still in flight — never overlap.
+    if (running) return;
+    running = true;
+    Promise.resolve()
+      .then(() => opts.tick())
+      .catch((err) => onError(err))
+      .finally(() => {
+        running = false;
+      });
+  }, intervalMs);
+
+  return {
+    stop(): void {
+      clearIntervalFn(timer);
+    },
+  };
+}

--- a/apps/ratel-mcp/src/ui/analysis-settings.test.ts
+++ b/apps/ratel-mcp/src/ui/analysis-settings.test.ts
@@ -1,0 +1,114 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { type AnalysisConfig, type HierarchyEnv, nodeJsonFs, writeJson } from "@ratel-ai/mcp-core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  maskAnalysis,
+  mergeAnalysisSecrets,
+  readAnalysisSettings,
+  SECRET_MASK,
+  writeAnalysisSettings,
+} from "./analysis-settings.js";
+
+describe("maskAnalysis", () => {
+  it("masks present apiKeys and leaves the rest intact", () => {
+    const masked = maskAnalysis({
+      enabled: true,
+      extractor: { endpoint: "http://x", apiKey: "sk-secret" },
+      skillGen: { provider: "anthropic-api", apiKey: "sk-ant" },
+    });
+    expect(masked.extractor?.apiKey).toBe(SECRET_MASK);
+    expect(masked.extractor?.endpoint).toBe("http://x");
+    expect(masked.skillGen?.apiKey).toBe(SECRET_MASK);
+  });
+
+  it("leaves missing apiKeys untouched", () => {
+    const masked = maskAnalysis({ extractor: { endpoint: "http://x" } });
+    expect(masked.extractor?.apiKey).toBeUndefined();
+  });
+});
+
+describe("mergeAnalysisSecrets", () => {
+  const existing: AnalysisConfig = {
+    extractor: { endpoint: "http://old", apiKey: "real-extractor-key" },
+    skillGen: { provider: "anthropic-api", apiKey: "real-skill-key" },
+  };
+
+  it("keeps the existing secret when the mask is sent back", () => {
+    const merged = mergeAnalysisSecrets(
+      { extractor: { endpoint: "http://new", apiKey: SECRET_MASK } },
+      existing,
+    );
+    expect(merged.extractor?.apiKey).toBe("real-extractor-key");
+    expect(merged.extractor?.endpoint).toBe("http://new");
+  });
+
+  it("replaces the secret when a new value is sent", () => {
+    const merged = mergeAnalysisSecrets({ extractor: { apiKey: "brand-new" } }, existing);
+    expect(merged.extractor?.apiKey).toBe("brand-new");
+  });
+
+  it("clears the secret when an empty string is sent", () => {
+    const merged = mergeAnalysisSecrets(
+      { extractor: { endpoint: "http://x", apiKey: "" } },
+      existing,
+    );
+    expect(merged.extractor?.apiKey).toBeUndefined();
+  });
+});
+
+describe("read/write round-trip", () => {
+  let dir: string;
+  let env: HierarchyEnv;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "ratel-settings-"));
+    env = { homeDir: dir };
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it("persists settings, masks on read, and preserves the real secret on disk", async () => {
+    await writeAnalysisSettings(env, nodeJsonFs, {
+      enabled: true,
+      cadence: { everyNMessages: 7, onIdle: true },
+      extractor: { endpoint: "http://127.0.0.1:8723", apiKey: "sk-real" },
+    });
+
+    const read = await readAnalysisSettings(env, nodeJsonFs);
+    expect(read.extractor?.apiKey).toBe(SECRET_MASK);
+    expect(read.cadence?.everyNMessages).toBe(7);
+
+    // a no-op save (mask echoed back) must keep the real key
+    await writeAnalysisSettings(env, nodeJsonFs, {
+      enabled: true,
+      cadence: { everyNMessages: 7, onIdle: true },
+      extractor: { endpoint: "http://127.0.0.1:8723", apiKey: SECRET_MASK },
+    });
+    const config = JSON.parse((await nodeJsonFs.read(join(dir, ".ratel", "config.json"))) ?? "{}");
+    expect(config.analysis.extractor.apiKey).toBe("sk-real");
+  });
+
+  it("preserves other top-level config keys when writing analysis", async () => {
+    await writeJson(nodeJsonFs, join(dir, ".ratel", "config.json"), {
+      mcpServers: { fs: { type: "stdio", command: "echo" } },
+      skills: { dirs: ["/x"] },
+    });
+    await writeAnalysisSettings(env, nodeJsonFs, { enabled: true });
+    const config = JSON.parse((await nodeJsonFs.read(join(dir, ".ratel", "config.json"))) ?? "{}");
+    expect(config.mcpServers.fs.command).toBe("echo");
+    expect(config.skills.dirs).toEqual(["/x"]);
+    expect(config.analysis.enabled).toBe(true);
+  });
+
+  it("rejects an invalid analysis block", async () => {
+    await expect(
+      writeAnalysisSettings(env, nodeJsonFs, {
+        cadence: { everyNMessages: -1 },
+      } as AnalysisConfig),
+    ).rejects.toThrow(/everyNMessages/);
+  });
+});

--- a/apps/ratel-mcp/src/ui/analysis-settings.test.ts
+++ b/apps/ratel-mcp/src/ui/analysis-settings.test.ts
@@ -5,7 +5,7 @@ import { type AnalysisConfig, type HierarchyEnv, nodeJsonFs, writeJson } from "@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   maskAnalysis,
-  mergeAnalysisSecrets,
+  mergeAnalysisConfig,
   readAnalysisSettings,
   SECRET_MASK,
   writeAnalysisSettings,
@@ -29,14 +29,15 @@ describe("maskAnalysis", () => {
   });
 });
 
-describe("mergeAnalysisSecrets", () => {
+describe("mergeAnalysisConfig", () => {
   const existing: AnalysisConfig = {
-    extractor: { endpoint: "http://old", apiKey: "real-extractor-key" },
+    extractor: { endpoint: "http://old", apiKey: "real-extractor-key", model: "claim-4B" },
+    cadence: { everyNMessages: 10, onIdle: true },
     skillGen: { provider: "anthropic-api", apiKey: "real-skill-key" },
   };
 
   it("keeps the existing secret when the mask is sent back", () => {
-    const merged = mergeAnalysisSecrets(
+    const merged = mergeAnalysisConfig(
       { extractor: { endpoint: "http://new", apiKey: SECRET_MASK } },
       existing,
     );
@@ -45,16 +46,37 @@ describe("mergeAnalysisSecrets", () => {
   });
 
   it("replaces the secret when a new value is sent", () => {
-    const merged = mergeAnalysisSecrets({ extractor: { apiKey: "brand-new" } }, existing);
+    const merged = mergeAnalysisConfig({ extractor: { apiKey: "brand-new" } }, existing);
     expect(merged.extractor?.apiKey).toBe("brand-new");
   });
 
   it("clears the secret when an empty string is sent", () => {
-    const merged = mergeAnalysisSecrets(
+    const merged = mergeAnalysisConfig(
       { extractor: { endpoint: "http://x", apiKey: "" } },
       existing,
     );
     expect(merged.extractor?.apiKey).toBeUndefined();
+  });
+
+  it("preserves omitted extractor fields on a partial save (the endpoint bug)", () => {
+    // A form that only carried `{ provider: "http" }` must not wipe endpoint/model.
+    const merged = mergeAnalysisConfig({ extractor: { provider: "http" } }, existing);
+    expect(merged.extractor?.provider).toBe("http");
+    expect(merged.extractor?.endpoint).toBe("http://old");
+    expect(merged.extractor?.model).toBe("claim-4B");
+    // the stored secret survives too
+    expect(merged.extractor?.apiKey).toBe("real-extractor-key");
+  });
+
+  it("preserves sibling sections a partial save omits", () => {
+    const merged = mergeAnalysisConfig({ extractor: { provider: "http" } }, existing);
+    expect(merged.cadence).toEqual({ everyNMessages: 10, onIdle: true });
+    expect(merged.skillGen?.provider).toBe("anthropic-api");
+  });
+
+  it("merges a nested section field-by-field rather than replacing it", () => {
+    const merged = mergeAnalysisConfig({ cadence: { everyNMessages: 5 } }, existing);
+    expect(merged.cadence).toEqual({ everyNMessages: 5, onIdle: true });
   });
 });
 
@@ -102,6 +124,25 @@ describe("read/write round-trip", () => {
     expect(config.mcpServers.fs.command).toBe("echo");
     expect(config.skills.dirs).toEqual(["/x"]);
     expect(config.analysis.enabled).toBe(true);
+  });
+
+  it("a partial save does not wipe previously-stored analysis fields", async () => {
+    // Seed a full block (what a working setup looks like on disk).
+    await writeAnalysisSettings(env, nodeJsonFs, {
+      enabled: true,
+      cadence: { everyNMessages: 10, onIdle: true },
+      skillGen: { provider: "auto" },
+      extractor: { provider: "http", endpoint: "http://127.0.0.1:8723", model: "claim-4B" },
+    });
+
+    // Reproduce the bug: a Settings form that only carried the provider.
+    await writeAnalysisSettings(env, nodeJsonFs, { extractor: { provider: "http" } });
+
+    const config = JSON.parse((await nodeJsonFs.read(join(dir, ".ratel", "config.json"))) ?? "{}");
+    expect(config.analysis.extractor.endpoint).toBe("http://127.0.0.1:8723");
+    expect(config.analysis.extractor.model).toBe("claim-4B");
+    expect(config.analysis.cadence).toEqual({ everyNMessages: 10, onIdle: true });
+    expect(config.analysis.skillGen.provider).toBe("auto");
   });
 
   it("rejects an invalid analysis block", async () => {

--- a/apps/ratel-mcp/src/ui/analysis-settings.ts
+++ b/apps/ratel-mcp/src/ui/analysis-settings.ts
@@ -8,7 +8,7 @@ import {
 
 /**
  * Sentinel returned in place of a stored secret. When the UI sends it back
- * unchanged, {@link mergeAnalysisSecrets} preserves the existing value rather
+ * unchanged, {@link mergeAnalysisConfig} preserves the existing value rather
  * than overwriting the real key with the mask.
  */
 export const SECRET_MASK = "__RATEL_SECRET_KEPT__";
@@ -25,17 +25,48 @@ export function maskAnalysis(analysis?: AnalysisConfig): AnalysisConfig {
 }
 
 /**
- * Reconcile incoming settings with what is stored: a masked `apiKey` keeps the
- * existing secret, an empty `apiKey` clears it, and any other value replaces it.
+ * Reconcile incoming settings with what is stored, field by field, so a partial
+ * save never discards values it didn't send:
+ *
+ *  - Nested sections (extractor/cadence/skillGen/coverage) merge key by key: keys
+ *    present in `incoming` win, keys it omits are kept from `existing`. This is
+ *    what stops a Settings form carrying only `{ provider: "http" }` from wiping a
+ *    previously-stored `endpoint`/`model` (and likewise for cadence/skillGen).
+ *  - Secrets keep their special handling: a masked `apiKey` preserves the stored
+ *    secret, an empty `apiKey` clears it, and any other value replaces it.
+ *
+ * Trade-off: because omitted keys are preserved, a section value can be changed
+ * but not unset through this path — acceptable since each field has a runtime
+ * default and the form always reflects the current value.
  */
-export function mergeAnalysisSecrets(
+export function mergeAnalysisConfig(
   incoming: AnalysisConfig,
   existing?: AnalysisConfig,
 ): AnalysisConfig {
-  const out: AnalysisConfig = { ...incoming };
-  if (incoming.extractor) out.extractor = mergeKey(incoming.extractor, existing?.extractor);
-  if (incoming.skillGen) out.skillGen = mergeKey(incoming.skillGen, existing?.skillGen);
+  const base = existing ?? {};
+  const out: AnalysisConfig = { ...base, ...incoming };
+
+  const extractor = mergeSection(base.extractor, incoming.extractor);
+  if (extractor) out.extractor = mergeKey(extractor, base.extractor);
+  const skillGen = mergeSection(base.skillGen, incoming.skillGen);
+  if (skillGen) out.skillGen = mergeKey(skillGen, base.skillGen);
+
+  const cadence = mergeSection(base.cadence, incoming.cadence);
+  if (cadence) out.cadence = cadence;
+  const coverage = mergeSection(base.coverage, incoming.coverage);
+  if (coverage) out.coverage = coverage;
+
   return out;
+}
+
+/** Field-level merge of one nested section: incoming keys win, omitted keys kept. */
+function mergeSection<T extends object>(
+  existing: T | undefined,
+  incoming: T | undefined,
+): T | undefined {
+  if (incoming === undefined) return existing;
+  if (existing === undefined) return incoming;
+  return { ...existing, ...incoming };
 }
 
 function maskKey<T extends WithApiKey>(value: T): T {
@@ -76,7 +107,7 @@ export async function writeAnalysisSettings(
   const path = ratelConfigPath("user", env);
   const current = await readRawConfig(fs, path);
   const existing = current.analysis as AnalysisConfig | undefined;
-  const merged = mergeAnalysisSecrets(incoming, existing);
+  const merged = mergeAnalysisConfig(incoming, existing);
 
   // Validate types/enums via the canonical parser (throws ConfigError on bad input).
   parseConfig({ mcpServers: {}, analysis: merged });

--- a/apps/ratel-mcp/src/ui/analysis-settings.ts
+++ b/apps/ratel-mcp/src/ui/analysis-settings.ts
@@ -1,0 +1,104 @@
+import {
+  type AnalysisConfig,
+  type HierarchyEnv,
+  type JsonFs,
+  parseConfig,
+  ratelConfigPath,
+} from "@ratel-ai/mcp-core";
+
+/**
+ * Sentinel returned in place of a stored secret. When the UI sends it back
+ * unchanged, {@link mergeAnalysisSecrets} preserves the existing value rather
+ * than overwriting the real key with the mask.
+ */
+export const SECRET_MASK = "__RATEL_SECRET_KEPT__";
+
+type WithApiKey = { apiKey?: string };
+
+/** Replace any present `apiKey` with {@link SECRET_MASK} so secrets never leave the server. */
+export function maskAnalysis(analysis?: AnalysisConfig): AnalysisConfig {
+  if (!analysis) return {};
+  const out: AnalysisConfig = { ...analysis };
+  if (analysis.extractor) out.extractor = maskKey(analysis.extractor);
+  if (analysis.skillGen) out.skillGen = maskKey(analysis.skillGen);
+  return out;
+}
+
+/**
+ * Reconcile incoming settings with what is stored: a masked `apiKey` keeps the
+ * existing secret, an empty `apiKey` clears it, and any other value replaces it.
+ */
+export function mergeAnalysisSecrets(
+  incoming: AnalysisConfig,
+  existing?: AnalysisConfig,
+): AnalysisConfig {
+  const out: AnalysisConfig = { ...incoming };
+  if (incoming.extractor) out.extractor = mergeKey(incoming.extractor, existing?.extractor);
+  if (incoming.skillGen) out.skillGen = mergeKey(incoming.skillGen, existing?.skillGen);
+  return out;
+}
+
+function maskKey<T extends WithApiKey>(value: T): T {
+  return value.apiKey ? { ...value, apiKey: SECRET_MASK } : value;
+}
+
+function mergeKey<T extends WithApiKey>(incoming: T, existing?: T): T {
+  if (incoming.apiKey === undefined) return incoming;
+  if (incoming.apiKey === SECRET_MASK) {
+    const out = { ...incoming };
+    if (existing?.apiKey) out.apiKey = existing.apiKey;
+    else delete (out as WithApiKey).apiKey;
+    return out;
+  }
+  if (incoming.apiKey === "") {
+    const out = { ...incoming };
+    delete (out as WithApiKey).apiKey;
+    return out;
+  }
+  return incoming;
+}
+
+/** Read the user-scope `analysis` block with secrets masked for transport. */
+export async function readAnalysisSettings(env: HierarchyEnv, fs: JsonFs): Promise<AnalysisConfig> {
+  return maskAnalysis(await readRawAnalysis(env, fs));
+}
+
+/**
+ * Validate + persist the `analysis` block into the user-scope config, preserving
+ * every other top-level key, and return the saved settings with secrets masked.
+ * Throws on an invalid block (callers map to HTTP 400).
+ */
+export async function writeAnalysisSettings(
+  env: HierarchyEnv,
+  fs: JsonFs,
+  incoming: AnalysisConfig,
+): Promise<AnalysisConfig> {
+  const path = ratelConfigPath("user", env);
+  const current = await readRawConfig(fs, path);
+  const existing = current.analysis as AnalysisConfig | undefined;
+  const merged = mergeAnalysisSecrets(incoming, existing);
+
+  // Validate types/enums via the canonical parser (throws ConfigError on bad input).
+  parseConfig({ mcpServers: {}, analysis: merged });
+
+  const next: Record<string, unknown> = { ...current, analysis: merged };
+  if (!next.mcpServers) next.mcpServers = {};
+  await fs.writeAtomic(path, `${JSON.stringify(next, null, 2)}\n`);
+  return maskAnalysis(merged);
+}
+
+async function readRawAnalysis(env: HierarchyEnv, fs: JsonFs): Promise<AnalysisConfig | undefined> {
+  const current = await readRawConfig(fs, ratelConfigPath("user", env));
+  return current.analysis as AnalysisConfig | undefined;
+}
+
+async function readRawConfig(fs: JsonFs, path: string): Promise<Record<string, unknown>> {
+  const raw = await fs.read(path);
+  if (!raw) return {};
+  try {
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? parsed : {};
+  } catch {
+    return {};
+  }
+}

--- a/apps/ratel-mcp/src/ui/analysis-settings.ts
+++ b/apps/ratel-mcp/src/ui/analysis-settings.ts
@@ -1,5 +1,6 @@
 import {
   type AnalysisConfig,
+  type ExtractorConfig,
   type HierarchyEnv,
   type JsonFs,
   parseConfig,
@@ -92,6 +93,21 @@ function mergeKey<T extends WithApiKey>(incoming: T, existing?: T): T {
 /** Read the user-scope `analysis` block with secrets masked for transport. */
 export async function readAnalysisSettings(env: HierarchyEnv, fs: JsonFs): Promise<AnalysisConfig> {
   return maskAnalysis(await readRawAnalysis(env, fs));
+}
+
+/**
+ * Resolve an extractor block submitted from the UI into one with its real secret,
+ * for a connection test. The form may send a masked `apiKey` (the user didn't
+ * retype it), so we merge over the stored config the same way a save does — the
+ * stored secret survives a masked value. Lets "Test connection" work before save.
+ */
+export async function resolveExtractorForTest(
+  env: HierarchyEnv,
+  fs: JsonFs,
+  incoming: ExtractorConfig,
+): Promise<ExtractorConfig> {
+  const existing = await readRawAnalysis(env, fs);
+  return mergeAnalysisConfig({ extractor: incoming }, existing).extractor ?? {};
 }
 
 /**

--- a/apps/ratel-mcp/src/ui/intents-routes.test.ts
+++ b/apps/ratel-mcp/src/ui/intents-routes.test.ts
@@ -217,6 +217,27 @@ describe("deleteIntentRoute + clearIntentsRoute", () => {
     const rebuilt = rebuildIndex(await readAllSessionIntents(nodeFs, intentsDir));
     expect(rebuilt.intents).toEqual([]);
   });
+
+  it("re-arms sessions so a plain re-run regenerates intents after a clear", async () => {
+    await seedAndRun();
+    await clearIntentsRoute(ctx);
+
+    // Clearing flags every captured session for re-analysis (its analyzed bookkeeping
+    // is otherwise still "done", which would make a plain run skip it).
+    const { readChatState, intentsPaths, resolveRatelDir } = await import("@ratel-ai/mcp-core");
+    const chatDir = intentsPaths(resolveRatelDir(process.env, home)).chatDir;
+    const state = await readChatState(nodeFs, chatDir);
+    expect(state.sessions["sess-1"].needsReanalysis).toBe(true);
+
+    // A plain "Run now" (no all/sessionId) now picks the session up and rebuilds intents.
+    await runIntentsRoute(ctx, {});
+    await waitForIdle();
+    const index = (await getIntents(ctx)).body as { intents: Array<{ content: string }> };
+    expect(index.intents.map((i) => i.content).sort()).toEqual([
+      "set up a grafana dashboard",
+      "write tests for the parser",
+    ]);
+  });
 });
 
 describe("analysis settings routes", () => {

--- a/apps/ratel-mcp/src/ui/intents-routes.test.ts
+++ b/apps/ratel-mcp/src/ui/intents-routes.test.ts
@@ -1,7 +1,13 @@
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { nodeFs, nodeJsonFs } from "@ratel-ai/mcp-core";
+import {
+  nodeFs,
+  nodeJsonFs,
+  type SkillDraft,
+  type SkillGenContext,
+  type SkillGenerator,
+} from "@ratel-ai/mcp-core";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import type { ParsedArgs } from "../cli/args.js";
 import type { HandlerCtx } from "../cli/handlers/types.js";
@@ -9,11 +15,18 @@ import { silentPromptAdapter } from "../cli/prompts.js";
 import { SECRET_MASK } from "./analysis-settings.js";
 import {
   clearIntentsRoute,
+  clearOfferJobRoute,
+  deleteChatRoute,
   deleteIntentRoute,
   getAnalysisSettings,
+  getChatRoute,
+  getChatsRoute,
   getIntents,
+  getObservabilityRoute,
   getSessionIntents,
+  listOfferJobsRoute,
   offerSkillRoute,
+  offerStatusRoute,
   putAnalysisSettings,
   runIntentsRoute,
 } from "./intents-routes.js";
@@ -50,16 +63,27 @@ afterEach(async () => {
   await rm(home, { recursive: true, force: true });
 });
 
-async function seedChat(sessionId: string, turns: Array<{ role: string; content: string }>) {
+async function seedChat(
+  sessionId: string,
+  turns: Array<{ role: string; content: string }>,
+  meta: Record<string, unknown> = {},
+) {
   const file = join(ratelDir, "chat", "claude-code", `${sessionId}.jsonl`);
   await nodeJsonFs.writeAtomic(file, `${turns.map((t) => JSON.stringify(t)).join("\n")}\n`);
-  await nodeJsonFs.writeAtomic(
-    join(ratelDir, "chat", "state.json"),
-    JSON.stringify({
-      version: 1,
-      sessions: { [sessionId]: { sessionId, host: "claude-code", newTurnCount: 99 } },
-    }),
-  );
+  // Merge with any existing state so multiple seedChat calls accumulate sessions.
+  const statePath = join(ratelDir, "chat", "state.json");
+  const existing = await nodeFs.read(statePath);
+  const state = existing
+    ? (JSON.parse(existing) as { version: number; sessions: Record<string, unknown> })
+    : { version: 1, sessions: {} };
+  state.sessions[sessionId] = {
+    sessionId,
+    host: "claude-code",
+    newTurnCount: 99,
+    updatedAt: new Date().toISOString(),
+    ...meta,
+  };
+  await nodeJsonFs.writeAtomic(statePath, JSON.stringify(state));
 }
 
 /** Wait for the fire-and-forget run to finish (getIntents.running → false). */
@@ -162,16 +186,35 @@ describe("deleteIntentRoute + clearIntentsRoute", () => {
     expect(index.intents.map((i) => i.content)).toEqual(["write tests for the parser"]);
   });
 
+  it("makes a deletion survive a rebuild from session files", async () => {
+    await seedAndRun();
+    await deleteIntentRoute(ctx, { content: "set up a grafana dashboard" });
+
+    // Rebuild from the durable per-session files: the deleted intent must stay gone.
+    const { readAllSessionIntents, rebuildIndex } = await import("@ratel-ai/mcp-core");
+    const { intentsPaths, resolveRatelDir } = await import("@ratel-ai/mcp-core");
+    const intentsDir = intentsPaths(resolveRatelDir(process.env, home)).intentsDir;
+    const rebuilt = rebuildIndex(await readAllSessionIntents(nodeFs, intentsDir));
+    expect(rebuilt.intents.map((i) => i.content)).toEqual(["write tests for the parser"]);
+  });
+
   it("requires content", async () => {
     await expect(deleteIntentRoute(ctx, { content: "  " })).rejects.toThrow(/content is required/);
   });
 
-  it("clears every intent", async () => {
+  it("clears every intent durably", async () => {
     await seedAndRun();
     await clearIntentsRoute(ctx);
     const index = (await getIntents(ctx)).body as { intents: unknown[]; sessions: unknown[] };
     expect(index.intents).toEqual([]);
     expect(index.sessions).toEqual([]);
+
+    // A rebuild from the (now removed) session files stays empty too.
+    const { readAllSessionIntents, rebuildIndex } = await import("@ratel-ai/mcp-core");
+    const { intentsPaths, resolveRatelDir } = await import("@ratel-ai/mcp-core");
+    const intentsDir = intentsPaths(resolveRatelDir(process.env, home)).intentsDir;
+    const rebuilt = rebuildIndex(await readAllSessionIntents(nodeFs, intentsDir));
+    expect(rebuilt.intents).toEqual([]);
   });
 });
 
@@ -200,8 +243,381 @@ describe("analysis settings routes", () => {
   });
 });
 
-describe("offerSkillRoute", () => {
+describe("offerSkillRoute (background job)", () => {
+  /** A controllable generator: resolves its draft only when `release()` is called. */
+  function deferredGenerator(draft: SkillDraft) {
+    let release!: () => void;
+    const gate = new Promise<void>((r) => {
+      release = r;
+    });
+    let lastContext: SkillGenContext | undefined;
+    const generator: SkillGenerator = {
+      async generate(_intent, context) {
+        lastContext = context;
+        await gate;
+        return draft;
+      },
+    };
+    return { generator, release: () => release(), context: () => lastContext };
+  }
+
+  function immediateGenerator(draft: SkillDraft): SkillGenerator {
+    return { generate: async () => draft };
+  }
+
+  async function waitForOfferStatus(intent: string, want: string) {
+    for (let i = 0; i < 200; i++) {
+      const body = (await offerStatusRoute(ctx, intent)).body as { status: string };
+      if (body.status === want) return body;
+      await new Promise((r) => setTimeout(r, 10));
+    }
+    throw new Error(`offer status never reached ${want}`);
+  }
+
   it("requires a non-empty intent", async () => {
     await expect(offerSkillRoute(ctx, { intent: "  " })).rejects.toThrow(/intent is required/);
+  });
+
+  it("starts a job and returns a draft via status when done", async () => {
+    const draft: SkillDraft = {
+      name: "grafana-dashboard",
+      description: "Set up a Grafana dashboard with Prometheus",
+      body: "# steps",
+    };
+    const start = await offerSkillRoute(
+      ctx,
+      { intent: "set up a grafana dashboard" },
+      { generator: immediateGenerator(draft) },
+    );
+    expect(start.body).toMatchObject({ started: true, intent: "set up a grafana dashboard" });
+    expect((start.body as { model: string }).model).toBeTruthy();
+
+    const done = (await waitForOfferStatus("set up a grafana dashboard", "done")) as {
+      status: string;
+      draft?: SkillDraft;
+    };
+    expect(done.status).toBe("done");
+    expect(done.draft?.name).toBe("grafana-dashboard");
+  });
+
+  it("reports alreadyRunning for a second call while in flight", async () => {
+    const deferred = deferredGenerator({
+      name: "x",
+      description: "d",
+      body: "b",
+    });
+    const first = await offerSkillRoute(
+      ctx,
+      { intent: "rig up a CI pipeline" },
+      { generator: deferred.generator },
+    );
+    expect(first.body).toMatchObject({ started: true });
+    expect((await offerStatusRoute(ctx, "rig up a CI pipeline")).body).toMatchObject({
+      status: "running",
+    });
+
+    const second = await offerSkillRoute(
+      ctx,
+      { intent: "rig up a CI pipeline" },
+      { generator: deferred.generator },
+    );
+    expect(second.body).toMatchObject({ started: false, alreadyRunning: true });
+
+    deferred.release();
+    await waitForOfferStatus("rig up a CI pipeline", "done");
+  });
+
+  it("passes a rich context built from session evidence + related intents", async () => {
+    await seedSkill("tdd-workflow", "Write unit tests first then implement", ["write tests"]);
+    await seedChat("sess-ctx", [
+      { role: "user", content: "write tests for the parser" },
+      { role: "user", content: "set up a grafana dashboard" },
+    ]);
+    await runIntentsRoute(ctx, {});
+    await waitForIdle();
+
+    const deferred = deferredGenerator({ name: "g", description: "d", body: "b" });
+    await offerSkillRoute(
+      ctx,
+      { intent: "set up a grafana dashboard" },
+      { generator: deferred.generator },
+    );
+    // Give the async job a tick to invoke generate() and capture context.
+    for (let i = 0; i < 100 && !deferred.context(); i++) {
+      await new Promise((r) => setTimeout(r, 10));
+    }
+    const context = deferred.context();
+    deferred.release();
+    await waitForOfferStatus("set up a grafana dashboard", "done");
+
+    expect(context?.relatedIntents).toContain("write tests for the parser");
+    expect(context?.existingSkillIds).toContain("tdd-workflow");
+  });
+
+  it("reports idle status when no job exists", async () => {
+    const res = await offerStatusRoute(ctx, "never offered this");
+    expect(res.body).toMatchObject({ status: "idle" });
+  });
+
+  it("lists offer jobs with hasDraft and no draft body", async () => {
+    // A done job (has a draft).
+    const draft: SkillDraft = { name: "done-skill", description: "d", body: "# steps" };
+    await offerSkillRoute(
+      ctx,
+      { intent: "list-test done intent" },
+      { generator: immediateGenerator(draft) },
+    );
+    await waitForOfferStatus("list-test done intent", "done");
+
+    // An error job (no draft).
+    const failing: SkillGenerator = {
+      generate: async () => {
+        throw new Error("boom");
+      },
+    };
+    await offerSkillRoute(ctx, { intent: "list-test error intent" }, { generator: failing });
+    await waitForOfferStatus("list-test error intent", "error");
+
+    // A running job (no draft yet).
+    const deferred = deferredGenerator({ name: "r", description: "d", body: "b" });
+    await offerSkillRoute(
+      ctx,
+      { intent: "list-test running intent" },
+      { generator: deferred.generator },
+    );
+    await waitForOfferStatus("list-test running intent", "running");
+
+    const res = await listOfferJobsRoute(ctx);
+    expect(res.status).toBe(200);
+    const jobs = (res.body as { jobs: Array<Record<string, unknown>> }).jobs;
+    const byIntent = Object.fromEntries(jobs.map((j) => [j.intent as string, j]));
+
+    const done = byIntent["list-test done intent"];
+    expect(done.status).toBe("done");
+    expect(done.hasDraft).toBe(true);
+    expect(done).not.toHaveProperty("draft");
+    expect(typeof done.model).toBe("string");
+    expect(typeof done.startedAt).toBe("string");
+
+    const errored = byIntent["list-test error intent"];
+    expect(errored.status).toBe("error");
+    expect(errored.hasDraft).toBe(false);
+    expect(errored.error).toBe("boom");
+    expect(errored).not.toHaveProperty("draft");
+
+    const running = byIntent["list-test running intent"];
+    expect(running.status).toBe("running");
+    expect(running.hasDraft).toBe(false);
+    expect(running).not.toHaveProperty("draft");
+
+    deferred.release();
+    await waitForOfferStatus("list-test running intent", "done");
+  });
+
+  it("clears a finished job so it no longer surfaces", async () => {
+    const intent = "clear-test intent";
+    await offerSkillRoute(
+      ctx,
+      { intent },
+      { generator: immediateGenerator({ name: "c", description: "d", body: "b" }) },
+    );
+    await waitForOfferStatus(intent, "done");
+
+    const cleared = await clearOfferJobRoute(ctx, intent);
+    expect(cleared.body).toMatchObject({ cleared: true });
+
+    expect((await offerStatusRoute(ctx, intent)).body).toMatchObject({ status: "idle" });
+    const jobs = (await listOfferJobsRoute(ctx)).body as { jobs: Array<{ intent: string }> };
+    expect(jobs.jobs.some((j) => j.intent === intent)).toBe(false);
+  });
+});
+
+describe("getObservabilityRoute", () => {
+  it("returns an empty, zeroed summary before any run", async () => {
+    const res = await getObservabilityRoute(ctx);
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      runs: [],
+      summary: { totalRuns: 0, lastRunAt: null, avgDurationMs: 0, avgGapsPerRun: 0 },
+    });
+  });
+
+  it("returns runs + a computed summary after a run", async () => {
+    await seedSkill("tdd-workflow", "Write unit tests first then implement", ["write tests"]);
+    await seedChat("sess-1", [
+      { role: "user", content: "write tests for the parser" },
+      { role: "user", content: "set up a grafana dashboard" },
+    ]);
+    await runIntentsRoute(ctx, {});
+    await waitForIdle();
+
+    const res = (await getObservabilityRoute(ctx)).body as {
+      runs: Array<{ runId: string }>;
+      summary: { totalRuns: number; lastRunAt: string | null };
+    };
+    expect(res.runs.length).toBeGreaterThanOrEqual(1);
+    expect(res.summary.totalRuns).toBe(res.runs.length);
+    expect(res.summary.lastRunAt).not.toBeNull();
+  });
+});
+
+describe("getChatsRoute + getChatRoute", () => {
+  it("derives titles and counts, sorted by updatedAt DESC", async () => {
+    await seedSkill("tdd-workflow", "Write unit tests first then implement", ["write tests"]);
+    await seedChat("sess-old", [{ role: "user", content: "  first   request   here  " }], {
+      updatedAt: "2026-01-01T00:00:00.000Z",
+      cwd: "/repo/alpha",
+    });
+    await seedChat(
+      "sess-new",
+      [
+        { role: "user", content: "write tests for the parser" },
+        { role: "user", content: "set up a grafana dashboard" },
+      ],
+      { updatedAt: "2026-06-01T00:00:00.000Z", cwd: "/repo/beta" },
+    );
+    await runIntentsRoute(ctx, {});
+    await waitForIdle();
+
+    const res = (await getChatsRoute(ctx)).body as {
+      chats: Array<{
+        sessionId: string;
+        title: string;
+        turnCount: number;
+        intentCount: number;
+        analyzed: boolean;
+      }>;
+    };
+    expect(res.chats.map((c) => c.sessionId)).toEqual(["sess-new", "sess-old"]);
+    const old = res.chats.find((c) => c.sessionId === "sess-old");
+    expect(old?.title).toBe("first request here");
+    const fresh = res.chats.find((c) => c.sessionId === "sess-new");
+    expect(fresh?.title).toBe("write tests for the parser");
+    expect(fresh?.turnCount).toBe(2);
+    expect(fresh?.analyzed).toBe(true);
+    expect(fresh?.intentCount).toBeGreaterThanOrEqual(1);
+  });
+
+  it("falls back to cwd basename when no readable user turn", async () => {
+    await seedChat("sess-empty", [{ role: "assistant", content: "hi" }], { cwd: "/repo/gamma" });
+    const res = (await getChatsRoute(ctx)).body as {
+      chats: Array<{ sessionId: string; title: string }>;
+    };
+    expect(res.chats.find((c) => c.sessionId === "sess-empty")?.title).toBe("gamma");
+  });
+
+  it("returns one chat with its transcript, 404 when unknown", async () => {
+    await seedChat("sess-1", [
+      { role: "user", content: "hello there" },
+      { role: "assistant", content: "hi" },
+    ]);
+    const res = (await getChatRoute(ctx, "sess-1")).body as {
+      sessionId: string;
+      title: string;
+      turns: Array<{ role: string }>;
+    };
+    expect(res.sessionId).toBe("sess-1");
+    expect(res.title).toBe("hello there");
+    expect(res.turns).toHaveLength(2);
+
+    const missing = await getChatRoute(ctx, "nope");
+    expect(missing.status).toBe(404);
+  });
+
+  it("returns the total turn count and the full transcript when under the limit", async () => {
+    await seedChat("sess-total", [
+      { role: "user", content: "hello there" },
+      { role: "assistant", content: "hi" },
+      { role: "user", content: "again" },
+    ]);
+    const res = (await getChatRoute(ctx, "sess-total")).body as {
+      turns: Array<{ role: string }>;
+      total: number;
+    };
+    expect(res.total).toBe(3);
+    expect(res.turns).toHaveLength(3);
+  });
+
+  it("paginates: returns only the last N turns and the correct total", async () => {
+    const turns = Array.from({ length: 50 }, (_, i) => ({
+      role: i % 2 === 0 ? "user" : "assistant",
+      content: `turn ${i}`,
+    }));
+    await seedChat("sess-page", turns);
+
+    const res = (await getChatRoute(ctx, "sess-page", 10)).body as {
+      turns: Array<{ content: string }>;
+      total: number;
+    };
+    expect(res.total).toBe(50);
+    expect(res.turns).toHaveLength(10);
+    // The last 10 turns (40..49), in order.
+    expect(res.turns[0].content).toBe("turn 40");
+    expect(res.turns[9].content).toBe("turn 49");
+    expect(res.total).toBeGreaterThan(res.turns.length);
+  });
+
+  it("applies the default limit when omitted", async () => {
+    const turns = Array.from({ length: 80 }, (_, i) => ({
+      role: i % 2 === 0 ? "user" : "assistant",
+      content: `turn ${i}`,
+    }));
+    await seedChat("sess-default", turns);
+
+    const res = (await getChatRoute(ctx, "sess-default")).body as {
+      turns: Array<{ content: string }>;
+      total: number;
+    };
+    expect(res.total).toBe(80);
+    // Default limit is 60.
+    expect(res.turns).toHaveLength(60);
+    expect(res.turns[0].content).toBe("turn 20");
+  });
+
+  it("treats a non-positive limit as the default", async () => {
+    const turns = Array.from({ length: 80 }, (_, i) => ({
+      role: i % 2 === 0 ? "user" : "assistant",
+      content: `turn ${i}`,
+    }));
+    await seedChat("sess-zero", turns);
+
+    const res = (await getChatRoute(ctx, "sess-zero", 0)).body as {
+      turns: Array<{ content: string }>;
+    };
+    expect(res.turns).toHaveLength(60);
+  });
+});
+
+describe("deleteChatRoute", () => {
+  it("removes turn file, state entry, session intents, and rebuilds the index", async () => {
+    await seedSkill("tdd-workflow", "Write unit tests first then implement", ["write tests"]);
+    await seedChat("sess-keep", [{ role: "user", content: "write tests for the parser" }]);
+    await seedChat("sess-drop", [{ role: "user", content: "set up a grafana dashboard" }]);
+    await runIntentsRoute(ctx, {});
+    await waitForIdle();
+
+    const del = await deleteChatRoute(ctx, "sess-drop");
+    expect(del.body).toMatchObject({ deleted: "sess-drop" });
+
+    // Chat list no longer includes the deleted session.
+    const chats = (await getChatsRoute(ctx)).body as { chats: Array<{ sessionId: string }> };
+    expect(chats.chats.map((c) => c.sessionId)).toEqual(["sess-keep"]);
+
+    // Its turn file + per-session intents file are gone, so the rebuilt index drops it.
+    const { readAllSessionIntents, rebuildIndex } = await import("@ratel-ai/mcp-core");
+    const { intentsPaths, resolveRatelDir } = await import("@ratel-ai/mcp-core");
+    const intentsDir = intentsPaths(resolveRatelDir(process.env, home)).intentsDir;
+    const rebuilt = rebuildIndex(await readAllSessionIntents(nodeFs, intentsDir));
+    expect(rebuilt.sessions.map((s) => s.sessionId)).toEqual(["sess-keep"]);
+    expect(rebuilt.intents.map((i) => i.content)).toEqual(["write tests for the parser"]);
+
+    // The turn file is unreadable now.
+    const turnFile = join(ratelDir, "chat", "claude-code", "sess-drop.jsonl");
+    expect(await nodeFs.read(turnFile)).toBeNull();
+  });
+
+  it("tolerates deleting an unknown session", async () => {
+    const del = await deleteChatRoute(ctx, "ghost");
+    expect(del.body).toMatchObject({ deleted: "ghost" });
   });
 });

--- a/apps/ratel-mcp/src/ui/intents-routes.test.ts
+++ b/apps/ratel-mcp/src/ui/intents-routes.test.ts
@@ -1,0 +1,207 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { nodeFs, nodeJsonFs } from "@ratel-ai/mcp-core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { ParsedArgs } from "../cli/args.js";
+import type { HandlerCtx } from "../cli/handlers/types.js";
+import { silentPromptAdapter } from "../cli/prompts.js";
+import { SECRET_MASK } from "./analysis-settings.js";
+import {
+  clearIntentsRoute,
+  deleteIntentRoute,
+  getAnalysisSettings,
+  getIntents,
+  getSessionIntents,
+  offerSkillRoute,
+  putAnalysisSettings,
+  runIntentsRoute,
+} from "./intents-routes.js";
+
+let home: string;
+let ratelDir: string;
+let ctx: HandlerCtx;
+const prevRatelHome = process.env.RATEL_HOME;
+
+const ARGV: ParsedArgs = {
+  group: "ui",
+  configPaths: [],
+  rest: [],
+  extras: [],
+  flags: {},
+};
+
+beforeEach(async () => {
+  home = await mkdtemp(join(tmpdir(), "ratel-iroutes-"));
+  ratelDir = join(home, ".ratel");
+  process.env.RATEL_HOME = ratelDir;
+  ctx = {
+    argv: ARGV,
+    env: { homeDir: home },
+    fs: nodeFs,
+    log: () => {},
+    prompts: silentPromptAdapter(),
+  };
+});
+
+afterEach(async () => {
+  if (prevRatelHome === undefined) delete process.env.RATEL_HOME;
+  else process.env.RATEL_HOME = prevRatelHome;
+  await rm(home, { recursive: true, force: true });
+});
+
+async function seedChat(sessionId: string, turns: Array<{ role: string; content: string }>) {
+  const file = join(ratelDir, "chat", "claude-code", `${sessionId}.jsonl`);
+  await nodeJsonFs.writeAtomic(file, `${turns.map((t) => JSON.stringify(t)).join("\n")}\n`);
+  await nodeJsonFs.writeAtomic(
+    join(ratelDir, "chat", "state.json"),
+    JSON.stringify({
+      version: 1,
+      sessions: { [sessionId]: { sessionId, host: "claude-code", newTurnCount: 99 } },
+    }),
+  );
+}
+
+/** Wait for the fire-and-forget run to finish (getIntents.running → false). */
+async function waitForIdle() {
+  for (let i = 0; i < 200; i++) {
+    const body = (await getIntents(ctx)).body as { running?: boolean };
+    if (!body.running) return;
+    await new Promise((r) => setTimeout(r, 20));
+  }
+  throw new Error("analysis run did not finish");
+}
+
+async function seedSkill(name: string, description: string, tags: string[]) {
+  const dir = join(ratelDir, "skills", name);
+  await mkdir(dir, { recursive: true });
+  await writeFile(
+    join(dir, "SKILL.md"),
+    [
+      "---",
+      `name: ${name}`,
+      `description: ${description}`,
+      `tags: [${tags.join(", ")}]`,
+      "---",
+      "# x",
+    ].join("\n"),
+  );
+}
+
+describe("getIntents", () => {
+  it("returns an empty index before any run", async () => {
+    const res = await getIntents(ctx);
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ intents: [], sessions: [] });
+  });
+});
+
+describe("runIntentsRoute + getIntents + getSessionIntents", () => {
+  it("analyzes, then serves cumulative + per-session intents", async () => {
+    await seedSkill(
+      "tdd-workflow",
+      "Write unit tests for parsers and modules before implementing",
+      ["tests", "testing", "write tests", "unit tests", "parser"],
+    );
+    await seedChat("sess-1", [
+      { role: "user", content: "write tests for the parser" },
+      { role: "user", content: "set up a grafana dashboard with prometheus" },
+    ]);
+
+    const run = await runIntentsRoute(ctx, {});
+    expect(run.body).toMatchObject({ started: true });
+    await waitForIdle();
+
+    const index = (await getIntents(ctx)).body as {
+      intents: Array<{ content: string; coverage: { status: string } }>;
+      sessions: Array<{ sessionId: string }>;
+    };
+    const byContent = Object.fromEntries(index.intents.map((i) => [i.content, i.coverage.status]));
+    expect(byContent["write tests for the parser"]).toBe("covered");
+    expect(byContent["set up a grafana dashboard with prometheus"]).toBe("gap");
+    expect(index.sessions[0].sessionId).toBe("sess-1");
+
+    const session = await getSessionIntents(ctx, "sess-1");
+    expect(session.status).toBe(200);
+
+    const missing = await getSessionIntents(ctx, "nope");
+    expect(missing.status).toBe(404);
+  });
+});
+
+describe("master switch (enabled)", () => {
+  it("does not run and reports disabled when analysis is off", async () => {
+    await putAnalysisSettings(ctx, { analysis: { enabled: false } });
+    const run = await runIntentsRoute(ctx, {});
+    expect(run.body).toMatchObject({ started: false, disabled: true });
+    const index = (await getIntents(ctx)).body as { enabled: boolean };
+    expect(index.enabled).toBe(false);
+  });
+
+  it("reports enabled by default (flag unset)", async () => {
+    const index = (await getIntents(ctx)).body as { enabled: boolean };
+    expect(index.enabled).toBe(true);
+  });
+});
+
+describe("deleteIntentRoute + clearIntentsRoute", () => {
+  async function seedAndRun() {
+    await seedSkill("tdd-workflow", "Write unit tests first then implement", ["write tests"]);
+    await seedChat("sess-1", [
+      { role: "user", content: "write tests for the parser" },
+      { role: "user", content: "set up a grafana dashboard" },
+    ]);
+    await runIntentsRoute(ctx, {});
+    await waitForIdle();
+  }
+
+  it("deletes a single intent by content", async () => {
+    await seedAndRun();
+    await deleteIntentRoute(ctx, { content: "set up a grafana dashboard" });
+    const index = (await getIntents(ctx)).body as { intents: Array<{ content: string }> };
+    expect(index.intents.map((i) => i.content)).toEqual(["write tests for the parser"]);
+  });
+
+  it("requires content", async () => {
+    await expect(deleteIntentRoute(ctx, { content: "  " })).rejects.toThrow(/content is required/);
+  });
+
+  it("clears every intent", async () => {
+    await seedAndRun();
+    await clearIntentsRoute(ctx);
+    const index = (await getIntents(ctx)).body as { intents: unknown[]; sessions: unknown[] };
+    expect(index.intents).toEqual([]);
+    expect(index.sessions).toEqual([]);
+  });
+});
+
+describe("analysis settings routes", () => {
+  it("persists settings and masks the apiKey on read", async () => {
+    await putAnalysisSettings(ctx, {
+      analysis: {
+        enabled: true,
+        cadence: { everyNMessages: 5, onIdle: true },
+        extractor: { endpoint: "http://127.0.0.1:8723", apiKey: "sk-secret" },
+      },
+    });
+    const res = (await getAnalysisSettings(ctx)).body as {
+      analysis: { cadence?: { everyNMessages?: number }; extractor?: { apiKey?: string } };
+      secretMask: string;
+    };
+    expect(res.analysis.cadence?.everyNMessages).toBe(5);
+    expect(res.analysis.extractor?.apiKey).toBe(SECRET_MASK);
+    expect(res.secretMask).toBe(SECRET_MASK);
+  });
+
+  it("rejects an invalid block", async () => {
+    await expect(
+      putAnalysisSettings(ctx, { analysis: { cadence: { everyNMessages: 0 } } }),
+    ).rejects.toThrow(/everyNMessages/);
+  });
+});
+
+describe("offerSkillRoute", () => {
+  it("requires a non-empty intent", async () => {
+    await expect(offerSkillRoute(ctx, { intent: "  " })).rejects.toThrow(/intent is required/);
+  });
+});

--- a/apps/ratel-mcp/src/ui/intents-routes.test.ts
+++ b/apps/ratel-mcp/src/ui/intents-routes.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readdir, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -185,6 +185,24 @@ describe("deleteIntentRoute + clearIntentsRoute", () => {
     await deleteIntentRoute(ctx, { content: "set up a grafana dashboard" });
     const index = (await getIntents(ctx)).body as { intents: Array<{ content: string }> };
     expect(index.intents.map((i) => i.content)).toEqual(["write tests for the parser"]);
+  });
+
+  it("drops the session's cache and re-arms it once its last intent is deleted", async () => {
+    await seedAndRun();
+    const { intentsPaths, resolveRatelDir, readChatState } = await import("@ratel-ai/mcp-core");
+    const { intentsDir, chatDir } = intentsPaths(resolveRatelDir(process.env, home));
+    const cacheDir = join(intentsDir, "cache");
+    expect((await readdir(cacheDir).catch(() => [])).length).toBeGreaterThan(0);
+
+    // Removing one of two intents leaves the session non-empty → cache stays.
+    await deleteIntentRoute(ctx, { content: "write tests for the parser" });
+    expect((await readdir(cacheDir).catch(() => [])).length).toBeGreaterThan(0);
+
+    // Removing the last intent empties the session → its cache is dropped and it's re-armed.
+    await deleteIntentRoute(ctx, { content: "set up a grafana dashboard" });
+    expect(await readdir(cacheDir).catch(() => [])).toEqual([]);
+    const state = await readChatState(nodeFs, chatDir);
+    expect(state.sessions["sess-1"].needsReanalysis).toBe(true);
   });
 
   it("makes a deletion survive a rebuild from session files", async () => {

--- a/apps/ratel-mcp/src/ui/intents-routes.test.ts
+++ b/apps/ratel-mcp/src/ui/intents-routes.test.ts
@@ -29,6 +29,7 @@ import {
   offerStatusRoute,
   putAnalysisSettings,
   runIntentsRoute,
+  testExtractorRoute,
 } from "./intents-routes.js";
 
 let home: string;
@@ -619,5 +620,68 @@ describe("deleteChatRoute", () => {
   it("tolerates deleting an unknown session", async () => {
     const del = await deleteChatRoute(ctx, "ghost");
     expect(del.body).toMatchObject({ deleted: "ghost" });
+  });
+});
+
+describe("testExtractorRoute", () => {
+  it("probes /health with the stored secret resolved from a masked apiKey", async () => {
+    // Seed a saved extractor with a real Basic-auth password.
+    await putAnalysisSettings(ctx, {
+      analysis: {
+        extractor: {
+          provider: "cloud",
+          endpoint: "https://extractor.example/api",
+          authScheme: "basic",
+          username: "alice",
+          apiKey: "s3cret",
+        },
+      },
+    });
+
+    const calls: Array<{ url: string; auth: string | null }> = [];
+    const fakeFetch = (async (url: string | URL, init?: RequestInit) => {
+      calls.push({
+        url: String(url),
+        auth: new Headers(init?.headers).get("Authorization"),
+      });
+      return new Response(JSON.stringify({ status: "ok" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }) as unknown as typeof fetch;
+
+    // The UI re-sends the masked apiKey (the user didn't retype the password).
+    const res = await testExtractorRoute(
+      ctx,
+      {
+        extractor: {
+          provider: "cloud",
+          endpoint: "https://extractor.example/api",
+          authScheme: "basic",
+          username: "alice",
+          apiKey: SECRET_MASK,
+        },
+      },
+      { fetch: fakeFetch },
+    );
+
+    expect(res.body).toEqual({ ok: true, status: 200, detail: "ok" });
+    expect(calls).toHaveLength(1);
+    expect(calls[0].url).toBe("https://extractor.example/api/health");
+    // alice:s3cret → YWxpY2U6czNjcmV0 (the stored secret, not the mask).
+    expect(calls[0].auth).toBe("Basic YWxpY2U6czNjcmV0");
+  });
+
+  it("returns a failure verdict (not an error) when the endpoint is unreachable", async () => {
+    const fakeFetch = (async () => {
+      throw new Error("ECONNREFUSED");
+    }) as unknown as typeof fetch;
+    const res = await testExtractorRoute(
+      ctx,
+      { extractor: { endpoint: "http://127.0.0.1:9", provider: "http" } },
+      { fetch: fakeFetch },
+    );
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ ok: false });
   });
 });

--- a/apps/ratel-mcp/src/ui/intents-routes.ts
+++ b/apps/ratel-mcp/src/ui/intents-routes.ts
@@ -9,6 +9,7 @@ import {
   HookChatSource,
   intentsPaths,
   loadSkills,
+  markSessionsForReanalysis,
   normalizeIntentKey,
   type RunLogEntry,
   readAllSessionIntents,
@@ -269,10 +270,12 @@ export async function deleteIntentRoute(
 /**
  * POST /api/intents/clear — wipe all analysis output durably: delete every
  * per-session file, drop the extraction cache (so the next run re-runs the model
- * instead of replaying cached results), and reset the index to empty.
+ * instead of replaying cached results), reset the index to empty, and flag every
+ * captured session for re-analysis so a plain "Run now" regenerates intents (without
+ * the flag the bookkeeping still reads "already analyzed" and the run skips them).
  */
 export async function clearIntentsRoute(ctx: HandlerCtx): Promise<ApiResponse> {
-  const dir = intentsDirFor(ctx);
+  const { intentsDir: dir, chatDir } = intentsPaths(resolveRatelDir(process.env, ctx.env.homeDir));
   const sessions = await readAllSessionIntents(ctx.fs, dir);
   for (const session of sessions) {
     await rm(join(dir, "sessions", `${session.sessionId}.json`), { force: true });
@@ -281,6 +284,8 @@ export async function clearIntentsRoute(ctx: HandlerCtx): Promise<ApiResponse> {
   // extractions and the cleared intents look like they "came back from cache".
   await rm(join(dir, "cache"), { recursive: true, force: true });
   await writeIntentsIndex(ctx.fs, dir, emptyIndex());
+  // Re-arm every captured session so the next run treats it as due.
+  await markSessionsForReanalysis(ctx.fs, chatDir);
   return ok({ cleared: true });
 }
 

--- a/apps/ratel-mcp/src/ui/intents-routes.ts
+++ b/apps/ratel-mcp/src/ui/intents-routes.ts
@@ -1,18 +1,35 @@
+import { rm } from "node:fs/promises";
+import { basename, join } from "node:path";
 import {
   type AnalysisConfig,
   createSkillGenerator,
   emptyIndex,
+  HookChatSource,
   intentsPaths,
   loadSkills,
+  normalizeIntentKey,
+  type RunLogEntry,
+  readAllSessionIntents,
   readChatState,
   readIntentsIndex,
+  readRunLog,
   readSessionIntents,
-  removeIntent,
+  rebuildIndex,
+  removeIntentFromSessions,
   resolveRatelDir,
+  type SkillDraft,
+  type SkillGenerator,
+  sessionTurnsPath,
+  writeChatState,
   writeIntentsIndex,
+  writeSessionIntents,
 } from "@ratel-ai/mcp-core";
 import type { HandlerCtx } from "../cli/handlers/types.js";
-import { loadUserAnalysis, resolveAnalysisRuntime } from "../intents/context.js";
+import {
+  type AnalysisRuntime,
+  loadUserAnalysis,
+  resolveAnalysisRuntime,
+} from "../intents/context.js";
 import { recomputeIntentCoverage } from "../intents/coverage.js";
 import { DEFAULT_EVERY_N_MESSAGES, runAnalysis } from "../intents/runner.js";
 import { readAnalysisSettings, SECRET_MASK, writeAnalysisSettings } from "./analysis-settings.js";
@@ -51,6 +68,10 @@ export async function getIntents(ctx: HandlerCtx): Promise<ApiResponse> {
     // On unless explicitly disabled (the feature predates this flag).
     enabled: analysis?.enabled !== false,
     running: runState.running,
+    runningSessionId: runState.sessionId,
+    queuedSessionIds: runState.queue
+      .map((q) => q.opts.sessionId)
+      .filter((s): s is string => Boolean(s)),
     lastError: runState.lastError,
   });
 }
@@ -70,56 +91,152 @@ export async function getSessionIntents(ctx: HandlerCtx, sessionId: string): Pro
  * for `running`, instead of blocking on a request that could hang on a slow or
  * crashed sidecar.
  */
-const runState: { running: boolean; lastError: string | null } = {
+interface RunRequest {
+  ctx: HandlerCtx;
+  opts: {
+    sessionId?: string;
+    everyNMessages?: number;
+    onIdle?: boolean;
+    all?: boolean;
+    recentHours?: number;
+    bypassCache?: boolean;
+  };
+  trigger: string;
+}
+
+const runState: {
+  running: boolean;
+  lastError: string | null;
+  sessionId: string | null;
+  queue: RunRequest[];
+} = {
   running: false,
   lastError: null,
+  // The session a per-chat run is processing (null for batch/all runs), so the UI
+  // can keep showing a per-chat "analyzing" indicator even after navigating away.
+  sessionId: null,
+  // Pending runs: model inference is serial, so concurrent triggers queue here and
+  // run one after another (clicking "Analyze" on several chats analyzes them all).
+  queue: [],
 };
 
 /**
- * POST /api/intents/run — manual trigger. Analyzes one session when `sessionId`
- * is given, otherwise every session with new activity since its last analysis
- * (skips up-to-date sessions, so it doesn't needlessly re-run the model). Returns
- * immediately; watch `running` from GET /api/intents.
+ * Start a fire-and-forget analysis run, honoring the module-level run guard and
+ * the analysis master switch. Shared by the manual UI trigger and the scheduler
+ * so the single-flight guard and error bookkeeping live in one place. Returns
+ * immediately; callers watch `running`/`lastError` via GET /api/intents.
+ *
+ * On completion the run's per-session failures are summarized into
+ * `runState.lastError` (cleared on a clean run); `runState.running` is always
+ * reset in `finally`.
+ */
+export async function startAnalysisRun(
+  ctx: HandlerCtx,
+  opts: RunRequest["opts"],
+  trigger: string,
+): Promise<{ started: boolean; alreadyRunning?: boolean; disabled?: boolean; queued?: boolean }> {
+  const analysis = await loadUserAnalysis(ctx.env, ctx.fs);
+  if (analysis?.enabled === false) {
+    return { started: false, disabled: true };
+  }
+  if (runState.running) {
+    // A run is in flight; queue this one (inference is serial). Dedupe so the same
+    // chat isn't queued twice, and a batch run doesn't pile up behind itself.
+    const sid = opts.sessionId;
+    const dup = sid
+      ? runState.sessionId === sid || runState.queue.some((q) => q.opts.sessionId === sid)
+      : runState.queue.some((q) => !q.opts.sessionId);
+    if (!dup) runState.queue.push({ ctx, opts, trigger });
+    return { started: false, queued: true };
+  }
+  launchAnalysis({ ctx, opts, trigger });
+  return { started: true };
+}
+
+/**
+ * Run one request now, then drain the queue. Sets the in-flight state, runs the
+ * analysis, and on completion starts the next queued request (if any) so chained
+ * per-chat analyses run sequentially.
+ */
+function launchAnalysis(req: RunRequest): void {
+  runState.running = true;
+  runState.lastError = null;
+  runState.sessionId = req.opts.sessionId ?? null;
+  void (async () => {
+    try {
+      const runtime = await resolveAnalysisRuntime(req.ctx.env, req.ctx.fs);
+      if (runtime.analysis?.enabled !== false) {
+        const result = await runAnalysis(
+          {
+            fs: req.ctx.fs,
+            intentsDir: runtime.paths.intentsDir,
+            chatSource: runtime.chatSource,
+            extractor: runtime.extractor,
+            matchSkill: runtime.matchSkill,
+            extractorModel: runtime.analysis?.extractor?.model,
+            now: () => new Date().toISOString(),
+            log: req.ctx.log,
+          },
+          // Recency window comes from config unless the caller set one; ignored for
+          // the explicit sessionId/all paths inside the runner.
+          {
+            recentHours: runtime.analysis?.cadence?.recentHours,
+            ...req.opts,
+            trigger: req.trigger,
+          },
+        );
+        runState.lastError = summarizeRunErrors(result.errors);
+        if (runState.lastError)
+          req.ctx.log(`[ratel] analysis completed with errors: ${runState.lastError}`);
+      }
+    } catch (err) {
+      runState.lastError = err instanceof Error ? err.message : String(err);
+      req.ctx.log(`[ratel] analysis failed: ${runState.lastError}`);
+    } finally {
+      runState.running = false;
+      runState.sessionId = null;
+      const next = runState.queue.shift();
+      if (next) launchAnalysis(next);
+    }
+  })();
+}
+
+/** Build a concise one-line summary of a run's per-session failures, or null when clean. */
+function summarizeRunErrors(errors: Array<{ sessionId: string; message: string }>): string | null {
+  if (errors.length === 0) return null;
+  return `${errors.length} session(s) failed: ${errors[0].message}`;
+}
+
+/**
+ * POST /api/intents/run — manual trigger. With `sessionId`, analyzes just that
+ * chat (always, ignoring due-checks). With `all: true`, re-analyzes every chat
+ * (ignores the new-activity/recency filters). Otherwise analyzes only chats with
+ * new activity since their last analysis (skips up-to-date chats so it doesn't
+ * needlessly re-run the model). Returns immediately; watch `running` via GET /api/intents.
  */
 export async function runIntentsRoute(
   ctx: HandlerCtx,
-  body: { sessionId?: unknown },
+  body: { sessionId?: unknown; all?: unknown },
 ): Promise<ApiResponse> {
-  if (runState.running) {
-    return ok({ started: false, alreadyRunning: true });
-  }
   const sessionId = typeof body.sessionId === "string" ? body.sessionId : undefined;
-  const runtime = await resolveAnalysisRuntime(ctx.env, ctx.fs);
-  if (runtime.analysis?.enabled === false) {
-    return ok({ started: false, disabled: true });
-  }
-  runState.running = true;
-  runState.lastError = null;
-  void (async () => {
-    try {
-      await runAnalysis(
-        {
-          fs: ctx.fs,
-          intentsDir: runtime.paths.intentsDir,
-          chatSource: runtime.chatSource,
-          extractor: runtime.extractor,
-          matchSkill: runtime.matchSkill,
-          now: () => new Date().toISOString(),
-          log: ctx.log,
-        },
-        sessionId ? { sessionId } : { everyNMessages: 1, onIdle: true },
-      );
-    } catch (err) {
-      runState.lastError = err instanceof Error ? err.message : String(err);
-      ctx.log(`[ratel] analysis failed: ${runState.lastError}`);
-    } finally {
-      runState.running = false;
-    }
-  })();
-  return ok({ started: true });
+  const all = body.all === true;
+  // "Re-analyze all" forces fresh extraction (bypass cache); the incremental and
+  // per-chat paths keep using the cache for speed.
+  const opts = sessionId
+    ? { sessionId }
+    : all
+      ? { all: true, bypassCache: true }
+      : { everyNMessages: 1, onIdle: true };
+  const trigger = sessionId ? "session" : all ? "all" : "manual";
+  const result = await startAnalysisRun(ctx, opts, trigger);
+  return ok(result);
 }
 
-/** POST /api/intents/delete — remove a single intent (by content) from the index. */
+/**
+ * POST /api/intents/delete — remove a single intent (by content) durably. Strips
+ * it from the per-session files (not just the index) so the next rebuild can't
+ * resurrect it, then rebuilds the index from the surviving session files.
+ */
 export async function deleteIntentRoute(
   ctx: HandlerCtx,
   body: { content?: unknown },
@@ -129,14 +246,34 @@ export async function deleteIntentRoute(
     throw new Error("content is required");
   }
   const dir = intentsDirFor(ctx);
-  const next = removeIntent(await readIntentsIndex(ctx.fs, dir), content);
+  const sessions = await readAllSessionIntents(ctx.fs, dir);
+  const updated = removeIntentFromSessions(sessions, content);
+  // Persist only the sessions whose intents actually changed.
+  for (let i = 0; i < sessions.length; i++) {
+    if (sessions[i].intents.length !== updated[i].intents.length) {
+      await writeSessionIntents(ctx.fs, dir, updated[i]);
+    }
+  }
+  const next = rebuildIndex(updated);
   await writeIntentsIndex(ctx.fs, dir, next);
   return ok({ removed: content, remaining: next.intents.length });
 }
 
-/** POST /api/intents/clear — wipe the cumulative index (intents are regenerated on the next run). */
+/**
+ * POST /api/intents/clear — wipe all analysis output durably: delete every
+ * per-session file, drop the extraction cache (so the next run re-runs the model
+ * instead of replaying cached results), and reset the index to empty.
+ */
 export async function clearIntentsRoute(ctx: HandlerCtx): Promise<ApiResponse> {
-  await writeIntentsIndex(ctx.fs, intentsDirFor(ctx), emptyIndex());
+  const dir = intentsDirFor(ctx);
+  const sessions = await readAllSessionIntents(ctx.fs, dir);
+  for (const session of sessions) {
+    await rm(join(dir, "sessions", `${session.sessionId}.json`), { force: true });
+  }
+  // Drop the extraction cache too — otherwise a re-analysis replays the cached
+  // extractions and the cleared intents look like they "came back from cache".
+  await rm(join(dir, "cache"), { recursive: true, force: true });
+  await writeIntentsIndex(ctx.fs, dir, emptyIndex());
   return ok({ cleared: true });
 }
 
@@ -158,24 +295,343 @@ export async function putAnalysisSettings(
 }
 
 /**
- * POST /api/skills/offer — draft a skill for an uncovered intent via the
- * configured generator (anthropic-api or `claude -p`). The draft is returned for
- * review only; the UI persists it through the existing `POST /api/skills`.
+ * A background skill-generation job. Generation can shell out to `claude -p` or
+ * call the Anthropic API, both of which take a while, so it runs fire-and-forget
+ * and the UI polls {@link offerStatusRoute} for the draft.
+ */
+export interface OfferJob {
+  status: "running" | "done" | "error";
+  intent: string;
+  /** Human label of the model the draft is/was generated with. */
+  model: string;
+  /** ISO timestamp when the job started. */
+  startedAt: string;
+  draft?: SkillDraft;
+  error?: string;
+}
+
+/** In-flight + completed offer jobs, keyed by {@link normalizeIntentKey} of the intent. */
+const offerJobs = new Map<string, OfferJob>();
+
+/** Resolve a human label for the skill-gen model, mirroring createSkillGenerator's selection. */
+function resolveSkillGenModelLabel(analysis: AnalysisConfig | undefined): string {
+  const skillGen = analysis?.skillGen ?? {};
+  if (skillGen.model) return skillGen.model;
+  const provider = skillGen.provider ?? "auto";
+  const useApi = provider === "anthropic-api" || (provider === "auto" && Boolean(skillGen.apiKey));
+  return useApi ? "claude-sonnet-4-6" : "haiku";
+}
+
+/**
+ * Build a rich generation context for an intent: the existing skill ids (so the
+ * draft avoids duplicates), the intent's own evidence snippets, and the other
+ * intents seen in the same sessions — all gathered from the durable per-session
+ * files. Both evidence and related-intent lists are de-duped and capped.
+ */
+async function buildOfferContext(
+  ctx: HandlerCtx,
+  runtime: AnalysisRuntime,
+  intent: string,
+): Promise<{
+  existingSkillIds: string[];
+  evidences: string[];
+  relatedIntents: string[];
+  cwd?: string;
+}> {
+  const key = normalizeIntentKey(intent);
+  const index = await readIntentsIndex(ctx.fs, runtime.paths.intentsDir);
+  const record = index.intents.find((i) => normalizeIntentKey(i.content) === key);
+  const sessionIds = record?.sessions ?? [];
+
+  const evidences = new Set<string>();
+  const relatedIntents = new Set<string>();
+  let cwd: string | undefined;
+  for (const sessionId of sessionIds) {
+    const session = await readSessionIntents(ctx.fs, runtime.paths.intentsDir, sessionId);
+    if (!session) continue;
+    if (!cwd && session.cwd) cwd = session.cwd;
+    for (const i of session.intents) {
+      if (normalizeIntentKey(i.content) === key) {
+        for (const e of i.evidences ?? []) evidences.add(e);
+      } else {
+        relatedIntents.add(i.content);
+      }
+    }
+  }
+
+  const skills = await loadSkills(runtime.skillDirs, {});
+  return {
+    existingSkillIds: skills.map((s) => s.id),
+    evidences: [...evidences].slice(0, 12),
+    relatedIntents: [...relatedIntents].slice(0, 12),
+    cwd,
+  };
+}
+
+/**
+ * POST /api/skills/offer — start drafting a skill for an uncovered intent in the
+ * background. Idempotent while running: a second call for the same intent returns
+ * `{ started:false, alreadyRunning:true }`. The draft is fetched via
+ * {@link offerStatusRoute}; the UI persists an accepted draft through the
+ * existing `POST /api/skills`.
+ *
+ * `deps.generator` is an injection seam for tests; in production the generator is
+ * built from config via `createSkillGenerator`.
  */
 export async function offerSkillRoute(
   ctx: HandlerCtx,
   body: { intent?: unknown },
+  deps: { generator?: SkillGenerator } = {},
 ): Promise<ApiResponse> {
   const intent = typeof body.intent === "string" ? body.intent.trim() : "";
   if (intent.length === 0) {
     throw new Error("intent is required");
   }
   const runtime = await resolveAnalysisRuntime(ctx.env, ctx.fs);
-  const skills = await loadSkills(runtime.skillDirs, {});
-  const generator = createSkillGenerator(runtime.analysis);
-  const draft = await generator.generate(
-    { content: intent },
-    { existingSkillIds: skills.map((s) => s.id) },
-  );
-  return ok({ draft });
+  const model = resolveSkillGenModelLabel(runtime.analysis);
+  const key = normalizeIntentKey(intent);
+
+  const existing = offerJobs.get(key);
+  if (existing?.status === "running") {
+    return ok({ started: false, alreadyRunning: true, intent, model });
+  }
+
+  const job: OfferJob = {
+    status: "running",
+    intent,
+    model,
+    startedAt: new Date().toISOString(),
+  };
+  offerJobs.set(key, job);
+
+  const generator = deps.generator ?? createSkillGenerator(runtime.analysis);
+  void (async () => {
+    try {
+      const context = await buildOfferContext(ctx, runtime, intent);
+      const draft = await generator.generate({ content: intent }, context);
+      offerJobs.set(key, { ...job, status: "done", draft });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      offerJobs.set(key, { ...job, status: "error", error: message });
+      ctx.log(`[ratel] skill offer failed for "${intent}": ${message}`);
+    }
+  })();
+
+  return ok({ started: true, intent, model });
+}
+
+/**
+ * GET /api/skills/offer/status?intent=… — poll a background skill-gen job. Reports
+ * `idle` when no job exists for the intent, else its current status with the draft
+ * (when done) or error message (when failed).
+ */
+export async function offerStatusRoute(_ctx: HandlerCtx, intent: string): Promise<ApiResponse> {
+  const key = normalizeIntentKey(typeof intent === "string" ? intent : "");
+  const job = offerJobs.get(key);
+  if (!job) {
+    return ok({ status: "idle" });
+  }
+  return ok({
+    status: job.status,
+    draft: job.draft,
+    error: job.error,
+    model: job.model,
+    startedAt: job.startedAt,
+  });
+}
+
+/**
+ * GET /api/skills/offer/jobs — summarize every background skill-gen job (running,
+ * done, or failed) so a returning user can find a draft they started earlier. The
+ * draft body is deliberately omitted to keep the payload small; the client fetches
+ * it via {@link offerStatusRoute} when opening the review.
+ */
+export async function listOfferJobsRoute(_ctx: HandlerCtx): Promise<ApiResponse> {
+  const jobs = [...offerJobs.values()].map((job) => ({
+    intent: job.intent,
+    status: job.status,
+    model: job.model,
+    startedAt: job.startedAt,
+    error: job.error,
+    hasDraft: Boolean(job.draft),
+  }));
+  return ok({ jobs });
+}
+
+/**
+ * DELETE /api/skills/offer?intent=… — drop a finished/declined authoring job from
+ * the registry so it stops surfacing as "Skill ready". Called after a draft is
+ * created (the skill now exists) or explicitly declined. Idempotent.
+ */
+export async function clearOfferJobRoute(_ctx: HandlerCtx, intent: string): Promise<ApiResponse> {
+  const key = normalizeIntentKey(typeof intent === "string" ? intent : "");
+  const removed = offerJobs.delete(key);
+  return ok({ cleared: removed });
+}
+
+/**
+ * GET /api/observability — recent analysis runs plus a small rollup summary, for
+ * the observability view. Tolerates an empty log (zeroed summary).
+ */
+export async function getObservabilityRoute(ctx: HandlerCtx): Promise<ApiResponse> {
+  const { intentsDir } = intentsPaths(resolveRatelDir(process.env, ctx.env.homeDir));
+  const runs = await readRunLog(ctx.fs, intentsDir, 50);
+  return ok({ runs, summary: summarizeRuns(runs) });
+}
+
+/** Roll a run list up into headline metrics; returns zeroed fields for an empty list. */
+function summarizeRuns(runs: RunLogEntry[]): {
+  totalRuns: number;
+  lastRunAt: string | null;
+  avgDurationMs: number;
+  avgGapsPerRun: number;
+} {
+  if (runs.length === 0) {
+    return { totalRuns: 0, lastRunAt: null, avgDurationMs: 0, avgGapsPerRun: 0 };
+  }
+  const totalDuration = runs.reduce((sum, r) => sum + (r.durationMs ?? 0), 0);
+  const totalGaps = runs.reduce((sum, r) => sum + (r.totalGaps ?? 0), 0);
+  // readRunLog returns newest-first, so the first entry is the most recent run.
+  return {
+    totalRuns: runs.length,
+    lastRunAt: runs[0].at ?? null,
+    avgDurationMs: Math.round(totalDuration / runs.length),
+    avgGapsPerRun: Math.round((totalGaps / runs.length) * 10) / 10,
+  };
+}
+
+/** One chat/session row for the Chats page. */
+export interface ChatSummary {
+  sessionId: string;
+  host: string;
+  cwd?: string;
+  title: string;
+  turnCount: number;
+  updatedAt?: string;
+  lastAnalyzedAt?: string;
+  idle: boolean;
+  intentCount: number;
+  gapCount: number;
+  /** True when a session summary exists in the intents index (i.e. it was analyzed). */
+  analyzed: boolean;
+}
+
+/** Collapse whitespace and truncate a turn into a short title (~80 chars). */
+function deriveTitle(text: string): string {
+  const collapsed = text.replace(/\s+/g, " ").trim();
+  if (collapsed.length <= 80) return collapsed;
+  return `${collapsed.slice(0, 80)}…`;
+}
+
+/**
+ * GET /api/chats — every captured session with a derived title and intent/gap
+ * counts, sorted by most-recently-updated. Resilient: a session whose turns are
+ * unreadable still lists (the title falls back to its cwd basename / id).
+ */
+export async function getChatsRoute(ctx: HandlerCtx): Promise<ApiResponse> {
+  const { intentsDir, chatDir } = intentsPaths(resolveRatelDir(process.env, ctx.env.homeDir));
+  const state = await readChatState(ctx.fs, chatDir);
+  const index = await readIntentsIndex(ctx.fs, intentsDir);
+  const source = new HookChatSource({ chatDir, fs: ctx.fs });
+  const summaryById = new Map(index.sessions.map((s) => [s.sessionId, s]));
+
+  const chats: ChatSummary[] = [];
+  for (const meta of Object.values(state.sessions)) {
+    const turns = await source.readSession(meta.sessionId);
+    const firstUser = turns.find((t) => t.role === "user");
+    const fallback = meta.cwd ? basename(meta.cwd) : meta.sessionId;
+    const title = firstUser ? deriveTitle(firstUser.content) : fallback;
+    const summary = summaryById.get(meta.sessionId);
+    chats.push({
+      sessionId: meta.sessionId,
+      host: meta.host,
+      cwd: meta.cwd,
+      title,
+      turnCount: turns.length,
+      updatedAt: meta.updatedAt,
+      lastAnalyzedAt: meta.lastAnalyzedAt,
+      idle: meta.idle === true,
+      intentCount: summary?.intentCount ?? 0,
+      gapCount: summary?.gapCount ?? 0,
+      analyzed: summary !== undefined,
+    });
+  }
+
+  chats.sort((a, b) => (b.updatedAt ?? "").localeCompare(a.updatedAt ?? ""));
+  return ok({ chats });
+}
+
+/** Default number of recent turns returned per chat request. */
+const DEFAULT_CHAT_TURNS = 60;
+/** Upper bound on the per-request turn window, so a huge limit can't bloat the response. */
+const MAX_CHAT_TURNS = 2000;
+
+/** Clamp a requested turn limit to a sane window, falling back to the default on bad input. */
+function resolveChatLimit(limit?: number): number {
+  if (limit === undefined || Number.isNaN(limit) || limit <= 0) {
+    return DEFAULT_CHAT_TURNS;
+  }
+  return Math.min(Math.floor(limit), MAX_CHAT_TURNS);
+}
+
+/**
+ * GET /api/chats/:sessionId — one session's metadata plus a recent slice of its
+ * transcript: the last `limit` turns (default 60, clamped to a sane max), with
+ * `total` carrying the full turn count so the UI can offer "load earlier".
+ * 404 when the session is unknown or has no readable turns.
+ */
+export async function getChatRoute(
+  ctx: HandlerCtx,
+  sessionId: string,
+  limit?: number,
+): Promise<ApiResponse> {
+  const { chatDir } = intentsPaths(resolveRatelDir(process.env, ctx.env.homeDir));
+  const state = await readChatState(ctx.fs, chatDir);
+  const meta = state.sessions[sessionId];
+  const source = new HookChatSource({ chatDir, fs: ctx.fs });
+  const turns = await source.readSession(sessionId);
+  if (!meta && turns.length === 0) {
+    return { status: 404, body: { error: `unknown session: ${sessionId}`, isError: true } };
+  }
+  const firstUser = turns.find((t) => t.role === "user");
+  const fallback = meta?.cwd ? basename(meta.cwd) : sessionId;
+  return ok({
+    sessionId,
+    host: meta?.host,
+    cwd: meta?.cwd,
+    title: firstUser ? deriveTitle(firstUser.content) : fallback,
+    turns: turns.slice(-resolveChatLimit(limit)),
+    total: turns.length,
+  });
+}
+
+/**
+ * DELETE /api/chats/:sessionId — durably delete a session: its captured turn
+ * file, its chat-state entry, and its per-session intents file, then rebuild the
+ * index from the survivors so the deletion sticks. Already-missing files are
+ * tolerated.
+ */
+export async function deleteChatRoute(ctx: HandlerCtx, sessionId: string): Promise<ApiResponse> {
+  const { intentsDir, chatDir } = intentsPaths(resolveRatelDir(process.env, ctx.env.homeDir));
+  const state = await readChatState(ctx.fs, chatDir);
+  const meta = state.sessions[sessionId];
+
+  // Remove the captured turn file (try the known host, else all candidates).
+  const hosts = meta?.host ? [meta.host] : ["claude-code", "codex", "unknown"];
+  for (const host of hosts) {
+    await rm(sessionTurnsPath(chatDir, host, sessionId), { force: true });
+  }
+
+  // Drop the session entry from chat state.
+  if (meta) {
+    const { [sessionId]: _removed, ...rest } = state.sessions;
+    await writeChatState(ctx.fs, chatDir, { ...state, sessions: rest });
+  }
+
+  // Remove its per-session intents file, then rebuild the index from survivors.
+  await rm(join(intentsDir, "sessions", `${sessionId}.json`), { force: true });
+  const sessions = await readAllSessionIntents(ctx.fs, intentsDir);
+  await writeIntentsIndex(ctx.fs, intentsDir, rebuildIndex(sessions));
+
+  return ok({ deleted: sessionId });
 }

--- a/apps/ratel-mcp/src/ui/intents-routes.ts
+++ b/apps/ratel-mcp/src/ui/intents-routes.ts
@@ -1,0 +1,181 @@
+import {
+  type AnalysisConfig,
+  createSkillGenerator,
+  emptyIndex,
+  intentsPaths,
+  loadSkills,
+  readChatState,
+  readIntentsIndex,
+  readSessionIntents,
+  removeIntent,
+  resolveRatelDir,
+  writeIntentsIndex,
+} from "@ratel-ai/mcp-core";
+import type { HandlerCtx } from "../cli/handlers/types.js";
+import { loadUserAnalysis, resolveAnalysisRuntime } from "../intents/context.js";
+import { recomputeIntentCoverage } from "../intents/coverage.js";
+import { DEFAULT_EVERY_N_MESSAGES, runAnalysis } from "../intents/runner.js";
+import { readAnalysisSettings, SECRET_MASK, writeAnalysisSettings } from "./analysis-settings.js";
+import type { ApiResponse } from "./routes.js";
+
+function ok(body: unknown): ApiResponse {
+  return { status: 200, body };
+}
+
+function intentsDirFor(ctx: HandlerCtx): string {
+  return intentsPaths(resolveRatelDir(process.env, ctx.env.homeDir)).intentsDir;
+}
+
+/**
+ * GET /api/intents — the cumulative index, enriched with the cadence threshold
+ * and each session's new-message count since its last analysis, so the UI can
+ * show how many more messages until the next automatic run.
+ */
+export async function getIntents(ctx: HandlerCtx): Promise<ApiResponse> {
+  const { intentsDir, chatDir } = intentsPaths(resolveRatelDir(process.env, ctx.env.homeDir));
+  const index = await readIntentsIndex(ctx.fs, intentsDir);
+  const state = await readChatState(ctx.fs, chatDir);
+  const analysis = await loadUserAnalysis(ctx.env, ctx.fs);
+  const cadence = {
+    everyNMessages: analysis?.cadence?.everyNMessages ?? DEFAULT_EVERY_N_MESSAGES,
+    onIdle: analysis?.cadence?.onIdle ?? false,
+  };
+  const sessions = index.sessions.map((s) => ({
+    ...s,
+    newTurnCount: state.sessions[s.sessionId]?.newTurnCount ?? 0,
+  }));
+  return ok({
+    ...index,
+    sessions,
+    cadence,
+    // On unless explicitly disabled (the feature predates this flag).
+    enabled: analysis?.enabled !== false,
+    running: runState.running,
+    lastError: runState.lastError,
+  });
+}
+
+/** GET /api/intents/:sessionId — the full per-session result (claims + annotated intents). */
+export async function getSessionIntents(ctx: HandlerCtx, sessionId: string): Promise<ApiResponse> {
+  const session = await readSessionIntents(ctx.fs, intentsDirFor(ctx), sessionId);
+  if (!session) {
+    return { status: 404, body: { error: `no intents for session: ${sessionId}`, isError: true } };
+  }
+  return ok(session);
+}
+
+/**
+ * In-flight analysis status. Model inference can take a while, so the run is
+ * fire-and-forget: the request returns immediately and the UI polls getIntents
+ * for `running`, instead of blocking on a request that could hang on a slow or
+ * crashed sidecar.
+ */
+const runState: { running: boolean; lastError: string | null } = {
+  running: false,
+  lastError: null,
+};
+
+/**
+ * POST /api/intents/run — manual trigger. Analyzes one session when `sessionId`
+ * is given, otherwise every session with new activity since its last analysis
+ * (skips up-to-date sessions, so it doesn't needlessly re-run the model). Returns
+ * immediately; watch `running` from GET /api/intents.
+ */
+export async function runIntentsRoute(
+  ctx: HandlerCtx,
+  body: { sessionId?: unknown },
+): Promise<ApiResponse> {
+  if (runState.running) {
+    return ok({ started: false, alreadyRunning: true });
+  }
+  const sessionId = typeof body.sessionId === "string" ? body.sessionId : undefined;
+  const runtime = await resolveAnalysisRuntime(ctx.env, ctx.fs);
+  if (runtime.analysis?.enabled === false) {
+    return ok({ started: false, disabled: true });
+  }
+  runState.running = true;
+  runState.lastError = null;
+  void (async () => {
+    try {
+      await runAnalysis(
+        {
+          fs: ctx.fs,
+          intentsDir: runtime.paths.intentsDir,
+          chatSource: runtime.chatSource,
+          extractor: runtime.extractor,
+          matchSkill: runtime.matchSkill,
+          now: () => new Date().toISOString(),
+          log: ctx.log,
+        },
+        sessionId ? { sessionId } : { everyNMessages: 1, onIdle: true },
+      );
+    } catch (err) {
+      runState.lastError = err instanceof Error ? err.message : String(err);
+      ctx.log(`[ratel] analysis failed: ${runState.lastError}`);
+    } finally {
+      runState.running = false;
+    }
+  })();
+  return ok({ started: true });
+}
+
+/** POST /api/intents/delete — remove a single intent (by content) from the index. */
+export async function deleteIntentRoute(
+  ctx: HandlerCtx,
+  body: { content?: unknown },
+): Promise<ApiResponse> {
+  const content = typeof body.content === "string" ? body.content : "";
+  if (content.trim().length === 0) {
+    throw new Error("content is required");
+  }
+  const dir = intentsDirFor(ctx);
+  const next = removeIntent(await readIntentsIndex(ctx.fs, dir), content);
+  await writeIntentsIndex(ctx.fs, dir, next);
+  return ok({ removed: content, remaining: next.intents.length });
+}
+
+/** POST /api/intents/clear — wipe the cumulative index (intents are regenerated on the next run). */
+export async function clearIntentsRoute(ctx: HandlerCtx): Promise<ApiResponse> {
+  await writeIntentsIndex(ctx.fs, intentsDirFor(ctx), emptyIndex());
+  return ok({ cleared: true });
+}
+
+/** GET /api/analysis/settings — masked settings + the sentinel the UI echoes for unchanged secrets. */
+export async function getAnalysisSettings(ctx: HandlerCtx): Promise<ApiResponse> {
+  return ok({ analysis: await readAnalysisSettings(ctx.env, ctx.fs), secretMask: SECRET_MASK });
+}
+
+/** PUT /api/analysis/settings — validate + persist the analysis block (throws → 400). */
+export async function putAnalysisSettings(
+  ctx: HandlerCtx,
+  body: Record<string, unknown>,
+): Promise<ApiResponse> {
+  const incoming = (body.analysis ?? body) as AnalysisConfig;
+  const saved = await writeAnalysisSettings(ctx.env, ctx.fs, incoming);
+  // Coverage thresholds may have changed — re-evaluate so the change shows now.
+  await recomputeIntentCoverage(ctx.env, ctx.fs).catch(() => undefined);
+  return ok({ analysis: saved, secretMask: SECRET_MASK });
+}
+
+/**
+ * POST /api/skills/offer — draft a skill for an uncovered intent via the
+ * configured generator (anthropic-api or `claude -p`). The draft is returned for
+ * review only; the UI persists it through the existing `POST /api/skills`.
+ */
+export async function offerSkillRoute(
+  ctx: HandlerCtx,
+  body: { intent?: unknown },
+): Promise<ApiResponse> {
+  const intent = typeof body.intent === "string" ? body.intent.trim() : "";
+  if (intent.length === 0) {
+    throw new Error("intent is required");
+  }
+  const runtime = await resolveAnalysisRuntime(ctx.env, ctx.fs);
+  const skills = await loadSkills(runtime.skillDirs, {});
+  const generator = createSkillGenerator(runtime.analysis);
+  const draft = await generator.generate(
+    { content: intent },
+    { existingSkillIds: skills.map((s) => s.id) },
+  );
+  return ok({ draft });
+}

--- a/apps/ratel-mcp/src/ui/intents-routes.ts
+++ b/apps/ratel-mcp/src/ui/intents-routes.ts
@@ -231,11 +231,7 @@ export async function runIntentsRoute(
 ): Promise<ApiResponse> {
   const sessionId = typeof body.sessionId === "string" ? body.sessionId : undefined;
   const all = body.all === true;
-  const opts = sessionId
-    ? { sessionId }
-    : all
-      ? { all: true, bypassCache: true }
-      : { all: true };
+  const opts = sessionId ? { sessionId } : all ? { all: true, bypassCache: true } : { all: true };
   const trigger = sessionId ? "session" : all ? "all" : "manual";
   const result = await startAnalysisRun(ctx, opts, trigger);
   return ok(result);

--- a/apps/ratel-mcp/src/ui/intents-routes.ts
+++ b/apps/ratel-mcp/src/ui/intents-routes.ts
@@ -2,7 +2,9 @@ import { rm } from "node:fs/promises";
 import { basename, join } from "node:path";
 import {
   type AnalysisConfig,
+  checkExtractorHealth,
   createSkillGenerator,
+  type ExtractorConfig,
   emptyIndex,
   HookChatSource,
   intentsPaths,
@@ -32,7 +34,12 @@ import {
 } from "../intents/context.js";
 import { recomputeIntentCoverage } from "../intents/coverage.js";
 import { DEFAULT_EVERY_N_MESSAGES, runAnalysis } from "../intents/runner.js";
-import { readAnalysisSettings, SECRET_MASK, writeAnalysisSettings } from "./analysis-settings.js";
+import {
+  readAnalysisSettings,
+  resolveExtractorForTest,
+  SECRET_MASK,
+  writeAnalysisSettings,
+} from "./analysis-settings.js";
 import type { ApiResponse } from "./routes.js";
 
 function ok(body: unknown): ApiResponse {
@@ -292,6 +299,24 @@ export async function putAnalysisSettings(
   // Coverage thresholds may have changed — re-evaluate so the change shows now.
   await recomputeIntentCoverage(ctx.env, ctx.fs).catch(() => undefined);
   return ok({ analysis: saved, secretMask: SECRET_MASK });
+}
+
+/**
+ * POST /api/analysis/extractor/test — probe the configured extractor endpoint's
+ * `GET /health` (server-side, so the secret never reaches the browser and there's
+ * no CORS hop). Accepts the in-progress form's extractor block; a masked apiKey
+ * resolves to the stored secret, so the test works before the settings are saved.
+ * `deps.fetch` is an injection seam for tests. Always returns 200 with an
+ * `{ ok, status?, detail? }` verdict — a failed probe is a result, not an error.
+ */
+export async function testExtractorRoute(
+  ctx: HandlerCtx,
+  body: { extractor?: unknown },
+  deps: { fetch?: typeof fetch } = {},
+): Promise<ApiResponse> {
+  const incoming = (body.extractor ?? {}) as ExtractorConfig;
+  const resolved = await resolveExtractorForTest(ctx.env, ctx.fs, incoming);
+  return ok(await checkExtractorHealth(resolved, deps));
 }
 
 /**

--- a/apps/ratel-mcp/src/ui/intents-routes.ts
+++ b/apps/ratel-mcp/src/ui/intents-routes.ts
@@ -34,6 +34,7 @@ import {
   resolveAnalysisRuntime,
 } from "../intents/context.js";
 import { recomputeIntentCoverage } from "../intents/coverage.js";
+import { cacheEntryPath, cacheKey } from "../intents/extraction-cache.js";
 import { DEFAULT_EVERY_N_MESSAGES, runAnalysis } from "../intents/runner.js";
 import {
   readAnalysisSettings,
@@ -250,18 +251,48 @@ export async function deleteIntentRoute(
   if (content.trim().length === 0) {
     throw new Error("content is required");
   }
-  const dir = intentsDirFor(ctx);
-  const sessions = await readAllSessionIntents(ctx.fs, dir);
+  const { intentsDir, chatDir } = intentsPaths(resolveRatelDir(process.env, ctx.env.homeDir));
+  const sessions = await readAllSessionIntents(ctx.fs, intentsDir);
   const updated = removeIntentFromSessions(sessions, content);
-  // Persist only the sessions whose intents actually changed.
+  // Persist only the sessions whose intents actually changed; note any left empty.
+  const emptied: string[] = [];
   for (let i = 0; i < sessions.length; i++) {
     if (sessions[i].intents.length !== updated[i].intents.length) {
-      await writeSessionIntents(ctx.fs, dir, updated[i]);
+      await writeSessionIntents(ctx.fs, intentsDir, updated[i]);
+      if (updated[i].intents.length === 0) emptied.push(updated[i].sessionId);
     }
   }
+  // When a session has no intents left, drop its extraction cache and re-arm it so the
+  // next run re-extracts it fresh instead of replaying the now-stale cached result.
+  if (emptied.length > 0) {
+    await dropSessionCaches(ctx, intentsDir, chatDir, emptied);
+    await markSessionsForReanalysis(ctx.fs, chatDir, emptied);
+  }
   const next = rebuildIndex(updated);
-  await writeIntentsIndex(ctx.fs, dir, next);
+  await writeIntentsIndex(ctx.fs, intentsDir, next);
   return ok({ removed: content, remaining: next.intents.length });
+}
+
+/**
+ * Delete the extraction-cache entries for the given sessions. The cache is keyed by a
+ * hash of `(turns, model)`, so we recompute each session's key from its captured turns
+ * (matching what the runner stored) and remove that file. Missing turns/files are a
+ * no-op — the goal is only to guarantee a fresh re-extraction next run.
+ */
+async function dropSessionCaches(
+  ctx: HandlerCtx,
+  intentsDir: string,
+  chatDir: string,
+  sessionIds: string[],
+): Promise<void> {
+  const analysis = await loadUserAnalysis(ctx.env, ctx.fs);
+  const model = analysis?.extractor?.model;
+  const source = new HookChatSource({ chatDir, fs: ctx.fs });
+  for (const sessionId of sessionIds) {
+    const turns = await source.readSession(sessionId);
+    if (turns.length === 0) continue;
+    await rm(cacheEntryPath(intentsDir, cacheKey(turns, model)), { force: true });
+  }
 }
 
 /**

--- a/apps/ratel-mcp/src/ui/intents-routes.ts
+++ b/apps/ratel-mcp/src/ui/intents-routes.ts
@@ -216,11 +216,14 @@ function summarizeRunErrors(errors: Array<{ sessionId: string; message: string }
 }
 
 /**
- * POST /api/intents/run — manual trigger. With `sessionId`, analyzes just that
- * chat (always, ignoring due-checks). With `all: true`, re-analyzes every chat
- * (ignores the new-activity/recency filters). Otherwise analyzes only chats with
- * new activity since their last analysis (skips up-to-date chats so it doesn't
- * needlessly re-run the model). Returns immediately; watch `running` via GET /api/intents.
+ * POST /api/intents/run — manual trigger. With `sessionId`, analyzes just that one
+ * chat. Both bare "Run now" and `all: true` analyze EVERY captured chat (so the button
+ * is never a no-op once chats are up to date — re-running is exactly what the user is
+ * asking for); they differ only in caching: "Run now" reuses cached extractions (fast,
+ * re-extracts only changed/uncached chats), while `all` forces fresh extraction. The
+ * cache makes "analyze everything" cheap for unchanged chats, so there's no separate
+ * incremental path here — that lives in the background scheduler. Returns immediately;
+ * watch `running` via GET /api/intents.
  */
 export async function runIntentsRoute(
   ctx: HandlerCtx,
@@ -228,13 +231,11 @@ export async function runIntentsRoute(
 ): Promise<ApiResponse> {
   const sessionId = typeof body.sessionId === "string" ? body.sessionId : undefined;
   const all = body.all === true;
-  // "Re-analyze all" forces fresh extraction (bypass cache); the incremental and
-  // per-chat paths keep using the cache for speed.
   const opts = sessionId
     ? { sessionId }
     : all
       ? { all: true, bypassCache: true }
-      : { everyNMessages: 1, onIdle: true };
+      : { all: true };
   const trigger = sessionId ? "session" : all ? "all" : "manual";
   const result = await startAnalysisRun(ctx, opts, trigger);
   return ok(result);

--- a/apps/ratel-mcp/src/ui/routes.ts
+++ b/apps/ratel-mcp/src/ui/routes.ts
@@ -30,9 +30,11 @@ import {
   activateSkills,
   deactivateSkills,
   defaultSkillManagePaths,
+  deleteManagedSkill,
   listManaged,
   type SkillSource,
 } from "../cli/skills/manage.js";
+import { recomputeIntentCoverage } from "../intents/coverage.js";
 
 export interface ApiResponse {
   status: number;
@@ -234,6 +236,8 @@ export async function activateSkillsRoute(
     source,
     logger: ctx.log,
   });
+  // Newly managed skills may now cover previously-gap intents.
+  await recomputeIntentCoverage(ctx.env, ctx.fs).catch(() => undefined);
   return ok({ moved: result.moved.map((m) => m.id), skipped: result.skipped });
 }
 
@@ -247,6 +251,8 @@ export async function deactivateSkillsRoute(
     ids,
     logger: ctx.log,
   });
+  // A skill that covered some intents is gone — those intents may be gaps again.
+  await recomputeIntentCoverage(ctx.env, ctx.fs).catch(() => undefined);
   return ok({ restored: result.restored.map((m) => m.id), skipped: result.skipped });
 }
 
@@ -277,6 +283,8 @@ export async function createSkillRoute(
   const contents = buildSkillMd({ name, description, tags, body: skillBody });
   await mkdir(skillDir, { recursive: true });
   await writeFile(join(skillDir, "SKILL.md"), contents, "utf8");
+  // A new skill may cover previously-uncovered intents.
+  await recomputeIntentCoverage(ctx.env, ctx.fs).catch(() => undefined);
   return ok({ created: name });
 }
 
@@ -315,7 +323,23 @@ export async function updateSkillRoute(
   const nextBody = stripBundledResources(body.body);
   const contents = rewriteSkillMd(found.raw, { description, tags, body: nextBody });
   await writeFileAtomic(found.filePath, contents);
+  // Editing a skill's description/tags changes what it matches.
+  await recomputeIntentCoverage(ctx.env, ctx.fs).catch(() => undefined);
   return ok({ updated: id });
+}
+
+/**
+ * Permanently delete a Ratel-managed skill (its `~/.ratel/skills/<id>` folder).
+ * Used for skills created in Ratel, which have no agent to restore to. Coverage
+ * is recomputed since a deleted skill may have covered some intents.
+ */
+export async function deleteSkillRoute(ctx: HandlerCtx, id: string): Promise<ApiResponse> {
+  const removed = await deleteManagedSkill(defaultSkillManagePaths(ctx.env.homeDir), id);
+  if (!removed) {
+    return { status: 404, body: { error: `unknown managed skill: ${id}`, isError: true } };
+  }
+  await recomputeIntentCoverage(ctx.env, ctx.fs).catch(() => undefined);
+  return ok({ deleted: id });
 }
 
 /**

--- a/apps/ratel-mcp/src/ui/server.ts
+++ b/apps/ratel-mcp/src/ui/server.ts
@@ -10,15 +10,25 @@ import type { AddressInfo } from "node:net";
 import { dirname, extname, join, normalize, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 import type { HandlerCtx } from "../cli/handlers/types.js";
+import { loadUserAnalysis } from "../intents/context.js";
+import { type CadenceScheduler, startCadenceScheduler } from "../intents/scheduler.js";
 import {
   clearIntentsRoute,
+  clearOfferJobRoute,
+  deleteChatRoute,
   deleteIntentRoute,
   getAnalysisSettings,
+  getChatRoute,
+  getChatsRoute,
   getIntents,
+  getObservabilityRoute,
   getSessionIntents,
+  listOfferJobsRoute,
   offerSkillRoute,
+  offerStatusRoute,
   putAnalysisSettings,
   runIntentsRoute,
+  startAnalysisRun,
 } from "./intents-routes.js";
 import {
   type ApiResponse,
@@ -80,10 +90,29 @@ export async function startUiServer(opts: StartUiServerOptions): Promise<UiServe
   const port = (server.address() as AddressInfo).port;
   const url = `http://${UI_HOST}:${port}/?t=${opts.token}`;
 
+  const scheduler = startCadenceScheduler({
+    tick: async () => {
+      const analysis = await loadUserAnalysis(opts.ctx.env, opts.ctx.fs);
+      if (analysis?.enabled === false) return;
+      const cadence = analysis?.cadence;
+      // Automatic runs are opt-in: the scheduler stays idle unless the user has
+      // enabled them in Settings. Manual "Run now" is unaffected by this flag.
+      if (cadence?.auto !== true) return;
+      await startAnalysisRun(
+        opts.ctx,
+        { everyNMessages: cadence.everyNMessages, onIdle: cadence.onIdle ?? false },
+        "cadence",
+      );
+    },
+    onError: (err) => {
+      opts.ctx.log(`cadence tick failed: ${(err as Error).message}`);
+    },
+  });
+
   return {
     url,
     port,
-    shutdown: () => closeServer(server),
+    shutdown: () => closeServer(server, scheduler),
   };
 }
 
@@ -208,6 +237,9 @@ async function route(
   if (method === "GET" && path === "/api/intents") {
     return getIntents(ctx);
   }
+  if (method === "GET" && path === "/api/intents/observability") {
+    return getObservabilityRoute(ctx);
+  }
   if (method === "POST" && path === "/api/intents/run") {
     const body = await readJsonBody(req);
     return runIntentsRoute(ctx, body);
@@ -230,9 +262,36 @@ async function route(
     const body = await readJsonBody(req);
     return putAnalysisSettings(ctx, body);
   }
+  if (method === "GET" && path === "/api/skills/offer/jobs") {
+    return listOfferJobsRoute(ctx);
+  }
+  if (method === "GET" && path === "/api/skills/offer/status") {
+    const intent = new URLSearchParams(req.url?.split("?")[1] ?? "").get("intent") ?? "";
+    return offerStatusRoute(ctx, intent);
+  }
   if (method === "POST" && path === "/api/skills/offer") {
     const body = await readJsonBody(req);
     return offerSkillRoute(ctx, body);
+  }
+  if (method === "DELETE" && path === "/api/skills/offer") {
+    const intent = new URLSearchParams(req.url?.split("?")[1] ?? "").get("intent") ?? "";
+    return clearOfferJobRoute(ctx, intent);
+  }
+
+  if (method === "GET" && path === "/api/chats") {
+    return getChatsRoute(ctx);
+  }
+  const chatMatch = /^\/api\/chats\/([^/]+)$/.exec(path);
+  if (chatMatch) {
+    const sessionId = decodeURIComponent(chatMatch[1]);
+    if (method === "GET") {
+      const limitParam = new URLSearchParams(req.url?.split("?")[1] ?? "").get("limit");
+      const limit = limitParam !== null ? Number(limitParam) : undefined;
+      return getChatRoute(ctx, sessionId, limit);
+    }
+    if (method === "DELETE") {
+      return deleteChatRoute(ctx, sessionId);
+    }
   }
 
   if (method === "POST" && path === "/api/import") {
@@ -295,7 +354,8 @@ function writePlain(res: ServerResponse, status: number, body: string): void {
   res.end(body);
 }
 
-function closeServer(server: Server): Promise<void> {
+function closeServer(server: Server, scheduler?: CadenceScheduler): Promise<void> {
+  scheduler?.stop();
   return new Promise((resolve) => {
     server.close(() => resolve());
   });

--- a/apps/ratel-mcp/src/ui/server.ts
+++ b/apps/ratel-mcp/src/ui/server.ts
@@ -11,6 +11,16 @@ import { dirname, extname, join, normalize, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 import type { HandlerCtx } from "../cli/handlers/types.js";
 import {
+  clearIntentsRoute,
+  deleteIntentRoute,
+  getAnalysisSettings,
+  getIntents,
+  getSessionIntents,
+  offerSkillRoute,
+  putAnalysisSettings,
+  runIntentsRoute,
+} from "./intents-routes.js";
+import {
   type ApiResponse,
   activateSkillsRoute,
   addServer,
@@ -20,6 +30,7 @@ import {
   authServer,
   createSkillRoute,
   deactivateSkillsRoute,
+  deleteSkillRoute,
   doImport,
   doLink,
   editServer,
@@ -162,6 +173,9 @@ async function route(
       const body = await readJsonBody(req);
       return updateSkillRoute(ctx, id, body);
     }
+    if (method === "DELETE") {
+      return deleteSkillRoute(ctx, id);
+    }
   }
   if (method === "POST" && path === "/api/open-file") {
     const body = await readJsonBody(req);
@@ -189,6 +203,36 @@ async function route(
   if (method === "POST" && authMatch) {
     const name = decodeURIComponent(authMatch[1]);
     return authServer(ctx, name);
+  }
+
+  if (method === "GET" && path === "/api/intents") {
+    return getIntents(ctx);
+  }
+  if (method === "POST" && path === "/api/intents/run") {
+    const body = await readJsonBody(req);
+    return runIntentsRoute(ctx, body);
+  }
+  if (method === "POST" && path === "/api/intents/delete") {
+    const body = await readJsonBody(req);
+    return deleteIntentRoute(ctx, body);
+  }
+  if (method === "POST" && path === "/api/intents/clear") {
+    return clearIntentsRoute(ctx);
+  }
+  const sessionIntentsMatch = /^\/api\/intents\/([^/]+)$/.exec(path);
+  if (method === "GET" && sessionIntentsMatch) {
+    return getSessionIntents(ctx, decodeURIComponent(sessionIntentsMatch[1]));
+  }
+  if (method === "GET" && path === "/api/analysis/settings") {
+    return getAnalysisSettings(ctx);
+  }
+  if (method === "PUT" && path === "/api/analysis/settings") {
+    const body = await readJsonBody(req);
+    return putAnalysisSettings(ctx, body);
+  }
+  if (method === "POST" && path === "/api/skills/offer") {
+    const body = await readJsonBody(req);
+    return offerSkillRoute(ctx, body);
   }
 
   if (method === "POST" && path === "/api/import") {

--- a/apps/ratel-mcp/src/ui/server.ts
+++ b/apps/ratel-mcp/src/ui/server.ts
@@ -192,8 +192,10 @@ async function route(
     const body = await readJsonBody(req);
     return deactivateSkillsRoute(ctx, body);
   }
+  // Note: `offer` is a reserved sub-path (skill-gen jobs), not a skill id — let it
+  // fall through to the /api/skills/offer* handlers below.
   const skillMatch = /^\/api\/skills\/([^/]+)$/.exec(path);
-  if (skillMatch) {
+  if (skillMatch && skillMatch[1] !== "offer") {
     const id = decodeURIComponent(skillMatch[1]);
     if (method === "GET") {
       return getSkill(ctx, id);

--- a/apps/ratel-mcp/src/ui/server.ts
+++ b/apps/ratel-mcp/src/ui/server.ts
@@ -29,6 +29,7 @@ import {
   putAnalysisSettings,
   runIntentsRoute,
   startAnalysisRun,
+  testExtractorRoute,
 } from "./intents-routes.js";
 import {
   type ApiResponse,
@@ -263,6 +264,10 @@ async function route(
   if (method === "PUT" && path === "/api/analysis/settings") {
     const body = await readJsonBody(req);
     return putAnalysisSettings(ctx, body);
+  }
+  if (method === "POST" && path === "/api/analysis/extractor/test") {
+    const body = await readJsonBody(req);
+    return testExtractorRoute(ctx, body);
   }
   if (method === "GET" && path === "/api/skills/offer/jobs") {
     return listOfferJobsRoute(ctx);

--- a/infra/claim-extractor/Dockerfile
+++ b/infra/claim-extractor/Dockerfile
@@ -1,0 +1,31 @@
+# ClaimExtractor sidecar for Linux + NVIDIA GPU (vLLM backend).
+#
+# This is the Docker/cloud path. On macOS, Docker cannot reach the Apple GPU —
+# use sidecar/run-apple-silicon.sh there instead.
+#
+# Build:  docker build -t ratel-claim-extractor infra/claim-extractor
+# Run:    docker run --gpus all -p 8723:8723 ratel-claim-extractor
+FROM nvidia/cuda:12.4.1-runtime-ubuntu22.04
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    PIP_NO_CACHE_DIR=1 \
+    CLAIM_EXTRACTOR_BACKEND=vllm \
+    CLAIM_EXTRACTOR_MODEL=principled-intelligence/claim-extractor-4B-q-2605 \
+    HF_HOME=/models
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends python3 python3-pip python3-venv \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+COPY sidecar/requirements.txt ./requirements.txt
+RUN pip3 install --upgrade pip \
+    && pip3 install -r requirements.txt \
+    && pip3 install "orbitals[claim-extractor-vllm]"
+# (orbitals[claim-extractor-vllm] is a valid extra; the hf extra is the Apple-Silicon path.)
+
+COPY sidecar/server.py ./server.py
+
+EXPOSE 8723
+# Bind 0.0.0.0 inside the container; publish to the host with -p.
+CMD ["uvicorn", "server:app", "--host", "0.0.0.0", "--port", "8723"]

--- a/infra/claim-extractor/README.md
+++ b/infra/claim-extractor/README.md
@@ -109,6 +109,14 @@ when a `username` is set, else `bearer`. (An older `"provider": "cloud"` is stil
 accepted and behaves identically.) With no endpoint configured, Ratel falls back to
 the model-free `naive` extractor.
 
+A long chat is split into size-bounded chunks before being sent, so it can't overflow
+the model's context window (which otherwise returns a fast 500); the per-chunk claims
+and intents are merged and de-duplicated. The chunk budget is the JSON size of one
+request's `conversation` and defaults to a conservative value tuned for the hosted
+model. Raise it for a sidecar with a larger window via the optional
+`"maxRequestChars": <positive integer>` under `extractor`. Transient `5xx`/network
+failures are retried with backoff; a `4xx` (and timeouts) are not.
+
 ## Mock mode
 
 Every deployment honors `CLAIM_EXTRACTOR_MOCK=1` (or `CLAIM_EXTRACTOR_BACKEND=mock`),

--- a/infra/claim-extractor/README.md
+++ b/infra/claim-extractor/README.md
@@ -1,0 +1,129 @@
+# ClaimExtractor sidecar
+
+Runs [`principled-intelligence/claim-extractor-4B-q-2605`](https://huggingface.co/principled-intelligence/claim-extractor-4B-q-2605)
+— a Qwen3.5-4B fine-tune (Apache-2.0) that turns conversation turns into structured
+**claims** and **intents** — as a small HTTP service that Ratel's intent pipeline calls.
+
+Ratel never imports the model. It only holds an HTTP client + an endpoint URL, so
+the *same* Ratel config works whether the model runs as a local sidecar, in Docker
+on a GPU box, or behind a cloud endpoint. Pick a deployment, point Ratel at it.
+
+## The contract
+
+```
+POST {endpoint}/v1/extract
+  { "model"?: str,
+    "messages": [{ "role": "user"|"assistant", "content": str }],
+    "service_description"?: object }
+->
+  { "claims":  [{ "subtype": "factoid"|"capability"|"user_assertion"|"unverifiable",
+                  "content": str, "evidences"?: [str] }],
+    "intents": [{ "content": str, "evidences"?: [str] }] }
+```
+
+`GET /health` returns `{ status, model, backend }`.
+
+## Deployments
+
+### 1. Apple Silicon (local, recommended on a Mac)
+
+Docker on macOS can't pass through the Apple GPU, so the Mac path is a **native
+sidecar** using `transformers` on MPS. Prefer the **2B variant** for latency.
+
+```bash
+cd infra/claim-extractor/sidecar
+./run-apple-silicon.sh                 # downloads the model on first run
+# or, to verify wiring with no model download:
+CLAIM_EXTRACTOR_MOCK=1 ./run-apple-silicon.sh
+```
+
+### 2. Docker + NVIDIA GPU (Linux / cloud)
+
+```bash
+docker compose -f infra/claim-extractor/docker-compose.yml up --build
+```
+
+Needs the NVIDIA Container Toolkit. The image uses the **vLLM** backend.
+
+### 3. Remote / cloud endpoint
+
+Run either of the above on a remote host (or a managed service) and point Ratel at
+its URL with an `apiKey`. Nothing else changes.
+
+## Point Ratel at it
+
+In the UI: **Intents → Settings → Extractor**. Or in `~/.ratel/config.json`:
+
+```json
+{
+  "analysis": {
+    "enabled": true,
+    "extractor": {
+      "provider": "http",
+      "endpoint": "http://127.0.0.1:8723",
+      "model": "claim-extractor-4B"
+    }
+  }
+}
+```
+
+For a remote/cloud endpoint, set `"provider": "cloud"` and add `"apiKey": "…"` (the
+key is sent as a bearer token and stored masked in the UI). With no endpoint
+configured, Ratel falls back to the model-free `naive` extractor.
+
+## Mock mode
+
+Every deployment honors `CLAIM_EXTRACTOR_MOCK=1` (or `CLAIM_EXTRACTOR_BACKEND=mock`),
+which returns deterministic output (one intent per user turn) with no model. Use it
+to validate the full Ratel → sidecar → Intents tab path on any machine before
+pulling multi-GB weights.
+
+## Configuration
+
+| Env var | Default | Purpose |
+|---|---|---|
+| `CLAIM_EXTRACTOR_BACKEND` | `auto` | `mock` \| `transformers` \| `vllm` \| `auto` |
+| `CLAIM_EXTRACTOR_MODEL` | `principled-intelligence/claim-extractor-4B-q-2605` | model id (swap for the 2B variant) |
+| `CLAIM_EXTRACTOR_MOCK` | `0` | `1` forces mock output |
+| `CLAIM_EXTRACTOR_DEVICE` | unset | `cpu` (stable, slower) or `mps` (Apple GPU); hf backend only |
+| `CLAIM_EXTRACTOR_MAX_TOKENS` | `4096` | max generated tokens (hf); lower = faster, raise only if output truncates |
+| `CLAIM_EXTRACTOR_INTENTS_ONLY` | `0` | `1` skips claim extraction (~2x faster; intents only) |
+| `PORT` | `8723` | sidecar port (Apple Silicon script) |
+
+## Troubleshooting
+
+**Sidecar aborts mid-run on Apple Silicon** with a Metal assertion like
+`A command encoder is already encoding to this command buffer` (often after a
+successful `200`):
+
+This is a PyTorch **MPS (Apple GPU) bug**, not a config problem — the model falls
+back to a torch implementation of linear attention whose MPS ops are unstable,
+and the Metal abort is a hard `SIGABRT` Python can't catch. Mitigations, in order:
+
+1. The sidecar already **serializes inference** (one GPU call at a time), which
+   removes the most common trigger. Make sure you're not running two sidecars on
+   the same model.
+2. If it still crashes, **run on CPU** — stable, just slower:
+   ```bash
+   CLAIM_EXTRACTOR_DEVICE=cpu ./run-apple-silicon.sh
+   ```
+3. Or try the lighter **2B variant**, which is gentler on MPS:
+   ```bash
+   CLAIM_EXTRACTOR_MODEL=principled-intelligence/claim-extractor-2B-q-2605 ./run-apple-silicon.sh
+   ```
+
+`NVML initialization failed` and the `flash-linear-attention` / `causal-conv1d`
+notices are harmless on a Mac (no NVIDIA GPU; the fast CUDA kernels just aren't
+used).
+
+**Extraction is slow / Ratel reports "intent extractor timed out":**
+The model is working (the sidecar logs show weight loading + generation), just
+slow on MPS/CPU. The sidecar already caps generation at
+`CLAIM_EXTRACTOR_MAX_TOKENS=4096`; lower it further (e.g. `2048`) and/or set
+`CLAIM_EXTRACTOR_INTENTS_ONLY=1` for ~2x faster runs. The lighter **2B variant**
+helps most. Ratel itself no longer blocks on the run — the Intents tab shows a
+live "Analyzing…" indicator while it finishes in the background.
+
+> The real backends load the model through the `orbitals` package. If its API
+> differs from the version pinned here, adjust `_extract_with_orbitals` in
+> `sidecar/server.py` — that's the only coupling point.

--- a/infra/claim-extractor/README.md
+++ b/infra/claim-extractor/README.md
@@ -10,18 +10,29 @@ on a GPU box, or behind a cloud endpoint. Pick a deployment, point Ratel at it.
 
 ## The contract
 
+Ratel speaks the **orbitals claim-extractor** contract, so a local sidecar and the
+hosted Principled endpoint are interchangeable — switching is just the `endpoint`
+URL (and auth):
+
 ```
-POST {endpoint}/v1/extract
-  { "model"?: str,
-    "messages": [{ "role": "user"|"assistant", "content": str }],
-    "service_description"?: object }
+POST {endpoint}/orbitals/claim-extractor/extract
+  { "conversation": [{ "role": "user"|"assistant", "content": str }],
+    "model"?: str,
+    "skip_evidences"?: bool,
+    "ai_service_description"?: object }
 ->
-  { "claims":  [{ "subtype": "factoid"|"capability"|"user_assertion"|"unverifiable",
-                  "content": str, "evidences"?: [str] }],
-    "intents": [{ "content": str, "evidences"?: [str] }] }
+  { "extractions": {
+      "claims":  [{ "subtype": "factoid"|"capability"|"user_assertion"|"unverifiable",
+                    "content": str, "evidences"?: [str] }],
+      "intents": [{ "content": str, "evidences"?: [str] }] },
+    "model": str, "usage": {…}, "time_taken": float }
 ```
 
-`GET /health` returns `{ status, model, backend }`.
+`GET /health` returns `{ status, … }`. The legacy `POST /v1/extract` route (body
+`messages`, an unwrapped `{ claims, intents }` response) is still served for older
+clients. `skip_evidences`/`model` are honored by the hosted endpoint; the sidecar
+serves the single model + settings it was launched with and ignores per-request
+overrides.
 
 ## Deployments
 
@@ -45,14 +56,21 @@ docker compose -f infra/claim-extractor/docker-compose.yml up --build
 
 Needs the NVIDIA Container Toolkit. The image uses the **vLLM** backend.
 
-### 3. Remote / cloud endpoint
+### 3. Remote / hosted endpoint
 
-Run either of the above on a remote host (or a managed service) and point Ratel at
-its URL with an `apiKey`. Nothing else changes.
+Run either of the above on a remote host, or point Ratel at the hosted Principled
+endpoint. Only the URL and auth change — the contract is identical. Auth is either
+`bearer` (a token) or `basic` (username + password):
+
+```bash
+curl https://orbitals-preview.principled.app/health \
+  -H 'authorization: Basic <base64(username:password)>'
+```
 
 ## Point Ratel at it
 
-In the UI: **Intents → Settings → Extractor**. Or in `~/.ratel/config.json`:
+In the UI: **Intents → Settings → Extractor** (use **Test connection** to verify
+the endpoint + credentials against `/health`). Or in `~/.ratel/config.json`:
 
 ```json
 {
@@ -60,16 +78,36 @@ In the UI: **Intents → Settings → Extractor**. Or in `~/.ratel/config.json`:
     "enabled": true,
     "extractor": {
       "provider": "http",
-      "endpoint": "http://127.0.0.1:8723",
-      "model": "claim-extractor-4B"
+      "endpoint": "http://127.0.0.1:8723"
     }
   }
 }
 ```
 
-For a remote/cloud endpoint, set `"provider": "cloud"` and add `"apiKey": "…"` (the
-key is sent as a bearer token and stored masked in the UI). With no endpoint
-configured, Ratel falls back to the model-free `naive` extractor.
+A local sidecar and a hosted endpoint use the **same** `http` provider — only the
+URL and auth differ. A local sidecar needs no auth; a hosted endpoint adds the auth
+fields — `basic` (with `username` + the password in `apiKey`) or `bearer` (token in
+`apiKey`):
+
+```json
+{
+  "analysis": {
+    "extractor": {
+      "provider": "http",
+      "endpoint": "https://orbitals-preview.principled.app",
+      "authScheme": "basic",
+      "username": "ratel",
+      "apiKey": "<password>"
+    }
+  }
+}
+```
+
+`apiKey` is the bearer token **or** the basic-auth password; it's stored masked in
+the UI (`username` is not secret). `authScheme` is optional — it defaults to `basic`
+when a `username` is set, else `bearer`. (An older `"provider": "cloud"` is still
+accepted and behaves identically.) With no endpoint configured, Ratel falls back to
+the model-free `naive` extractor.
 
 ## Mock mode
 

--- a/infra/claim-extractor/docker-compose.yml
+++ b/infra/claim-extractor/docker-compose.yml
@@ -1,0 +1,34 @@
+# ClaimExtractor sidecar (Linux + NVIDIA GPU).
+#
+#   docker compose -f infra/claim-extractor/docker-compose.yml up --build
+#
+# Then point Ratel at it (Intents → Settings, or ~/.ratel/config.json):
+#   "analysis": { "extractor": { "provider": "http", "endpoint": "http://127.0.0.1:8723" } }
+#
+# Requires the NVIDIA Container Toolkit. On macOS there is no GPU passthrough —
+# use sidecar/run-apple-silicon.sh instead.
+services:
+  claim-extractor:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - "8723:8723"
+    environment:
+      CLAIM_EXTRACTOR_BACKEND: vllm
+      CLAIM_EXTRACTOR_MODEL: principled-intelligence/claim-extractor-4B-q-2605
+      # Set to "1" to run without the model (wiring check only).
+      CLAIM_EXTRACTOR_MOCK: "0"
+    volumes:
+      # Cache model weights across restarts.
+      - claim-extractor-models:/models
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: 1
+              capabilities: [gpu]
+
+volumes:
+  claim-extractor-models:

--- a/infra/claim-extractor/sidecar/requirements.txt
+++ b/infra/claim-extractor/sidecar/requirements.txt
@@ -1,0 +1,18 @@
+# HTTP layer (always required)
+fastapi>=0.110
+uvicorn[standard]>=0.29
+pydantic>=2.6
+
+# Model backend — install ONE set depending on where you run:
+#
+#   Apple Silicon / CPU (the local sidecar path):
+#     pip install "orbitals[claim-extractor-hf]"
+#     # transformers + accelerate (→ torch) for the hf backend, runs on MPS
+#
+#   Linux + NVIDIA GPU (the Docker image installs this):
+#     pip install "orbitals[claim-extractor-vllm]"
+#
+# Left commented so `pip install -r requirements.txt` works in MOCK mode with no
+# heavy ML deps. Uncomment the line that matches your machine:
+# orbitals[claim-extractor-hf]
+# orbitals[claim-extractor-vllm]

--- a/infra/claim-extractor/sidecar/run-apple-silicon.sh
+++ b/infra/claim-extractor/sidecar/run-apple-silicon.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Run the ClaimExtractor sidecar locally on Apple Silicon (transformers + MPS).
+#
+# Docker on macOS cannot pass through the Apple GPU, so the Mac path is this
+# native sidecar (not the Docker image). Recommend the 2B variant for latency.
+#
+# All tunables live in settings.json (model, backend, device, intentsOnly,
+# maxTokens, maxMessages, port). Edit it once; this script reads it directly.
+# Any CLAIM_EXTRACTOR_* / PORT env var still overrides the file for one run.
+#
+# Usage:
+#   ./run-apple-silicon.sh            # real model (downloads on first run)
+#   CLAIM_EXTRACTOR_MOCK=1 ./run-apple-silicon.sh   # mock, no model — wiring check
+set -euo pipefail
+cd "$(dirname "$0")"
+
+# Let PyTorch fall back to CPU for any op MPS doesn't implement yet.
+export PYTORCH_ENABLE_MPS_FALLBACK="${PYTORCH_ENABLE_MPS_FALLBACK:-1}"
+
+# orbitals requires Python >=3.10; the macOS system python3 is often older.
+# Pick the newest available >=3.10 interpreter (override with PYTHON=...).
+if [ -z "${PYTHON:-}" ]; then
+  for cand in python3.12 python3.13 python3.11 python3.10 python3; do
+    if command -v "$cand" >/dev/null 2>&1 &&
+      "$cand" -c 'import sys; sys.exit(0 if sys.version_info[:2] >= (3, 10) else 1)'; then
+      PYTHON="$cand"
+      break
+    fi
+  done
+fi
+if [ -z "${PYTHON:-}" ]; then
+  echo "Need Python >=3.10 (orbitals requires it). Try: brew install python@3.12" >&2
+  exit 1
+fi
+echo "Using $("$PYTHON" --version) ($PYTHON)"
+
+# Load settings.json into the environment (env vars already set still win).
+# settings.py is stdlib-only, so the system interpreter can read it pre-venv.
+eval "$("$PYTHON" settings.py --exports)"
+PORT="${PORT:-8723}"
+
+if [ ! -d ".venv" ]; then
+  "$PYTHON" -m venv .venv
+fi
+# shellcheck disable=SC1091
+source .venv/bin/activate
+pip install --quiet --upgrade pip
+pip install --quiet -r requirements.txt
+if [ "${CLAIM_EXTRACTOR_MOCK:-}" != "1" ]; then
+  # claim-extractor-hf pulls transformers + accelerate (→ torch) for the hf backend.
+  pip install "orbitals[claim-extractor-hf]"
+fi
+
+echo "ClaimExtractor sidecar on http://127.0.0.1:${PORT}"
+echo "  backend=${CLAIM_EXTRACTOR_BACKEND:-?} model=${CLAIM_EXTRACTOR_MODEL:-?} mock=${CLAIM_EXTRACTOR_MOCK:-0}"
+echo "  intentsOnly=${CLAIM_EXTRACTOR_INTENTS_ONLY:-0} maxTokens=${CLAIM_EXTRACTOR_MAX_TOKENS:-?} maxMessages=${CLAIM_EXTRACTOR_MAX_MESSAGES:-0} device=${CLAIM_EXTRACTOR_DEVICE:-auto}"
+echo "Point Ratel at it:  analysis.extractor = { provider: \"http\", endpoint: \"http://127.0.0.1:${PORT}\" }"
+exec uvicorn server:app --host 127.0.0.1 --port "${PORT}"

--- a/infra/claim-extractor/sidecar/server.py
+++ b/infra/claim-extractor/sidecar/server.py
@@ -23,8 +23,10 @@ official inference library). The exact orbitals call may differ by version — t
 
 from __future__ import annotations
 
+import logging
 import sys
 import threading
+import time
 from pathlib import Path
 from typing import Any, Optional
 
@@ -56,6 +58,9 @@ class ExtractRequest(BaseModel):
 
 
 app = FastAPI(title="Ratel ClaimExtractor sidecar")
+# Log through uvicorn's logger so our progress lines show up next to the access
+# log (the "POST /v1/extract 200 OK" lines), not swallowed by the root logger.
+logger = logging.getLogger("uvicorn.error")
 _extractor: Any = None
 # Serializes inference: MPS (Apple GPU) aborts the process with a Metal
 # command-buffer assertion if two model calls touch the GPU concurrently.
@@ -69,6 +74,7 @@ def health() -> dict[str, Any]:
         "model": MODEL_ID,
         "backend": "mock" if MOCK else BACKEND,
         "intentsOnly": bool(SETTINGS["intentsOnly"]),
+        "skipEvidences": bool(SETTINGS["skipEvidences"]),
         "maxTokens": int(SETTINGS["maxTokens"]),
         "maxMessages": MAX_MESSAGES,
         "device": SETTINGS["device"],
@@ -81,19 +87,63 @@ def extract(req: ExtractRequest) -> dict[str, Any]:
     # transcripts are the main driver of MPS latency/timeouts, and recent turns
     # carry the live intent; 0 disables the cap.
     messages = limit_messages(req.messages, MAX_MESSAGES)
+    capped = "" if len(messages) == len(req.messages) else f" (capped from {len(req.messages)})"
+    logger.info(
+        "extract: %d messages%s | model=%s evidence=%s intentsOnly=%s maxTokens=%s",
+        len(messages),
+        capped,
+        MODEL_ID,
+        "on" if not SETTINGS["skipEvidences"] else "off",
+        bool(SETTINGS["intentsOnly"]),
+        int(SETTINGS["maxTokens"]) or "∞",
+    )
     if MOCK:
         return _extract_mock(messages)
+    started = time.monotonic()
     try:
         # One inference at a time — see _extract_lock (MPS is not concurrency-safe).
         with _extract_lock:
-            return _normalize(_extract_with_orbitals(messages, req.service_description))
+            result = _extract_with_orbitals(messages, req.service_description)
+        normalized = _normalize(result)
+        usage = _attr(result, "usage")
+        logger.info(
+            "extract done in %.1fs: %d intents, %d claims (completion_tokens=%s)",
+            time.monotonic() - started,
+            len(normalized["intents"]),
+            len(normalized["claims"]),
+            _attr(usage, "completion_tokens"),
+        )
+        _warn_if_suspect(result, normalized)
+        return normalized
     except Exception as e:  # surface the cause; this is a local dev sidecar
-        import logging
-
-        logging.exception("extraction failed")
+        logger.exception("extract failed after %.1fs", time.monotonic() - started)
         from fastapi import HTTPException
 
         raise HTTPException(status_code=500, detail=f"{type(e).__name__}: {e}") from e
+
+
+def _warn_if_suspect(result: Any, normalized: dict[str, Any]) -> None:
+    """Surface the silent failure mode: the model's JSON truncates at the token
+    cap, orbitals returns nothing, and the run shows 0 intents with no error. Log
+    a clear hint when the output hit the cap, or when a run came back empty."""
+    usage = _attr(result, "usage")
+    completion = _attr(usage, "completion_tokens")
+    max_new = int(SETTINGS["maxTokens"])
+    empty = not normalized["intents"] and not normalized["claims"]
+    if max_new > 0 and isinstance(completion, int) and completion >= max_new:
+        logger.warning(
+            "extraction hit maxTokens=%d (completion_tokens=%d): the model's JSON was likely "
+            "truncated, so intents/claims may be empty or partial. Raise maxTokens (0 = no cap) "
+            "or set skipEvidences=true.",
+            max_new,
+            completion,
+        )
+    elif empty:
+        logger.info(
+            "extraction returned 0 intents and 0 claims (completion_tokens=%s). The window may "
+            "genuinely contain no intents, or the output truncated — check maxTokens.",
+            completion,
+        )
 
 
 # orbitals backends: "hf" (transformers, incl. Apple Silicon MPS) or "vllm" (CUDA GPU).
@@ -129,9 +179,11 @@ def _get_extractor() -> Any:
             extra["do_sample"] = False
             # Cap generation: extraction output is small (a short JSON), and the
             # orbitals default of 20k new tokens is the main cause of slow MPS/CPU
-            # inference + timeouts. Raise settings.maxTokens only if outputs get
-            # truncated.
-            extra["max_new_tokens"] = int(SETTINGS["maxTokens"])
+            # inference + timeouts. settings.maxTokens caps generation; 0 = no cap
+            # (let orbitals use its full default — needed for evidence-heavy output,
+            # but slow and may exceed the client's request timeout).
+            if int(SETTINGS["maxTokens"]) > 0:
+                extra["max_new_tokens"] = int(SETTINGS["maxTokens"])
             # Optional device pin: settings.device="cpu" avoids MPS instability
             # (slower but crash-free); "mps" forces the Apple GPU. None lets
             # transformers pick (MPS when available).
@@ -141,6 +193,10 @@ def _get_extractor() -> Any:
         # the UI keys off). Toggle with settings.intentsOnly.
         if SETTINGS["intentsOnly"]:
             extra["intents_only"] = True
+        # orbitals defaults skip_evidences=True (faster). We default it False so the
+        # model emits verbatim evidence quotes (the UI's "proof" view); flip via
+        # settings.skipEvidences for the fastest runs.
+        extra["skip_evidences"] = bool(SETTINGS["skipEvidences"])
         _extractor = ClaimExtractor(backend=backend, model=MODEL_ID, **extra)
     return _extractor
 
@@ -162,20 +218,60 @@ _SUBTYPE_MAP = {
 
 def _normalize(result: Any) -> dict[str, Any]:
     """Coerce an orbitals ClaimExtractorOutput into the wire contract."""
-    extractions = getattr(result, "extractions", result)
+    # The result may be an object with `.extractions` (the orbitals output) or a
+    # plain dict; `_attr` reads both. Fall back to `result` itself when there's no
+    # wrapper (i.e. it already holds claims/intents).
+    extractions = _attr(result, "extractions")
+    if extractions is None:
+        extractions = result
     claims = []
     for c in _attr(extractions, "claims") or []:
         raw = _attr(c, "subtype")
         subtype = _SUBTYPE_MAP.get(str(getattr(raw, "value", raw)).strip().lower())
         content = _attr(c, "content")
         if subtype and content:
-            claims.append({"subtype": subtype, "content": str(content)})
+            claim: dict[str, Any] = {"subtype": subtype, "content": str(content)}
+            ev = _evidences(c)
+            if ev:
+                claim["evidences"] = ev
+            claims.append(claim)
     intents = []
     for i in _attr(extractions, "intents") or []:
         content = _attr(i, "content")
         if content:
-            intents.append({"content": str(content)})
+            intent: dict[str, Any] = {"content": str(content)}
+            ev = _evidences(i)
+            if ev:
+                intent["evidences"] = ev
+            intents.append(intent)
     return {"claims": claims, "intents": intents}
+
+
+def _evidences(obj: Any) -> list[str]:
+    """Pull supporting evidence spans off a claim/intent as a list of strings.
+
+    The orbitals output may attach evidence under ``evidences`` (or ``evidence``),
+    and each item may be a plain string or an object carrying the span text under
+    one of several field names. Anything that can't be read as text is skipped.
+    """
+    raw = _attr(obj, "evidences")
+    if raw is None:
+        raw = _attr(obj, "evidence")
+    out: list[str] = []
+    for e in raw or []:
+        if isinstance(e, str):
+            text: Any = e
+        else:
+            text = (
+                _attr(e, "text")
+                or _attr(e, "content")
+                or _attr(e, "quote")
+                or _attr(e, "span")
+                or _attr(e, "evidence")
+            )
+        if text:
+            out.append(str(text).strip())
+    return out
 
 
 def _attr(obj: Any, name: str) -> Any:

--- a/infra/claim-extractor/sidecar/server.py
+++ b/infra/claim-extractor/sidecar/server.py
@@ -1,0 +1,200 @@
+"""HTTP sidecar exposing the ClaimExtractor model over Ratel's extractor contract.
+
+Ratel's `HttpIntentExtractor` always speaks one contract, regardless of where the
+model runs (Apple-Silicon sidecar, Docker+GPU box, or a remote/cloud endpoint):
+
+    POST /v1/extract
+      { "model"?: str,
+        "messages": [{ "role": "user"|"assistant", "content": str }, ...],
+        "service_description"?: object }
+    -> { "claims":  [{ "subtype": str, "content": str, "evidences"?: [str] }, ...],
+         "intents": [{ "content": str, "evidences"?: [str] }, ...] }
+
+Backends (set CLAIM_EXTRACTOR_BACKEND):
+  - mock          deterministic, no model — verify Ratel<->sidecar wiring anywhere
+  - transformers  HuggingFace transformers (Apple Silicon: device=mps; CPU fallback)
+  - vllm          vLLM (Linux + CUDA GPU; used by the Docker image)
+  - auto          mock if MOCK=1, else transformers
+
+The real backends load the model through the `orbitals` package (the model's
+official inference library). The exact orbitals call may differ by version — the
+`_extract_with_orbitals` helper is the single place to adjust if so.
+"""
+
+from __future__ import annotations
+
+import sys
+import threading
+from pathlib import Path
+from typing import Any, Optional
+
+from fastapi import FastAPI
+from pydantic import BaseModel
+
+# Import the shared settings loader whether the server is started from this
+# directory (uvicorn server:app) or imported from elsewhere (tests).
+sys.path.insert(0, str(Path(__file__).parent))
+from settings import limit_messages, load_settings  # noqa: E402
+
+# Resolved once at startup: defaults < settings.json < environment (see settings.py).
+SETTINGS = load_settings()
+MODEL_ID = SETTINGS["model"]
+BACKEND = str(SETTINGS["backend"]).lower()
+MOCK = bool(SETTINGS["mock"]) or BACKEND == "mock"
+MAX_MESSAGES = int(SETTINGS["maxMessages"])
+
+
+class Message(BaseModel):
+    role: str
+    content: str
+
+
+class ExtractRequest(BaseModel):
+    messages: list[Message]
+    model: Optional[str] = None
+    service_description: Optional[Any] = None
+
+
+app = FastAPI(title="Ratel ClaimExtractor sidecar")
+_extractor: Any = None
+# Serializes inference: MPS (Apple GPU) aborts the process with a Metal
+# command-buffer assertion if two model calls touch the GPU concurrently.
+_extract_lock = threading.Lock()
+
+
+@app.get("/health")
+def health() -> dict[str, Any]:
+    return {
+        "status": "ok",
+        "model": MODEL_ID,
+        "backend": "mock" if MOCK else BACKEND,
+        "intentsOnly": bool(SETTINGS["intentsOnly"]),
+        "maxTokens": int(SETTINGS["maxTokens"]),
+        "maxMessages": MAX_MESSAGES,
+        "device": SETTINGS["device"],
+    }
+
+
+@app.post("/v1/extract")
+def extract(req: ExtractRequest) -> dict[str, Any]:
+    # Send only the last N messages to the model (settings.maxMessages). Long
+    # transcripts are the main driver of MPS latency/timeouts, and recent turns
+    # carry the live intent; 0 disables the cap.
+    messages = limit_messages(req.messages, MAX_MESSAGES)
+    if MOCK:
+        return _extract_mock(messages)
+    try:
+        # One inference at a time — see _extract_lock (MPS is not concurrency-safe).
+        with _extract_lock:
+            return _normalize(_extract_with_orbitals(messages, req.service_description))
+    except Exception as e:  # surface the cause; this is a local dev sidecar
+        import logging
+
+        logging.exception("extraction failed")
+        from fastapi import HTTPException
+
+        raise HTTPException(status_code=500, detail=f"{type(e).__name__}: {e}") from e
+
+
+# orbitals backends: "hf" (transformers, incl. Apple Silicon MPS) or "vllm" (CUDA GPU).
+def _orbitals_backend() -> str:
+    if BACKEND == "vllm":
+        return "vllm"
+    if BACKEND in {"hf", "transformers", "mlx", "mps"}:
+        return "hf"
+    try:
+        import torch  # type: ignore
+
+        if torch.cuda.is_available():
+            return "vllm"
+    except Exception:
+        pass
+    return "hf"
+
+
+def _get_extractor() -> Any:
+    global _extractor
+    if _extractor is None:
+        # Official inference package for this model:
+        #   pip install "orbitals[claim-extractor-hf]"    # Apple Silicon / CPU (backend hf)
+        #   pip install "orbitals[claim-extractor-vllm]"  # CUDA GPU (backend vllm)
+        # ClaimExtractor is exported from the submodule, not the namespace root.
+        from orbitals.claim_extractor import ClaimExtractor  # type: ignore
+
+        # API (orbitals): ClaimExtractor(backend, model) then .extract(conversation, ...).
+        backend = _orbitals_backend()
+        extra: dict[str, Any] = {}
+        if backend == "hf":
+            # Greedy decoding → stable, repeatable extractions (no reworded dupes).
+            extra["do_sample"] = False
+            # Cap generation: extraction output is small (a short JSON), and the
+            # orbitals default of 20k new tokens is the main cause of slow MPS/CPU
+            # inference + timeouts. Raise settings.maxTokens only if outputs get
+            # truncated.
+            extra["max_new_tokens"] = int(SETTINGS["maxTokens"])
+            # Optional device pin: settings.device="cpu" avoids MPS instability
+            # (slower but crash-free); "mps" forces the Apple GPU. None lets
+            # transformers pick (MPS when available).
+            if SETTINGS["device"]:
+                extra["device"] = SETTINGS["device"]
+        # Skip claim extraction for ~2x faster intents-only runs (intents are what
+        # the UI keys off). Toggle with settings.intentsOnly.
+        if SETTINGS["intentsOnly"]:
+            extra["intents_only"] = True
+        _extractor = ClaimExtractor(backend=backend, model=MODEL_ID, **extra)
+    return _extractor
+
+
+def _extract_with_orbitals(messages: list[Message], service_description: Any = None) -> Any:
+    extractor = _get_extractor()
+    conversation = [{"role": m.role, "content": m.content} for m in messages]
+    return extractor.extract(conversation, ai_service_description=service_description)
+
+
+# orbitals subtypes are Title Case; map to the wire contract's lowercase_underscore form.
+_SUBTYPE_MAP = {
+    "factoid": "factoid",
+    "capability": "capability",
+    "user assertion": "user_assertion",
+    "unverifiable": "unverifiable",
+}
+
+
+def _normalize(result: Any) -> dict[str, Any]:
+    """Coerce an orbitals ClaimExtractorOutput into the wire contract."""
+    extractions = getattr(result, "extractions", result)
+    claims = []
+    for c in _attr(extractions, "claims") or []:
+        raw = _attr(c, "subtype")
+        subtype = _SUBTYPE_MAP.get(str(getattr(raw, "value", raw)).strip().lower())
+        content = _attr(c, "content")
+        if subtype and content:
+            claims.append({"subtype": subtype, "content": str(content)})
+    intents = []
+    for i in _attr(extractions, "intents") or []:
+        content = _attr(i, "content")
+        if content:
+            intents.append({"content": str(content)})
+    return {"claims": claims, "intents": intents}
+
+
+def _attr(obj: Any, name: str) -> Any:
+    if isinstance(obj, dict):
+        return obj.get(name)
+    return getattr(obj, name, None)
+
+
+def _extract_mock(messages: list[Message]) -> dict[str, Any]:
+    """Deterministic stand-in: one intent per user turn, plus a sample claim.
+    Lets you validate the whole pipeline before downloading a multi-GB model."""
+    intents = [
+        {"content": m.content.strip()}
+        for m in messages
+        if m.role == "user" and m.content.strip()
+    ]
+    claims = []
+    if intents:
+        claims.append(
+            {"subtype": "user_assertion", "content": f"User is working on: {intents[0]['content']}"}
+        )
+    return {"claims": claims, "intents": intents}

--- a/infra/claim-extractor/sidecar/server.py
+++ b/infra/claim-extractor/sidecar/server.py
@@ -1,14 +1,22 @@
 """HTTP sidecar exposing the ClaimExtractor model over Ratel's extractor contract.
 
-Ratel's `HttpIntentExtractor` always speaks one contract, regardless of where the
-model runs (Apple-Silicon sidecar, Docker+GPU box, or a remote/cloud endpoint):
+Ratel's `HttpIntentExtractor` speaks the orbitals claim-extractor contract, so the
+same client serves every deployment (Apple-Silicon sidecar, Docker+GPU box, or the
+hosted Principled endpoint) — only the URL and auth differ:
 
-    POST /v1/extract
-      { "model"?: str,
-        "messages": [{ "role": "user"|"assistant", "content": str }, ...],
-        "service_description"?: object }
-    -> { "claims":  [{ "subtype": str, "content": str, "evidences"?: [str] }, ...],
-         "intents": [{ "content": str, "evidences"?: [str] }, ...] }
+    POST /orbitals/claim-extractor/extract
+      { "conversation": [{ "role": "user"|"assistant", "content": str }, ...],
+        "model"?: str,
+        "skip_evidences"?: bool,
+        "ai_service_description"?: object }
+    -> { "extractions": { "claims":  [{ "subtype": str, "content": str, "evidences"?: [str] }, ...],
+                          "intents": [{ "content": str, "evidences"?: [str] }, ...] },
+         "model": str, "usage": { ... }, "time_taken": float }
+
+`skip_evidences`/`model` are honored by the hosted endpoint; the sidecar serves the
+single model + settings it was launched with (settings.json / CLAIM_EXTRACTOR_*) and
+ignores per-request overrides. The legacy `POST /v1/extract` route (body `messages`,
+unwrapped `{claims, intents}` response) remains for older clients.
 
 Backends (set CLAIM_EXTRACTOR_BACKEND):
   - mock          deterministic, no model — verify Ratel<->sidecar wiring anywhere
@@ -28,7 +36,7 @@ import sys
 import threading
 import time
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, Optional, Union
 
 from fastapi import FastAPI
 from pydantic import BaseModel
@@ -52,9 +60,22 @@ class Message(BaseModel):
 
 
 class ExtractRequest(BaseModel):
+    """Legacy /v1/extract body."""
+
     messages: list[Message]
     model: Optional[str] = None
     service_description: Optional[Any] = None
+
+
+class OrbitalsExtractRequest(BaseModel):
+    """orbitals claim-extractor body. `conversation` may be a list of messages, a
+    single message, or a bare string; `skip_evidences`/`model` are accepted for
+    contract parity but ignored here (the sidecar serves its configured model)."""
+
+    conversation: Union[list[Message], Message, str]
+    ai_service_description: Optional[Any] = None
+    skip_evidences: Optional[bool] = None
+    model: Optional[str] = None
 
 
 app = FastAPI(title="Ratel ClaimExtractor sidecar")
@@ -83,14 +104,50 @@ def health() -> dict[str, Any]:
 
 @app.post("/v1/extract")
 def extract(req: ExtractRequest) -> dict[str, Any]:
+    """Legacy contract: returns the unwrapped ``{claims, intents}`` directly."""
+    normalized, _usage, _elapsed = _run_extraction(req.messages, req.service_description)
+    return normalized
+
+
+@app.post("/orbitals/claim-extractor/extract")
+def orbitals_extract(req: OrbitalsExtractRequest) -> dict[str, Any]:
+    """orbitals contract: same extraction, wrapped in ``extractions`` with usage/timing
+    so Ratel can point at this sidecar or the hosted endpoint interchangeably."""
+    messages = _coerce_conversation(req.conversation)
+    normalized, usage, elapsed = _run_extraction(messages, req.ai_service_description)
+    return {
+        "extractions": {"intents": normalized["intents"], "claims": normalized["claims"]},
+        "model": MODEL_ID,
+        "usage": usage,
+        "time_taken": elapsed,
+    }
+
+
+def _coerce_conversation(conversation: Union[list[Message], Message, str]) -> list[Message]:
+    """Accept the orbitals ``conversation`` union and reduce it to a list of messages
+    (a bare string becomes a single user turn)."""
+    if isinstance(conversation, str):
+        return [Message(role="user", content=conversation)]
+    if isinstance(conversation, Message):
+        return [conversation]
+    return list(conversation)
+
+
+def _run_extraction(
+    messages: list[Message], service_description: Any
+) -> tuple[dict[str, Any], dict[str, int], float]:
+    """Shared extraction core for both routes. Returns the normalized
+    ``{claims, intents}`` plus a usage dict and the elapsed seconds."""
     # Send only the last N messages to the model (settings.maxMessages). Long
     # transcripts are the main driver of MPS latency/timeouts, and recent turns
     # carry the live intent; 0 disables the cap.
-    messages = limit_messages(req.messages, MAX_MESSAGES)
-    capped = "" if len(messages) == len(req.messages) else f" (capped from {len(req.messages)})"
+    capped_messages = limit_messages(messages, MAX_MESSAGES)
+    capped = (
+        "" if len(capped_messages) == len(messages) else f" (capped from {len(messages)})"
+    )
     logger.info(
         "extract: %d messages%s | model=%s evidence=%s intentsOnly=%s maxTokens=%s",
-        len(messages),
+        len(capped_messages),
         capped,
         MODEL_ID,
         "on" if not SETTINGS["skipEvidences"] else "off",
@@ -98,28 +155,43 @@ def extract(req: ExtractRequest) -> dict[str, Any]:
         int(SETTINGS["maxTokens"]) or "∞",
     )
     if MOCK:
-        return _extract_mock(messages)
+        return _extract_mock(capped_messages), _empty_usage(), 0.0
     started = time.monotonic()
     try:
         # One inference at a time — see _extract_lock (MPS is not concurrency-safe).
         with _extract_lock:
-            result = _extract_with_orbitals(messages, req.service_description)
+            result = _extract_with_orbitals(capped_messages, service_description)
         normalized = _normalize(result)
-        usage = _attr(result, "usage")
+        elapsed = time.monotonic() - started
+        usage = _usage_dict(_attr(result, "usage"))
         logger.info(
             "extract done in %.1fs: %d intents, %d claims (completion_tokens=%s)",
-            time.monotonic() - started,
+            elapsed,
             len(normalized["intents"]),
             len(normalized["claims"]),
-            _attr(usage, "completion_tokens"),
+            usage["completion_tokens"],
         )
         _warn_if_suspect(result, normalized)
-        return normalized
+        return normalized, usage, elapsed
     except Exception as e:  # surface the cause; this is a local dev sidecar
         logger.exception("extract failed after %.1fs", time.monotonic() - started)
         from fastapi import HTTPException
 
         raise HTTPException(status_code=500, detail=f"{type(e).__name__}: {e}") from e
+
+
+def _empty_usage() -> dict[str, int]:
+    return {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0}
+
+
+def _usage_dict(usage: Any) -> dict[str, int]:
+    """Coerce an orbitals usage object/dict into the wire contract's int fields."""
+    out = _empty_usage()
+    for key in out:
+        value = _attr(usage, key)
+        if isinstance(value, (int, float)):
+            out[key] = int(value)
+    return out
 
 
 def _warn_if_suspect(result: Any, normalized: dict[str, Any]) -> None:

--- a/infra/claim-extractor/sidecar/settings.json
+++ b/infra/claim-extractor/sidecar/settings.json
@@ -5,6 +5,7 @@
   "mock": false,
   "device": null,
   "intentsOnly": true,
-  "maxTokens": 2048,
-  "maxMessages": 40
+  "skipEvidences": true,
+  "maxTokens": 4096,
+  "maxMessages": 120
 }

--- a/infra/claim-extractor/sidecar/settings.json
+++ b/infra/claim-extractor/sidecar/settings.json
@@ -1,0 +1,10 @@
+{
+  "port": 8723,
+  "backend": "transformers",
+  "model": "principled-intelligence/claim-extractor-2B-q-2605",
+  "mock": false,
+  "device": null,
+  "intentsOnly": true,
+  "maxTokens": 2048,
+  "maxMessages": 40
+}

--- a/infra/claim-extractor/sidecar/settings.py
+++ b/infra/claim-extractor/sidecar/settings.py
@@ -1,0 +1,147 @@
+"""Single source of truth for the ClaimExtractor sidecar's runtime settings.
+
+Resolution order (highest priority first):
+
+  1. Environment variable (``CLAIM_EXTRACTOR_*`` / ``PORT``) — ad-hoc override
+  2. ``settings.json`` next to this file (or ``$CLAIM_EXTRACTOR_SETTINGS``)
+  3. Built-in :data:`DEFAULTS`
+
+Both ``server.py`` and ``run-apple-silicon.sh`` read their configuration through
+here, so the file is set once and honored everywhere. The script consumes the
+``--exports`` form (``eval``-able ``export`` lines); the server imports
+:func:`load_settings` directly.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shlex
+from pathlib import Path
+from typing import Any
+
+# Built-in defaults. Tuned for the local Apple-Silicon path: intents-only and a
+# capped output/transcript keep MPS inference fast and well under the client's
+# 5-minute timeout. Override any of these in settings.json.
+DEFAULTS: dict[str, Any] = {
+    "port": 8723,
+    "backend": "transformers",  # mock | transformers/hf | vllm | auto
+    "model": "principled-intelligence/claim-extractor-4B-q-2605",
+    "mock": False,
+    "device": None,  # None → let transformers pick (MPS when available); "cpu"/"mps" to pin
+    "intentsOnly": True,  # skip the claim pass (~2x faster); the UI only uses intents
+    "maxTokens": 2048,  # max NEW tokens generated per extraction
+    "maxMessages": 40,  # send only the last N messages to the model (0 = no limit)
+}
+
+# setting key -> (environment variable, value kind)
+ENV_MAP: dict[str, tuple[str, str]] = {
+    "port": ("PORT", "int"),
+    "backend": ("CLAIM_EXTRACTOR_BACKEND", "str"),
+    "model": ("CLAIM_EXTRACTOR_MODEL", "str"),
+    "mock": ("CLAIM_EXTRACTOR_MOCK", "bool"),
+    "device": ("CLAIM_EXTRACTOR_DEVICE", "str"),
+    "intentsOnly": ("CLAIM_EXTRACTOR_INTENTS_ONLY", "bool"),
+    "maxTokens": ("CLAIM_EXTRACTOR_MAX_TOKENS", "int"),
+    "maxMessages": ("CLAIM_EXTRACTOR_MAX_MESSAGES", "int"),
+}
+
+_TRUE = {"1", "true", "yes", "on"}
+
+
+def _kind_of(key: str) -> str:
+    return ENV_MAP[key][1]
+
+
+def _coerce(value: Any, kind: str) -> Any:
+    if kind == "int":
+        return int(value)
+    if kind == "bool":
+        if isinstance(value, bool):
+            return value
+        return str(value).strip().lower() in _TRUE
+    return str(value)
+
+
+def _settings_path(path: str | os.PathLike[str] | None = None) -> Path:
+    if path is not None:
+        return Path(path)
+    env = os.environ.get("CLAIM_EXTRACTOR_SETTINGS")
+    if env:
+        return Path(env)
+    return Path(__file__).with_name("settings.json")
+
+
+def load_settings(
+    path: str | os.PathLike[str] | None = None,
+    environ: dict[str, str] | None = None,
+) -> dict[str, Any]:
+    """Resolve settings from defaults < settings.json < environment.
+
+    A missing or malformed settings file is non-fatal: the sidecar falls back to
+    defaults (and any env overrides) rather than failing to start.
+    """
+    environ = os.environ if environ is None else environ
+    settings = dict(DEFAULTS)
+
+    file_path = _settings_path(path)
+    try:
+        raw = json.loads(file_path.read_text(encoding="utf-8"))
+        if isinstance(raw, dict):
+            for key in settings:
+                if key in raw and raw[key] is not None:
+                    settings[key] = _coerce(raw[key], _kind_of(key))
+    except FileNotFoundError:
+        pass
+    except (ValueError, OSError):
+        # malformed JSON / unreadable file — keep defaults rather than crash
+        pass
+
+    for key, (env_name, kind) in ENV_MAP.items():
+        value = environ.get(env_name)
+        if value not in (None, ""):
+            settings[key] = _coerce(value, kind)
+
+    return settings
+
+
+def limit_messages(messages: list[Any], max_messages: int | None) -> list[Any]:
+    """Return only the last ``max_messages`` entries (0/None/negative → all)."""
+    items = list(messages)
+    if not max_messages or max_messages <= 0:
+        return items
+    return items[-max_messages:]
+
+
+def shell_exports(settings: dict[str, Any]) -> str:
+    """Render resolved settings as ``eval``-able ``export`` lines for the run script."""
+    lines: list[str] = []
+    for key, (env_name, kind) in ENV_MAP.items():
+        value = settings.get(key)
+        if value is None:
+            continue
+        if kind == "bool":
+            value = "1" if value else "0"
+        lines.append(f"export {env_name}={shlex.quote(str(value))}")
+    return "\n".join(lines)
+
+
+def _main(argv: list[str]) -> int:
+    settings = load_settings()
+    arg = argv[1] if len(argv) > 1 else "--exports"
+    if arg == "--exports":
+        print(shell_exports(settings))
+    elif arg.startswith("--get="):
+        print(settings.get(arg[len("--get=") :], ""))
+    elif arg == "--json":
+        print(json.dumps(settings, indent=2))
+    else:
+        print(f"usage: {argv[0]} [--exports|--get=<key>|--json]", flush=True)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    import sys
+
+    raise SystemExit(_main(sys.argv))

--- a/infra/claim-extractor/sidecar/settings.py
+++ b/infra/claim-extractor/sidecar/settings.py
@@ -30,7 +30,18 @@ DEFAULTS: dict[str, Any] = {
     "mock": False,
     "device": None,  # None → let transformers pick (MPS when available); "cpu"/"mps" to pin
     "intentsOnly": True,  # skip the claim pass (~2x faster); the UI only uses intents
-    "maxTokens": 2048,  # max NEW tokens generated per extraction
+    # True (default) → compact output, reliable intent extraction. Setting it False
+    # makes the model emit verbatim evidence quotes for the UI's "proof" view, but
+    # that output is much larger: if it exceeds maxTokens it truncates, the model's
+    # JSON fails to parse, and orbitals SILENTLY returns zero intents. So only turn
+    # evidence on together with a much larger maxTokens (e.g. 8192).
+    "skipEvidences": True,
+    # max NEW tokens generated per extraction. Too low truncates the output → the
+    # JSON won't parse → zero intents (silently; the server logs a warning when it
+    # detects this). 4096 is a safe ceiling for intents-only; evidence needs much
+    # more (8192+). 0 = no cap (orbitals' full default ~20k — slowest, but never
+    # truncates; may exceed the client's request timeout on long inputs).
+    "maxTokens": 4096,
     "maxMessages": 40,  # send only the last N messages to the model (0 = no limit)
 }
 
@@ -42,6 +53,7 @@ ENV_MAP: dict[str, tuple[str, str]] = {
     "mock": ("CLAIM_EXTRACTOR_MOCK", "bool"),
     "device": ("CLAIM_EXTRACTOR_DEVICE", "str"),
     "intentsOnly": ("CLAIM_EXTRACTOR_INTENTS_ONLY", "bool"),
+    "skipEvidences": ("CLAIM_EXTRACTOR_SKIP_EVIDENCES", "bool"),
     "maxTokens": ("CLAIM_EXTRACTOR_MAX_TOKENS", "int"),
     "maxMessages": ("CLAIM_EXTRACTOR_MAX_MESSAGES", "int"),
 }

--- a/infra/claim-extractor/sidecar/test_server.py
+++ b/infra/claim-extractor/sidecar/test_server.py
@@ -45,5 +45,35 @@ class TestExtractEndpointMessageCap(unittest.TestCase):
         self.assertEqual(intents, ["u0", "u1", "u2", "u3", "u4"])
 
 
+class TestNormalizeEvidence(unittest.TestCase):
+    """`_normalize` must carry the model's evidence spans into the wire contract."""
+
+    def _server(self):
+        os.environ["CLAIM_EXTRACTOR_MOCK"] = "1"
+        import server
+
+        importlib.reload(server)
+        return server
+
+    def tearDown(self) -> None:
+        os.environ.pop("CLAIM_EXTRACTOR_MOCK", None)
+
+    def test_carries_evidence_from_strings_and_objects(self) -> None:
+        server = self._server()
+        result = {
+            "extractions": {
+                "claims": [{"subtype": "factoid", "content": "c1", "evidences": ["span a"]}],
+                "intents": [
+                    {"content": "i1", "evidences": [{"text": "span b"}]},  # object-shaped
+                    {"content": "i2"},  # none → field omitted
+                ],
+            }
+        }
+        out = server._normalize(result)
+        self.assertEqual(out["claims"][0]["evidences"], ["span a"])
+        self.assertEqual(out["intents"][0]["evidences"], ["span b"])
+        self.assertNotIn("evidences", out["intents"][1])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/infra/claim-extractor/sidecar/test_server.py
+++ b/infra/claim-extractor/sidecar/test_server.py
@@ -1,0 +1,49 @@
+"""Endpoint test: the /v1/extract route applies the last-N-messages cap.
+
+Runs against the deterministic mock backend (no model download). Stdlib unittest
++ FastAPI TestClient (httpx). Env is set before importing/reloading ``server`` so
+its module-level settings pick up the test config.
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+import unittest
+
+
+class TestExtractEndpointMessageCap(unittest.TestCase):
+    def _client(self, max_messages: str):
+        os.environ["CLAIM_EXTRACTOR_MOCK"] = "1"
+        os.environ["CLAIM_EXTRACTOR_MAX_MESSAGES"] = max_messages
+        import server
+
+        importlib.reload(server)
+        from fastapi.testclient import TestClient
+
+        return TestClient(server.app)
+
+    def tearDown(self) -> None:
+        os.environ.pop("CLAIM_EXTRACTOR_MOCK", None)
+        os.environ.pop("CLAIM_EXTRACTOR_MAX_MESSAGES", None)
+
+    def test_only_last_n_messages_reach_the_model(self) -> None:
+        client = self._client("2")
+        messages = [{"role": "user", "content": f"u{i}"} for i in range(5)]
+        res = client.post("/v1/extract", json={"messages": messages})
+        self.assertEqual(res.status_code, 200)
+        # mock emits one intent per user message it actually sees → only the last 2.
+        intents = [i["content"] for i in res.json()["intents"]]
+        self.assertEqual(intents, ["u3", "u4"])
+
+    def test_zero_means_all_messages(self) -> None:
+        client = self._client("0")
+        messages = [{"role": "user", "content": f"u{i}"} for i in range(5)]
+        res = client.post("/v1/extract", json={"messages": messages})
+        self.assertEqual(res.status_code, 200)
+        intents = [i["content"] for i in res.json()["intents"]]
+        self.assertEqual(intents, ["u0", "u1", "u2", "u3", "u4"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/infra/claim-extractor/sidecar/test_server.py
+++ b/infra/claim-extractor/sidecar/test_server.py
@@ -45,6 +45,68 @@ class TestExtractEndpointMessageCap(unittest.TestCase):
         self.assertEqual(intents, ["u0", "u1", "u2", "u3", "u4"])
 
 
+class TestOrbitalsExtractEndpoint(unittest.TestCase):
+    """The orbitals-contract route accepts `conversation` and wraps the result so
+    Ratel can swap between this sidecar and the hosted endpoint by URL alone."""
+
+    def _client(self, max_messages: str = "0"):
+        os.environ["CLAIM_EXTRACTOR_MOCK"] = "1"
+        os.environ["CLAIM_EXTRACTOR_MAX_MESSAGES"] = max_messages
+        import server
+
+        importlib.reload(server)
+        from fastapi.testclient import TestClient
+
+        return TestClient(server.app)
+
+    def tearDown(self) -> None:
+        os.environ.pop("CLAIM_EXTRACTOR_MOCK", None)
+        os.environ.pop("CLAIM_EXTRACTOR_MAX_MESSAGES", None)
+
+    def test_wraps_result_in_extractions_with_usage_and_timing(self) -> None:
+        client = self._client()
+        res = client.post(
+            "/orbitals/claim-extractor/extract",
+            json={"conversation": [{"role": "user", "content": "add OAuth"}]},
+        )
+        self.assertEqual(res.status_code, 200)
+        body = res.json()
+        self.assertEqual([i["content"] for i in body["extractions"]["intents"]], ["add OAuth"])
+        self.assertIn("claims", body["extractions"])
+        self.assertIn("model", body)
+        self.assertIn("usage", body)
+        self.assertEqual(
+            set(body["usage"]), {"prompt_tokens", "completion_tokens", "total_tokens"}
+        )
+        self.assertIn("time_taken", body)
+
+    def test_applies_the_message_cap(self) -> None:
+        client = self._client("2")
+        conversation = [{"role": "user", "content": f"u{i}"} for i in range(5)]
+        res = client.post("/orbitals/claim-extractor/extract", json={"conversation": conversation})
+        self.assertEqual(res.status_code, 200)
+        intents = [i["content"] for i in res.json()["extractions"]["intents"]]
+        self.assertEqual(intents, ["u3", "u4"])
+
+    def test_accepts_a_bare_string_conversation(self) -> None:
+        client = self._client()
+        res = client.post(
+            "/orbitals/claim-extractor/extract", json={"conversation": "just a string"}
+        )
+        self.assertEqual(res.status_code, 200)
+        intents = [i["content"] for i in res.json()["extractions"]["intents"]]
+        self.assertEqual(intents, ["just a string"])
+
+    def test_legacy_v1_route_still_returns_unwrapped(self) -> None:
+        client = self._client()
+        res = client.post("/v1/extract", json={"messages": [{"role": "user", "content": "hi"}]})
+        self.assertEqual(res.status_code, 200)
+        body = res.json()
+        # Old shape: claims/intents at the top level, no `extractions` wrapper.
+        self.assertNotIn("extractions", body)
+        self.assertEqual([i["content"] for i in body["intents"]], ["hi"])
+
+
 class TestNormalizeEvidence(unittest.TestCase):
     """`_normalize` must carry the model's evidence spans into the wire contract."""
 

--- a/infra/claim-extractor/sidecar/test_settings.py
+++ b/infra/claim-extractor/sidecar/test_settings.py
@@ -1,0 +1,114 @@
+"""Tests for the sidecar settings loader and the last-N-messages cap.
+
+Stdlib-only (``python -m unittest``); also discovered by pytest. No model deps.
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from settings import DEFAULTS, limit_messages, load_settings, shell_exports
+
+
+def _write(tmp: Path, data: object) -> Path:
+    path = tmp / "settings.json"
+    path.write_text(json.dumps(data), encoding="utf-8")
+    return path
+
+
+class TestLoadSettings(unittest.TestCase):
+    def test_defaults_when_no_file_and_no_env(self) -> None:
+        settings = load_settings(path="/nonexistent/settings.json", environ={})
+        self.assertEqual(settings, DEFAULTS)
+
+    def test_json_overrides_defaults(self) -> None:
+        with tempfile.TemporaryDirectory() as d:
+            path = _write(Path(d), {"maxTokens": 999, "intentsOnly": False, "maxMessages": 5})
+            settings = load_settings(path=path, environ={})
+        self.assertEqual(settings["maxTokens"], 999)
+        self.assertEqual(settings["intentsOnly"], False)
+        self.assertEqual(settings["maxMessages"], 5)
+        # untouched keys keep their defaults
+        self.assertEqual(settings["model"], DEFAULTS["model"])
+
+    def test_env_overrides_json(self) -> None:
+        with tempfile.TemporaryDirectory() as d:
+            path = _write(Path(d), {"maxTokens": 999})
+            settings = load_settings(
+                path=path,
+                environ={"CLAIM_EXTRACTOR_MAX_TOKENS": "16", "CLAIM_EXTRACTOR_MAX_MESSAGES": "3"},
+            )
+        self.assertEqual(settings["maxTokens"], 16)
+        self.assertEqual(settings["maxMessages"], 3)
+
+    def test_bool_coercion_from_env_and_json(self) -> None:
+        with tempfile.TemporaryDirectory() as d:
+            path = _write(Path(d), {"intentsOnly": False})
+            from_json = load_settings(path=path, environ={})
+            from_env = load_settings(path=path, environ={"CLAIM_EXTRACTOR_INTENTS_ONLY": "1"})
+        self.assertIs(from_json["intentsOnly"], False)
+        self.assertIs(from_env["intentsOnly"], True)
+
+    def test_null_device_falls_back_to_default(self) -> None:
+        with tempfile.TemporaryDirectory() as d:
+            path = _write(Path(d), {"device": None})
+            settings = load_settings(path=path, environ={})
+        self.assertIsNone(settings["device"])
+
+    def test_malformed_json_falls_back_to_defaults(self) -> None:
+        with tempfile.TemporaryDirectory() as d:
+            path = Path(d) / "settings.json"
+            path.write_text("{ this is not json", encoding="utf-8")
+            settings = load_settings(path=path, environ={})
+        self.assertEqual(settings, DEFAULTS)
+
+    def test_empty_env_value_does_not_override(self) -> None:
+        with tempfile.TemporaryDirectory() as d:
+            path = _write(Path(d), {"maxTokens": 999})
+            settings = load_settings(path=path, environ={"CLAIM_EXTRACTOR_MAX_TOKENS": ""})
+        self.assertEqual(settings["maxTokens"], 999)
+
+
+class TestLimitMessages(unittest.TestCase):
+    def setUp(self) -> None:
+        self.msgs = [{"role": "user", "content": f"m{i}"} for i in range(5)]
+
+    def test_returns_last_n(self) -> None:
+        self.assertEqual(limit_messages(self.msgs, 2), self.msgs[-2:])
+
+    def test_zero_means_no_limit(self) -> None:
+        self.assertEqual(limit_messages(self.msgs, 0), self.msgs)
+
+    def test_none_means_no_limit(self) -> None:
+        self.assertEqual(limit_messages(self.msgs, None), self.msgs)
+
+    def test_negative_means_no_limit(self) -> None:
+        self.assertEqual(limit_messages(self.msgs, -1), self.msgs)
+
+    def test_larger_than_length_returns_all(self) -> None:
+        self.assertEqual(limit_messages(self.msgs, 99), self.msgs)
+
+    def test_does_not_mutate_input(self) -> None:
+        original = list(self.msgs)
+        limit_messages(self.msgs, 2)
+        self.assertEqual(self.msgs, original)
+
+
+class TestShellExports(unittest.TestCase):
+    def test_emits_export_lines_with_bool_as_1_0(self) -> None:
+        settings = load_settings(path="/nonexistent", environ={})
+        out = shell_exports(settings)
+        self.assertIn("export PORT=8723", out)
+        self.assertIn("export CLAIM_EXTRACTOR_MAX_MESSAGES=40", out)
+        self.assertIn("export CLAIM_EXTRACTOR_INTENTS_ONLY=1", out)
+
+    def test_omits_none_device(self) -> None:
+        settings = load_settings(path="/nonexistent", environ={})
+        self.assertNotIn("CLAIM_EXTRACTOR_DEVICE", shell_exports(settings))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/packages/core/src/lib/config.test.ts
+++ b/packages/core/src/lib/config.test.ts
@@ -375,6 +375,31 @@ describe("parseConfig analysis", () => {
     ).toThrow(/everyNMessages/);
   });
 
+  it("parses and round-trips cadence.auto", () => {
+    const config = parseConfig({
+      mcpServers: {},
+      analysis: { cadence: { auto: true, everyNMessages: 5 } },
+    });
+    expect(config.analysis?.cadence).toEqual({ auto: true, everyNMessages: 5 });
+  });
+
+  it("rejects a non-boolean cadence.auto", () => {
+    expect(() => parseConfig({ mcpServers: {}, analysis: { cadence: { auto: "yes" } } })).toThrow(
+      /analysis\.cadence\.auto/,
+    );
+  });
+
+  it("parses cadence.recentHours and rejects non-positive values", () => {
+    const config = parseConfig({ mcpServers: {}, analysis: { cadence: { recentHours: 5 } } });
+    expect(config.analysis?.cadence?.recentHours).toBe(5);
+    expect(() =>
+      parseConfig({ mcpServers: {}, analysis: { cadence: { recentHours: 0 } } }),
+    ).toThrow(/analysis\.cadence\.recentHours/);
+    expect(() =>
+      parseConfig({ mcpServers: {}, analysis: { cadence: { recentHours: -1 } } }),
+    ).toThrow(/analysis\.cadence\.recentHours/);
+  });
+
   it("rejects a non-boolean enabled", () => {
     expect(() => parseConfig({ mcpServers: {}, analysis: { enabled: "yes" } })).toThrow(
       /analysis\.enabled/,
@@ -385,6 +410,24 @@ describe("parseConfig analysis", () => {
     expect(() =>
       parseConfig({ mcpServers: {}, analysis: { skillGen: { provider: "wizard" } } }),
     ).toThrow(/analysis\.skillGen\.provider/);
+  });
+
+  it("parses and round-trips a skillGen model", () => {
+    const config = parseConfig({
+      mcpServers: {},
+      analysis: { skillGen: { provider: "auto", apiKey: "sk-anthropic", model: "haiku" } },
+    });
+    expect(config.analysis?.skillGen).toEqual({
+      provider: "auto",
+      apiKey: "sk-anthropic",
+      model: "haiku",
+    });
+  });
+
+  it("rejects a non-string skillGen model", () => {
+    expect(() => parseConfig({ mcpServers: {}, analysis: { skillGen: { model: 42 } } })).toThrow(
+      /analysis\.skillGen\.model/,
+    );
   });
 
   it("parses a coverage block", () => {

--- a/packages/core/src/lib/config.test.ts
+++ b/packages/core/src/lib/config.test.ts
@@ -305,3 +305,123 @@ describe("mergeConfigs skills", () => {
     expect(merged.skills?.dirs).toEqual(["/one"]);
   });
 });
+
+describe("parseConfig analysis", () => {
+  it("parses a full analysis block", () => {
+    const config = parseConfig({
+      mcpServers: {},
+      analysis: {
+        enabled: true,
+        chatSource: "hooks",
+        extractor: {
+          provider: "http",
+          endpoint: "http://127.0.0.1:8723",
+          apiKey: "sk-secret",
+          model: "claim-extractor-4B",
+        },
+        cadence: { everyNMessages: 10, onIdle: true },
+        skillGen: { provider: "auto", apiKey: "sk-anthropic" },
+      },
+    });
+    expect(config.analysis).toEqual({
+      enabled: true,
+      chatSource: "hooks",
+      extractor: {
+        provider: "http",
+        endpoint: "http://127.0.0.1:8723",
+        apiKey: "sk-secret",
+        model: "claim-extractor-4B",
+      },
+      cadence: { everyNMessages: 10, onIdle: true },
+      skillGen: { provider: "auto", apiKey: "sk-anthropic" },
+    });
+  });
+
+  it("leaves analysis undefined when the block is absent", () => {
+    const config = parseConfig({ mcpServers: {} });
+    expect(config.analysis).toBeUndefined();
+  });
+
+  it("accepts a partial analysis block", () => {
+    const config = parseConfig({
+      mcpServers: {},
+      analysis: { cadence: { everyNMessages: 5 } },
+    });
+    expect(config.analysis).toEqual({ cadence: { everyNMessages: 5 } });
+  });
+
+  it("rejects a non-object analysis block", () => {
+    expect(() => parseConfig({ mcpServers: {}, analysis: "nope" })).toThrow(/analysis.*object/i);
+  });
+
+  it("rejects an unknown chatSource", () => {
+    expect(() => parseConfig({ mcpServers: {}, analysis: { chatSource: "telepathy" } })).toThrow(
+      /analysis\.chatSource/,
+    );
+  });
+
+  it("rejects an unknown extractor provider", () => {
+    expect(() =>
+      parseConfig({ mcpServers: {}, analysis: { extractor: { provider: "magic" } } }),
+    ).toThrow(/analysis\.extractor\.provider/);
+  });
+
+  it("rejects a non-integer everyNMessages", () => {
+    expect(() =>
+      parseConfig({ mcpServers: {}, analysis: { cadence: { everyNMessages: 2.5 } } }),
+    ).toThrow(/everyNMessages/);
+    expect(() =>
+      parseConfig({ mcpServers: {}, analysis: { cadence: { everyNMessages: 0 } } }),
+    ).toThrow(/everyNMessages/);
+  });
+
+  it("rejects a non-boolean enabled", () => {
+    expect(() => parseConfig({ mcpServers: {}, analysis: { enabled: "yes" } })).toThrow(
+      /analysis\.enabled/,
+    );
+  });
+
+  it("rejects an unknown skillGen provider", () => {
+    expect(() =>
+      parseConfig({ mcpServers: {}, analysis: { skillGen: { provider: "wizard" } } }),
+    ).toThrow(/analysis\.skillGen\.provider/);
+  });
+
+  it("parses a coverage block", () => {
+    const config = parseConfig({
+      mcpServers: {},
+      analysis: { coverage: { minScore: 1.5, relativeRatio: 0.7, maxSkills: 3 } },
+    });
+    expect(config.analysis?.coverage).toEqual({ minScore: 1.5, relativeRatio: 0.7, maxSkills: 3 });
+  });
+
+  it("rejects an out-of-range relativeRatio and a negative minScore", () => {
+    expect(() =>
+      parseConfig({ mcpServers: {}, analysis: { coverage: { relativeRatio: 1.5 } } }),
+    ).toThrow(/relativeRatio/);
+    expect(() => parseConfig({ mcpServers: {}, analysis: { coverage: { minScore: -1 } } })).toThrow(
+      /minScore/,
+    );
+    expect(() => parseConfig({ mcpServers: {}, analysis: { coverage: { maxSkills: 0 } } })).toThrow(
+      /maxSkills/,
+    );
+  });
+});
+
+describe("mergeConfigs analysis", () => {
+  it("carries analysis through and lets the right-most config win", () => {
+    const merged = mergeConfigs([
+      { mcpServers: {}, analysis: { cadence: { everyNMessages: 5 } } },
+      { mcpServers: {}, analysis: { cadence: { everyNMessages: 20 } } },
+    ]);
+    expect(merged.analysis?.cadence?.everyNMessages).toBe(20);
+  });
+
+  it("preserves an earlier analysis block when later configs omit one", () => {
+    const merged = mergeConfigs([
+      { mcpServers: {}, analysis: { enabled: true } },
+      { mcpServers: {} },
+    ]);
+    expect(merged.analysis?.enabled).toBe(true);
+  });
+});

--- a/packages/core/src/lib/config.test.ts
+++ b/packages/core/src/lib/config.test.ts
@@ -366,6 +366,40 @@ describe("parseConfig analysis", () => {
     ).toThrow(/analysis\.extractor\.provider/);
   });
 
+  it("parses basic-auth extractor fields (authScheme + username)", () => {
+    const config = parseConfig({
+      mcpServers: {},
+      analysis: {
+        extractor: {
+          provider: "cloud",
+          endpoint: "https://extractor.example/api",
+          authScheme: "basic",
+          username: "alice",
+          apiKey: "s3cret",
+        },
+      },
+    });
+    expect(config.analysis?.extractor).toEqual({
+      provider: "cloud",
+      endpoint: "https://extractor.example/api",
+      authScheme: "basic",
+      username: "alice",
+      apiKey: "s3cret",
+    });
+  });
+
+  it("rejects an unknown extractor authScheme", () => {
+    expect(() =>
+      parseConfig({ mcpServers: {}, analysis: { extractor: { authScheme: "oauth" } } }),
+    ).toThrow(/analysis\.extractor\.authScheme/);
+  });
+
+  it("rejects a non-string extractor username", () => {
+    expect(() =>
+      parseConfig({ mcpServers: {}, analysis: { extractor: { username: 42 } } }),
+    ).toThrow(/analysis\.extractor\.username/);
+  });
+
   it("rejects a non-integer everyNMessages", () => {
     expect(() =>
       parseConfig({ mcpServers: {}, analysis: { cadence: { everyNMessages: 2.5 } } }),

--- a/packages/core/src/lib/config.ts
+++ b/packages/core/src/lib/config.ts
@@ -25,9 +25,65 @@ export interface SkillsConfig {
   dirs?: string[];
 }
 
+/** Where captured chat comes from. `hooks` reads local capture files; `api`/`cloud` pull remotely. */
+export type ChatSourceKind = "hooks" | "api" | "cloud";
+
+/** Which intent-extraction backend to use. `http` is a local sidecar or remote endpoint. */
+export type ExtractorProvider = "http" | "naive" | "cloud";
+
+/** How a skill draft is generated. `auto` picks anthropic-api when a key is set, else claude-cli. */
+export type SkillGenProvider = "auto" | "anthropic-api" | "claude-cli";
+
+/** Intent-extraction backend: an HTTP endpoint (local sidecar, remote, or cloud) + optional auth. */
+export interface ExtractorConfig {
+  provider?: ExtractorProvider;
+  /** Base URL of the extractor HTTP service (local Apple-Silicon sidecar, Docker box, or cloud). */
+  endpoint?: string;
+  /** Bearer key for a remote/cloud endpoint. Secret-bearing — masked when read back over the UI. */
+  apiKey?: string;
+  /** Model identifier the endpoint should serve, e.g. "claim-extractor-4B". */
+  model?: string;
+}
+
+/** When the analysis runner fires. Manual is always available; these are the automatic triggers. */
+export interface CadenceConfig {
+  /** Trigger after this many new captured turns. Must be a positive integer (default 10). */
+  everyNMessages?: number;
+  /** Also trigger when a session goes idle (driven by the Stop hook). */
+  onIdle?: boolean;
+}
+
+/** Skill-draft generation backend. */
+export interface SkillGenConfig {
+  provider?: SkillGenProvider;
+  /** Anthropic API key. Secret-bearing — masked when read back over the UI. */
+  apiKey?: string;
+}
+
+/** Thresholds for deciding which skills "cover" an intent (BM25 search results). */
+export interface CoverageConfig {
+  /** Absolute BM25 floor: a skill scoring below this never covers an intent. */
+  minScore?: number;
+  /** Keep only skills within this fraction (0–1) of the top match for an intent. */
+  relativeRatio?: number;
+  /** Max skills reported as covering one intent. */
+  maxSkills?: number;
+}
+
+/** Chat → intent extraction pipeline settings. All optional; UI-configurable at user scope. */
+export interface AnalysisConfig {
+  enabled?: boolean;
+  chatSource?: ChatSourceKind;
+  extractor?: ExtractorConfig;
+  cadence?: CadenceConfig;
+  skillGen?: SkillGenConfig;
+  coverage?: CoverageConfig;
+}
+
 export interface RatelConfig {
   mcpServers: Record<string, ServerEntry>;
   skills?: SkillsConfig;
+  analysis?: AnalysisConfig;
 }
 
 export function parseConfig(input: unknown): RatelConfig {
@@ -49,7 +105,142 @@ export function parseConfig(input: unknown): RatelConfig {
   if (skills !== undefined) {
     config.skills = parseSkills(skills);
   }
+  const analysis = (input as Record<string, unknown>).analysis;
+  if (analysis !== undefined) {
+    config.analysis = parseAnalysis(analysis);
+  }
   return config;
+}
+
+const CHAT_SOURCES: readonly ChatSourceKind[] = ["hooks", "api", "cloud"];
+const EXTRACTOR_PROVIDERS: readonly ExtractorProvider[] = ["http", "naive", "cloud"];
+const SKILL_GEN_PROVIDERS: readonly SkillGenProvider[] = ["auto", "anthropic-api", "claude-cli"];
+
+function parseAnalysis(raw: unknown): AnalysisConfig {
+  if (!isPlainObject(raw)) {
+    throw new ConfigError("`analysis` must be a JSON object");
+  }
+  const analysis: AnalysisConfig = {};
+  if (raw.enabled !== undefined) {
+    if (typeof raw.enabled !== "boolean") {
+      throw new ConfigError("`analysis.enabled` must be a boolean");
+    }
+    analysis.enabled = raw.enabled;
+  }
+  if (raw.chatSource !== undefined) {
+    if (!CHAT_SOURCES.includes(raw.chatSource as ChatSourceKind)) {
+      throw new ConfigError(`\`analysis.chatSource\` must be one of ${CHAT_SOURCES.join("|")}`);
+    }
+    analysis.chatSource = raw.chatSource as ChatSourceKind;
+  }
+  if (raw.extractor !== undefined) {
+    analysis.extractor = parseExtractor(raw.extractor);
+  }
+  if (raw.cadence !== undefined) {
+    analysis.cadence = parseCadence(raw.cadence);
+  }
+  if (raw.skillGen !== undefined) {
+    analysis.skillGen = parseSkillGen(raw.skillGen);
+  }
+  if (raw.coverage !== undefined) {
+    analysis.coverage = parseCoverage(raw.coverage);
+  }
+  return analysis;
+}
+
+function parseCoverage(raw: unknown): CoverageConfig {
+  if (!isPlainObject(raw)) {
+    throw new ConfigError("`analysis.coverage` must be a JSON object");
+  }
+  const coverage: CoverageConfig = {};
+  if (raw.minScore !== undefined) {
+    if (typeof raw.minScore !== "number" || Number.isNaN(raw.minScore) || raw.minScore < 0) {
+      throw new ConfigError("`analysis.coverage.minScore` must be a non-negative number");
+    }
+    coverage.minScore = raw.minScore;
+  }
+  if (raw.relativeRatio !== undefined) {
+    const r = raw.relativeRatio;
+    if (typeof r !== "number" || Number.isNaN(r) || r < 0 || r > 1) {
+      throw new ConfigError("`analysis.coverage.relativeRatio` must be between 0 and 1");
+    }
+    coverage.relativeRatio = r;
+  }
+  if (raw.maxSkills !== undefined) {
+    const n = raw.maxSkills;
+    if (typeof n !== "number" || !Number.isInteger(n) || n < 1) {
+      throw new ConfigError("`analysis.coverage.maxSkills` must be a positive integer");
+    }
+    coverage.maxSkills = n;
+  }
+  return coverage;
+}
+
+function parseExtractor(raw: unknown): ExtractorConfig {
+  if (!isPlainObject(raw)) {
+    throw new ConfigError("`analysis.extractor` must be a JSON object");
+  }
+  const extractor: ExtractorConfig = {};
+  if (raw.provider !== undefined) {
+    if (!EXTRACTOR_PROVIDERS.includes(raw.provider as ExtractorProvider)) {
+      throw new ConfigError(
+        `\`analysis.extractor.provider\` must be one of ${EXTRACTOR_PROVIDERS.join("|")}`,
+      );
+    }
+    extractor.provider = raw.provider as ExtractorProvider;
+  }
+  for (const field of ["endpoint", "apiKey", "model"] as const) {
+    if (raw[field] !== undefined) {
+      if (typeof raw[field] !== "string") {
+        throw new ConfigError(`\`analysis.extractor.${field}\` must be a string`);
+      }
+      extractor[field] = raw[field] as string;
+    }
+  }
+  return extractor;
+}
+
+function parseCadence(raw: unknown): CadenceConfig {
+  if (!isPlainObject(raw)) {
+    throw new ConfigError("`analysis.cadence` must be a JSON object");
+  }
+  const cadence: CadenceConfig = {};
+  if (raw.everyNMessages !== undefined) {
+    const n = raw.everyNMessages;
+    if (typeof n !== "number" || !Number.isInteger(n) || n < 1) {
+      throw new ConfigError("`analysis.cadence.everyNMessages` must be a positive integer");
+    }
+    cadence.everyNMessages = n;
+  }
+  if (raw.onIdle !== undefined) {
+    if (typeof raw.onIdle !== "boolean") {
+      throw new ConfigError("`analysis.cadence.onIdle` must be a boolean");
+    }
+    cadence.onIdle = raw.onIdle;
+  }
+  return cadence;
+}
+
+function parseSkillGen(raw: unknown): SkillGenConfig {
+  if (!isPlainObject(raw)) {
+    throw new ConfigError("`analysis.skillGen` must be a JSON object");
+  }
+  const skillGen: SkillGenConfig = {};
+  if (raw.provider !== undefined) {
+    if (!SKILL_GEN_PROVIDERS.includes(raw.provider as SkillGenProvider)) {
+      throw new ConfigError(
+        `\`analysis.skillGen.provider\` must be one of ${SKILL_GEN_PROVIDERS.join("|")}`,
+      );
+    }
+    skillGen.provider = raw.provider as SkillGenProvider;
+  }
+  if (raw.apiKey !== undefined) {
+    if (typeof raw.apiKey !== "string") {
+      throw new ConfigError("`analysis.skillGen.apiKey` must be a string");
+    }
+    skillGen.apiKey = raw.apiKey;
+  }
+  return skillGen;
 }
 
 function parseSkills(raw: unknown): SkillsConfig {
@@ -193,13 +384,18 @@ function isPlainObject(v: unknown): v is Record<string, unknown> {
 export function mergeConfigs(configs: readonly RatelConfig[]): RatelConfig {
   const out: Record<string, ServerEntry> = {};
   let skills: SkillsConfig | undefined;
+  let analysis: AnalysisConfig | undefined;
   for (const c of configs) {
     for (const [name, entry] of Object.entries(c.mcpServers)) {
       out[name] = entry;
     }
     if (c.skills) skills = c.skills;
+    if (c.analysis) analysis = c.analysis;
   }
-  return skills ? { mcpServers: out, skills } : { mcpServers: out };
+  const merged: RatelConfig = { mcpServers: out };
+  if (skills) merged.skills = skills;
+  if (analysis) merged.analysis = analysis;
+  return merged;
 }
 
 export class ConfigError extends Error {

--- a/packages/core/src/lib/config.ts
+++ b/packages/core/src/lib/config.ts
@@ -47,10 +47,22 @@ export interface ExtractorConfig {
 
 /** When the analysis runner fires. Manual is always available; these are the automatic triggers. */
 export interface CadenceConfig {
+  /**
+   * Master switch for the background scheduler: when true, the gateway runs
+   * analysis automatically on a timer (subject to the triggers below). Defaults
+   * to false — automatic runs are opt-in; manual "Run now" always works.
+   */
+  auto?: boolean;
   /** Trigger after this many new captured turns. Must be a positive integer (default 10). */
   everyNMessages?: number;
   /** Also trigger when a session goes idle (driven by the Stop hook). */
   onIdle?: boolean;
+  /**
+   * Limit automatic/bulk runs to chats active within this many hours (a positive
+   * number; fractional allowed). Omitted = no limit (analyze every due chat).
+   * Per-chat manual analysis ignores this.
+   */
+  recentHours?: number;
 }
 
 /** Skill-draft generation backend. */
@@ -58,6 +70,8 @@ export interface SkillGenConfig {
   provider?: SkillGenProvider;
   /** Anthropic API key. Secret-bearing — masked when read back over the UI. */
   apiKey?: string;
+  /** Model id/alias the skill generator should use (e.g. an Anthropic model id, or a `claude -p` alias like 'haiku'/'sonnet'). Optional; the generator falls back to its default. */
+  model?: string;
 }
 
 /** Thresholds for deciding which skills "cover" an intent (BM25 search results). */
@@ -205,6 +219,12 @@ function parseCadence(raw: unknown): CadenceConfig {
     throw new ConfigError("`analysis.cadence` must be a JSON object");
   }
   const cadence: CadenceConfig = {};
+  if (raw.auto !== undefined) {
+    if (typeof raw.auto !== "boolean") {
+      throw new ConfigError("`analysis.cadence.auto` must be a boolean");
+    }
+    cadence.auto = raw.auto;
+  }
   if (raw.everyNMessages !== undefined) {
     const n = raw.everyNMessages;
     if (typeof n !== "number" || !Number.isInteger(n) || n < 1) {
@@ -217,6 +237,13 @@ function parseCadence(raw: unknown): CadenceConfig {
       throw new ConfigError("`analysis.cadence.onIdle` must be a boolean");
     }
     cadence.onIdle = raw.onIdle;
+  }
+  if (raw.recentHours !== undefined) {
+    const h = raw.recentHours;
+    if (typeof h !== "number" || Number.isNaN(h) || h <= 0) {
+      throw new ConfigError("`analysis.cadence.recentHours` must be a positive number");
+    }
+    cadence.recentHours = h;
   }
   return cadence;
 }
@@ -239,6 +266,12 @@ function parseSkillGen(raw: unknown): SkillGenConfig {
       throw new ConfigError("`analysis.skillGen.apiKey` must be a string");
     }
     skillGen.apiKey = raw.apiKey;
+  }
+  if (raw.model !== undefined) {
+    if (typeof raw.model !== "string") {
+      throw new ConfigError("`analysis.skillGen.model` must be a string");
+    }
+    skillGen.model = raw.model;
   }
   return skillGen;
 }

--- a/packages/core/src/lib/config.ts
+++ b/packages/core/src/lib/config.ts
@@ -63,6 +63,14 @@ export interface ExtractorConfig {
   apiKey?: string;
   /** Model identifier the endpoint should serve, e.g. "claim-extractor-4B". */
   model?: string;
+  /**
+   * Cap on the JSON size (in characters) of the `conversation` sent in one request.
+   * Long chats are split into chunks under this budget and the per-chunk results are
+   * merged — the hosted model has a fixed context window and returns 500 when the
+   * conversation overflows it. Omitted = a safe built-in default; raise it for a local
+   * sidecar with a larger window. Must be a positive integer.
+   */
+  maxRequestChars?: number;
 }
 
 /** When the analysis runner fires. Manual is always available; these are the automatic triggers. */
@@ -239,6 +247,13 @@ function parseExtractor(raw: unknown): ExtractorConfig {
       }
       extractor[field] = raw[field] as string;
     }
+  }
+  if (raw.maxRequestChars !== undefined) {
+    const n = raw.maxRequestChars;
+    if (typeof n !== "number" || !Number.isInteger(n) || n < 1) {
+      throw new ConfigError("`analysis.extractor.maxRequestChars` must be a positive integer");
+    }
+    extractor.maxRequestChars = n;
   }
   return extractor;
 }

--- a/packages/core/src/lib/config.ts
+++ b/packages/core/src/lib/config.ts
@@ -34,12 +34,32 @@ export type ExtractorProvider = "http" | "naive" | "cloud";
 /** How a skill draft is generated. `auto` picks anthropic-api when a key is set, else claude-cli. */
 export type SkillGenProvider = "auto" | "anthropic-api" | "claude-cli";
 
-/** Intent-extraction backend: an HTTP endpoint (local sidecar, remote, or cloud) + optional auth. */
+/**
+ * How the extractor endpoint is authenticated. `bearer` sends `Authorization:
+ * Bearer <apiKey>`; `basic` sends `Authorization: Basic <base64(username:apiKey)>`.
+ * Omitted = auto: basic when a username is set, else bearer when an apiKey is set,
+ * else no auth (a local sidecar needs none).
+ */
+export type ExtractorAuthScheme = "bearer" | "basic";
+
+/**
+ * Intent-extraction backend: an HTTP endpoint speaking the orbitals claim-extractor
+ * contract — a local Apple-Silicon sidecar, a Docker+GPU box, or a remote/hosted
+ * endpoint. They differ only by URL and auth, so switching `endpoint` (and creds)
+ * is all it takes to move between them.
+ */
 export interface ExtractorConfig {
   provider?: ExtractorProvider;
-  /** Base URL of the extractor HTTP service (local Apple-Silicon sidecar, Docker box, or cloud). */
+  /** Base URL of the extractor HTTP service (local Apple-Silicon sidecar, Docker box, or hosted). */
   endpoint?: string;
-  /** Bearer key for a remote/cloud endpoint. Secret-bearing — masked when read back over the UI. */
+  /** How to authenticate (`bearer`|`basic`). Omitted = auto-detect from username/apiKey. */
+  authScheme?: ExtractorAuthScheme;
+  /** Username for `basic` auth. Not secret — stored and read back in the clear. */
+  username?: string;
+  /**
+   * The secret credential: the bearer token (scheme `bearer`) or the password
+   * (scheme `basic`). Secret-bearing — masked when read back over the UI.
+   */
   apiKey?: string;
   /** Model identifier the endpoint should serve, e.g. "claim-extractor-4B". */
   model?: string;
@@ -128,6 +148,7 @@ export function parseConfig(input: unknown): RatelConfig {
 
 const CHAT_SOURCES: readonly ChatSourceKind[] = ["hooks", "api", "cloud"];
 const EXTRACTOR_PROVIDERS: readonly ExtractorProvider[] = ["http", "naive", "cloud"];
+const EXTRACTOR_AUTH_SCHEMES: readonly ExtractorAuthScheme[] = ["bearer", "basic"];
 const SKILL_GEN_PROVIDERS: readonly SkillGenProvider[] = ["auto", "anthropic-api", "claude-cli"];
 
 function parseAnalysis(raw: unknown): AnalysisConfig {
@@ -203,7 +224,15 @@ function parseExtractor(raw: unknown): ExtractorConfig {
     }
     extractor.provider = raw.provider as ExtractorProvider;
   }
-  for (const field of ["endpoint", "apiKey", "model"] as const) {
+  if (raw.authScheme !== undefined) {
+    if (!EXTRACTOR_AUTH_SCHEMES.includes(raw.authScheme as ExtractorAuthScheme)) {
+      throw new ConfigError(
+        `\`analysis.extractor.authScheme\` must be one of ${EXTRACTOR_AUTH_SCHEMES.join("|")}`,
+      );
+    }
+    extractor.authScheme = raw.authScheme as ExtractorAuthScheme;
+  }
+  for (const field of ["endpoint", "username", "apiKey", "model"] as const) {
     if (raw[field] !== undefined) {
       if (typeof raw[field] !== "string") {
         throw new ConfigError(`\`analysis.extractor.${field}\` must be a string`);

--- a/packages/core/src/lib/index.ts
+++ b/packages/core/src/lib/index.ts
@@ -1,4 +1,16 @@
-export type { RatelConfig, ServerEntry, SkillsConfig } from "./config.js";
+export type {
+  AnalysisConfig,
+  CadenceConfig,
+  ChatSourceKind,
+  CoverageConfig,
+  ExtractorConfig,
+  ExtractorProvider,
+  RatelConfig,
+  ServerEntry,
+  SkillGenConfig,
+  SkillGenProvider,
+  SkillsConfig,
+} from "./config.js";
 export { ConfigError, mergeConfigs, parseConfig } from "./config.js";
 export type {
   BuildGatewayOptions,
@@ -9,6 +21,7 @@ export {
   buildGatewayFromConfig,
   defaultTransportFactory,
 } from "./gateway.js";
+export * from "./intents/index.js";
 export type {
   AuthFlowOptions,
   AuthFlowResult,

--- a/packages/core/src/lib/index.ts
+++ b/packages/core/src/lib/index.ts
@@ -3,6 +3,7 @@ export type {
   CadenceConfig,
   ChatSourceKind,
   CoverageConfig,
+  ExtractorAuthScheme,
   ExtractorConfig,
   ExtractorProvider,
   RatelConfig,

--- a/packages/core/src/lib/intents/chat-source.test.ts
+++ b/packages/core/src/lib/intents/chat-source.test.ts
@@ -1,0 +1,93 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { nodeJsonFs, writeJson } from "../../io.js";
+import type { ChatState } from "./chat-source.js";
+import { HookChatSource, readChatState, sessionTurnsPath, writeChatState } from "./chat-source.js";
+
+let dir: string;
+let chatDir: string;
+
+beforeEach(async () => {
+  dir = await mkdtemp(join(tmpdir(), "ratel-chat-"));
+  chatDir = join(dir, "chat");
+});
+
+afterEach(async () => {
+  await rm(dir, { recursive: true, force: true });
+});
+
+async function seedTurns(host: string, sessionId: string, lines: string[]): Promise<void> {
+  await nodeJsonFs.writeAtomic(sessionTurnsPath(chatDir, host, sessionId), `${lines.join("\n")}\n`);
+}
+
+describe("readChatState / writeChatState", () => {
+  it("returns an empty state when no file exists", async () => {
+    const state = await readChatState(nodeJsonFs, chatDir);
+    expect(state.sessions).toEqual({});
+  });
+
+  it("round-trips through an atomic write", async () => {
+    const state: ChatState = {
+      version: 1,
+      sessions: { s1: { sessionId: "s1", host: "claude-code", newTurnCount: 3 } },
+    };
+    await writeChatState(nodeJsonFs, chatDir, state);
+    const read = await readChatState(nodeJsonFs, chatDir);
+    expect(read.sessions.s1.newTurnCount).toBe(3);
+  });
+
+  it("recovers to an empty state on malformed JSON", async () => {
+    await nodeJsonFs.writeAtomic(join(chatDir, "state.json"), "{not json");
+    const state = await readChatState(nodeJsonFs, chatDir);
+    expect(state.sessions).toEqual({});
+  });
+});
+
+describe("HookChatSource", () => {
+  it("lists sessions from state.json", async () => {
+    await writeJson(nodeJsonFs, join(chatDir, "state.json"), {
+      version: 1,
+      sessions: {
+        s1: { sessionId: "s1", host: "claude-code", newTurnCount: 2, cwd: "/proj" },
+        s2: { sessionId: "s2", host: "codex", newTurnCount: 0 },
+      },
+    });
+    const source = new HookChatSource({ chatDir, fs: nodeJsonFs });
+    const sessions = await source.listSessions();
+    expect(sessions.map((s) => s.sessionId).sort()).toEqual(["s1", "s2"]);
+  });
+
+  it("reads and parses a session's turns, skipping malformed lines", async () => {
+    await writeJson(nodeJsonFs, join(chatDir, "state.json"), {
+      version: 1,
+      sessions: { s1: { sessionId: "s1", host: "claude-code", newTurnCount: 2 } },
+    });
+    await seedTurns("claude-code", "s1", [
+      JSON.stringify({ role: "user", content: "first" }),
+      "{ broken line",
+      "",
+      JSON.stringify({ role: "assistant", content: "second" }),
+      JSON.stringify({ role: "user" }), // missing content → dropped
+    ]);
+    const source = new HookChatSource({ chatDir, fs: nodeJsonFs });
+    const turns = await source.readSession("s1");
+    expect(turns).toEqual([
+      { role: "user", content: "first" },
+      { role: "assistant", content: "second" },
+    ]);
+  });
+
+  it("returns an empty array for an unknown session", async () => {
+    const source = new HookChatSource({ chatDir, fs: nodeJsonFs });
+    expect(await source.readSession("nope")).toEqual([]);
+  });
+
+  it("falls back to scanning known host dirs when state lacks the session", async () => {
+    await seedTurns("codex", "orphan", [JSON.stringify({ role: "user", content: "hi" })]);
+    const source = new HookChatSource({ chatDir, fs: nodeJsonFs });
+    const turns = await source.readSession("orphan");
+    expect(turns).toEqual([{ role: "user", content: "hi" }]);
+  });
+});

--- a/packages/core/src/lib/intents/chat-source.test.ts
+++ b/packages/core/src/lib/intents/chat-source.test.ts
@@ -4,7 +4,13 @@ import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { nodeJsonFs, writeJson } from "../../io.js";
 import type { ChatState } from "./chat-source.js";
-import { HookChatSource, readChatState, sessionTurnsPath, writeChatState } from "./chat-source.js";
+import {
+  HookChatSource,
+  markSessionsForReanalysis,
+  readChatState,
+  sessionTurnsPath,
+  writeChatState,
+} from "./chat-source.js";
 
 let dir: string;
 let chatDir: string;
@@ -89,5 +95,57 @@ describe("HookChatSource", () => {
     const source = new HookChatSource({ chatDir, fs: nodeJsonFs });
     const turns = await source.readSession("orphan");
     expect(turns).toEqual([{ role: "user", content: "hi" }]);
+  });
+
+  it("markAnalyzed clears the re-analysis flag", async () => {
+    await writeJson(nodeJsonFs, join(chatDir, "state.json"), {
+      version: 1,
+      sessions: {
+        s1: { sessionId: "s1", host: "claude-code", newTurnCount: 5, needsReanalysis: true },
+      },
+    });
+    const source = new HookChatSource({ chatDir, fs: nodeJsonFs });
+    await source.markAnalyzed("s1", "2026-06-23T00:00:00.000Z");
+    const state = await readChatState(nodeJsonFs, chatDir);
+    expect(state.sessions.s1.needsReanalysis).toBe(false);
+    expect(state.sessions.s1.newTurnCount).toBe(0);
+    expect(state.sessions.s1.lastAnalyzedAt).toBe("2026-06-23T00:00:00.000Z");
+  });
+});
+
+describe("markSessionsForReanalysis", () => {
+  it("flags all known sessions and clears their lastAnalyzedAt", async () => {
+    await writeJson(nodeJsonFs, join(chatDir, "state.json"), {
+      version: 1,
+      sessions: {
+        s1: { sessionId: "s1", host: "claude-code", newTurnCount: 0, lastAnalyzedAt: "x" },
+        s2: { sessionId: "s2", host: "codex", newTurnCount: 0, lastAnalyzedAt: "y" },
+      },
+    });
+    await markSessionsForReanalysis(nodeJsonFs, chatDir);
+    const state = await readChatState(nodeJsonFs, chatDir);
+    expect(state.sessions.s1.needsReanalysis).toBe(true);
+    expect(state.sessions.s2.needsReanalysis).toBe(true);
+    expect(state.sessions.s1.lastAnalyzedAt).toBeUndefined();
+  });
+
+  it("flags only the listed sessions when ids are given", async () => {
+    await writeJson(nodeJsonFs, join(chatDir, "state.json"), {
+      version: 1,
+      sessions: {
+        s1: { sessionId: "s1", host: "claude-code", newTurnCount: 0 },
+        s2: { sessionId: "s2", host: "codex", newTurnCount: 0 },
+      },
+    });
+    await markSessionsForReanalysis(nodeJsonFs, chatDir, ["s1"]);
+    const state = await readChatState(nodeJsonFs, chatDir);
+    expect(state.sessions.s1.needsReanalysis).toBe(true);
+    expect(state.sessions.s2.needsReanalysis).toBeUndefined();
+  });
+
+  it("is a no-op when nothing matches", async () => {
+    await markSessionsForReanalysis(nodeJsonFs, chatDir, ["ghost"]);
+    const state = await readChatState(nodeJsonFs, chatDir);
+    expect(state.sessions).toEqual({});
   });
 });

--- a/packages/core/src/lib/intents/chat-source.ts
+++ b/packages/core/src/lib/intents/chat-source.ts
@@ -85,11 +85,42 @@ export class HookChatSource implements ChatSource {
       ...state,
       sessions: {
         ...state.sessions,
-        [sessionId]: { ...meta, newTurnCount: 0, lastAnalyzedAt: at, idle: false },
+        [sessionId]: {
+          ...meta,
+          newTurnCount: 0,
+          lastAnalyzedAt: at,
+          idle: false,
+          needsReanalysis: false,
+        },
       },
     };
     await writeChatState(this.fs, this.chatDir, next);
   }
+}
+
+/**
+ * Flag sessions as needing (re)analysis after their analysis output was deleted, so
+ * the next manual/idle run treats them as due even though they have no new turns.
+ * `lastAnalyzedAt` is cleared to match (the prior analysis no longer exists).
+ * `sessionIds` omitted = every known session. A no-op when nothing matches.
+ */
+export async function markSessionsForReanalysis(
+  fs: JsonFs,
+  chatDir: string,
+  sessionIds?: string[],
+): Promise<void> {
+  const state = await readChatState(fs, chatDir);
+  const targets = sessionIds ?? Object.keys(state.sessions);
+  const sessions = { ...state.sessions };
+  let changed = false;
+  for (const id of targets) {
+    const meta = sessions[id];
+    if (!meta) continue;
+    sessions[id] = { ...meta, needsReanalysis: true, lastAnalyzedAt: undefined };
+    changed = true;
+  }
+  if (!changed) return;
+  await writeChatState(fs, chatDir, { ...state, sessions });
 }
 
 function parseTurns(raw: string): ChatTurn[] {

--- a/packages/core/src/lib/intents/chat-source.ts
+++ b/packages/core/src/lib/intents/chat-source.ts
@@ -1,0 +1,121 @@
+import { join } from "node:path";
+import { type JsonFs, readJson, writeJson } from "../../io.js";
+import type { ChatRole, ChatSessionMeta, ChatSource, ChatTurn } from "./types.js";
+
+export const CHAT_STATE_VERSION = 1;
+
+/** Hosts the capture hook may write under; used to locate turn files when state lacks a session. */
+const KNOWN_HOSTS = ["claude-code", "codex", "unknown"] as const;
+
+/**
+ * Per-session bookkeeping persisted by the capture hook at `<chatDir>/state.json`.
+ * Kept in sync (by format) with `apps/ratel-mcp/plugin/hooks/capture-chat.mjs`.
+ */
+export interface ChatState {
+  version: number;
+  sessions: Record<string, ChatSessionMeta>;
+}
+
+/** Absolute path to a session's append-only turn log: `<chatDir>/<host>/<sessionId>.jsonl`. */
+export function sessionTurnsPath(chatDir: string, host: string, sessionId: string): string {
+  return join(chatDir, host, `${sessionId}.jsonl`);
+}
+
+function chatStatePath(chatDir: string): string {
+  return join(chatDir, "state.json");
+}
+
+/** Read chat capture state; recovers to an empty state when missing or malformed. */
+export async function readChatState(fs: JsonFs, chatDir: string): Promise<ChatState> {
+  try {
+    const state = await readJson<ChatState>(fs, chatStatePath(chatDir));
+    if (state && typeof state === "object" && state.sessions) return state;
+  } catch {
+    // malformed JSON — fall through to an empty state
+  }
+  return { version: CHAT_STATE_VERSION, sessions: {} };
+}
+
+/** Atomically persist chat capture state. */
+export async function writeChatState(fs: JsonFs, chatDir: string, state: ChatState): Promise<void> {
+  await writeJson(fs, chatStatePath(chatDir), state);
+}
+
+export interface HookChatSourceOptions {
+  /** The `~/.ratel/chat` directory the capture hook writes to. */
+  chatDir: string;
+  fs: JsonFs;
+}
+
+/**
+ * Reads chat captured by the plugin hooks from `<chatDir>`. The default v1 input
+ * seam; future `ApiChatSource`/`CloudChatSource` implement the same
+ * {@link ChatSource} interface so call sites never change.
+ */
+export class HookChatSource implements ChatSource {
+  private readonly chatDir: string;
+  private readonly fs: JsonFs;
+
+  constructor(opts: HookChatSourceOptions) {
+    this.chatDir = opts.chatDir;
+    this.fs = opts.fs;
+  }
+
+  async listSessions(): Promise<ChatSessionMeta[]> {
+    const state = await readChatState(this.fs, this.chatDir);
+    return Object.values(state.sessions);
+  }
+
+  async readSession(sessionId: string): Promise<ChatTurn[]> {
+    const state = await readChatState(this.fs, this.chatDir);
+    const host = state.sessions[sessionId]?.host;
+    const hosts = host ? [host] : KNOWN_HOSTS;
+    for (const h of hosts) {
+      const raw = await this.fs.read(sessionTurnsPath(this.chatDir, h, sessionId));
+      if (raw !== null) return parseTurns(raw);
+    }
+    return [];
+  }
+
+  async markAnalyzed(sessionId: string, at: string): Promise<void> {
+    const state = await readChatState(this.fs, this.chatDir);
+    const meta = state.sessions[sessionId];
+    if (!meta) return;
+    const next: ChatState = {
+      ...state,
+      sessions: {
+        ...state.sessions,
+        [sessionId]: { ...meta, newTurnCount: 0, lastAnalyzedAt: at, idle: false },
+      },
+    };
+    await writeChatState(this.fs, this.chatDir, next);
+  }
+}
+
+function parseTurns(raw: string): ChatTurn[] {
+  const turns: ChatTurn[] = [];
+  for (const line of raw.split("\n")) {
+    const trimmed = line.trim();
+    if (trimmed.length === 0) continue;
+    const turn = parseTurn(trimmed);
+    if (turn) turns.push(turn);
+  }
+  return turns;
+}
+
+function parseTurn(line: string): ChatTurn | undefined {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(line);
+  } catch {
+    return undefined;
+  }
+  if (typeof parsed !== "object" || parsed === null) return undefined;
+  const obj = parsed as Record<string, unknown>;
+  const role = obj.role;
+  const content = obj.content;
+  if ((role !== "user" && role !== "assistant") || typeof content !== "string") return undefined;
+  const turn: ChatTurn = { role: role as ChatRole, content };
+  if (typeof obj.ts === "string") turn.ts = obj.ts;
+  return turn;
+}

--- a/packages/core/src/lib/intents/extractor.test.ts
+++ b/packages/core/src/lib/intents/extractor.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import type { AnalysisConfig } from "../config.js";
 import {
   checkExtractorHealth,
+  chunkTurns,
   createExtractor,
   HttpIntentExtractor,
   NaiveIntentExtractor,
@@ -156,14 +157,115 @@ describe("HttpIntentExtractor", () => {
     expect(result.intents).toEqual([{ content: "valid" }]);
   });
 
-  it("throws a helpful error on a non-2xx response", async () => {
+  it("throws immediately on a 4xx without retrying", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response("bad input", { status: 422 }));
+    const extractor = new HttpIntentExtractor(
+      { endpoint: "http://x" },
+      { fetch: fetchMock, sleep: () => Promise.resolve() },
+    );
+    await expect(extractor.extract(TURNS)).rejects.toThrow(/422.*bad input/);
+    // A client error won't fix itself, so we don't burn retries on it.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries a transient 5xx and succeeds on a later attempt", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response("flaky", { status: 500 }))
+      .mockResolvedValueOnce(extractResponse({ intents: [{ content: "recovered" }] }));
+    const extractor = new HttpIntentExtractor(
+      { endpoint: "http://x" },
+      { fetch: fetchMock, sleep: () => Promise.resolve() },
+    );
+    const result = await extractor.extract(TURNS);
+    expect(result.intents).toEqual([{ content: "recovered" }]);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("gives up after the retry budget on a persistent 5xx", async () => {
     const fetchMock = vi.fn().mockResolvedValue(new Response("boom", { status: 503 }));
-    const extractor = new HttpIntentExtractor({ endpoint: "http://x" }, { fetch: fetchMock });
+    const extractor = new HttpIntentExtractor(
+      { endpoint: "http://x" },
+      { fetch: fetchMock, sleep: () => Promise.resolve() },
+    );
     await expect(extractor.extract(TURNS)).rejects.toThrow(/503/);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("does not retry a timeout (bounds total run time)", async () => {
+    const timeout = Object.assign(new Error("timed out"), { name: "TimeoutError" });
+    const fetchMock = vi.fn().mockRejectedValue(timeout);
+    const extractor = new HttpIntentExtractor(
+      { endpoint: "http://x" },
+      { fetch: fetchMock, sleep: () => Promise.resolve() },
+    );
+    await expect(extractor.extract(TURNS)).rejects.toThrow(/timed out/i);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("splits a conversation over the budget into chunks and merges the results", async () => {
+    // Two requests' worth of turns: a tiny budget forces one turn per chunk.
+    const turns: ChatTurn[] = [
+      { role: "user", content: "first request about caching" },
+      { role: "user", content: "second request about auth" },
+    ];
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        extractResponse({
+          claims: [{ subtype: "factoid", content: "shared" }],
+          intents: [{ content: "cache things" }],
+        }),
+      )
+      .mockResolvedValueOnce(
+        extractResponse({
+          // "shared" claim repeats across chunks and must be de-duplicated.
+          claims: [{ subtype: "factoid", content: "shared" }],
+          intents: [{ content: "auth things" }],
+        }),
+      );
+    const extractor = new HttpIntentExtractor(
+      { endpoint: "http://x", maxRequestChars: 1 },
+      { fetch: fetchMock, sleep: () => Promise.resolve() },
+    );
+    const result = await extractor.extract(turns);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(result.intents).toEqual([{ content: "cache things" }, { content: "auth things" }]);
+    expect(result.claims).toEqual([{ subtype: "factoid", content: "shared" }]);
   });
 
   it("requires an endpoint", () => {
     expect(() => new HttpIntentExtractor({})).toThrow(/endpoint/i);
+  });
+});
+
+describe("chunkTurns", () => {
+  const t = (content: string): ChatTurn => ({ role: "user", content });
+
+  it("keeps a small conversation as a single chunk", () => {
+    const turns = [t("a"), t("b"), t("c")];
+    expect(chunkTurns(turns, 10_000)).toEqual([turns]);
+  });
+
+  it("splits when the running size would exceed the budget", () => {
+    // Each turn serializes to ~30+ chars; a 60-char budget fits about two per chunk.
+    const turns = [t("one"), t("two"), t("three"), t("four")];
+    const chunks = chunkTurns(turns, 70);
+    expect(chunks.length).toBeGreaterThan(1);
+    // No turn is dropped and order is preserved.
+    expect(chunks.flat()).toEqual(turns);
+  });
+
+  it("never splits a single oversized turn — it gets its own chunk", () => {
+    const turns = [t("x".repeat(5000)), t("small")];
+    const chunks = chunkTurns(turns, 100);
+    expect(chunks).toHaveLength(2);
+    expect(chunks[0]).toEqual([turns[0]]);
+    expect(chunks[1]).toEqual([turns[1]]);
+  });
+
+  it("returns no chunks for an empty conversation", () => {
+    expect(chunkTurns([], 100)).toEqual([]);
   });
 });
 

--- a/packages/core/src/lib/intents/extractor.test.ts
+++ b/packages/core/src/lib/intents/extractor.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it, vi } from "vitest";
+import type { AnalysisConfig } from "../config.js";
+import { createExtractor, HttpIntentExtractor, NaiveIntentExtractor } from "./extractor.js";
+import type { ChatTurn } from "./types.js";
+
+const TURNS: ChatTurn[] = [
+  { role: "user", content: "Help me add OAuth login to my Next.js app" },
+  { role: "assistant", content: "Sure, here is how..." },
+];
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("HttpIntentExtractor", () => {
+  it("POSTs the conversation and normalizes the model response", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      jsonResponse({
+        claims: [{ subtype: "capability", content: "The app uses Next.js" }],
+        intents: [{ content: "Add OAuth login to a Next.js app" }],
+      }),
+    );
+    const extractor = new HttpIntentExtractor(
+      { endpoint: "http://127.0.0.1:8723", model: "claim-extractor-4B" },
+      { fetch: fetchMock },
+    );
+
+    const result = await extractor.extract(TURNS);
+
+    expect(result.intents).toEqual([{ content: "Add OAuth login to a Next.js app" }]);
+    expect(result.claims[0]).toEqual({
+      subtype: "capability",
+      content: "The app uses Next.js",
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("http://127.0.0.1:8723/v1/extract");
+    expect(init.method).toBe("POST");
+    const sentBody = JSON.parse(init.body as string);
+    expect(sentBody.model).toBe("claim-extractor-4B");
+    expect(sentBody.messages).toEqual([
+      { role: "user", content: "Help me add OAuth login to my Next.js app" },
+      { role: "assistant", content: "Sure, here is how..." },
+    ]);
+  });
+
+  it("trims a trailing slash on the endpoint", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ claims: [], intents: [] }));
+    const extractor = new HttpIntentExtractor(
+      { endpoint: "http://127.0.0.1:8723/" },
+      { fetch: fetchMock },
+    );
+    await extractor.extract(TURNS);
+    expect(fetchMock.mock.calls[0][0]).toBe("http://127.0.0.1:8723/v1/extract");
+  });
+
+  it("sends a bearer header when an apiKey is configured", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ claims: [], intents: [] }));
+    const extractor = new HttpIntentExtractor(
+      { endpoint: "http://remote/api", apiKey: "sk-secret" },
+      { fetch: fetchMock },
+    );
+    await extractor.extract(TURNS);
+    const headers = new Headers(fetchMock.mock.calls[0][1].headers);
+    expect(headers.get("Authorization")).toBe("Bearer sk-secret");
+  });
+
+  it("drops malformed claims/intents instead of throwing", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      jsonResponse({
+        claims: [{ subtype: "bogus", content: "x" }, { content: "no subtype" }, 42],
+        intents: [{ content: "valid" }, { nope: true }, "string-intent"],
+      }),
+    );
+    const extractor = new HttpIntentExtractor({ endpoint: "http://x" }, { fetch: fetchMock });
+    const result = await extractor.extract(TURNS);
+    expect(result.claims).toEqual([]);
+    expect(result.intents).toEqual([{ content: "valid" }]);
+  });
+
+  it("throws a helpful error on a non-2xx response", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response("boom", { status: 503 }));
+    const extractor = new HttpIntentExtractor({ endpoint: "http://x" }, { fetch: fetchMock });
+    await expect(extractor.extract(TURNS)).rejects.toThrow(/503/);
+  });
+
+  it("requires an endpoint", () => {
+    expect(() => new HttpIntentExtractor({})).toThrow(/endpoint/i);
+  });
+});
+
+describe("NaiveIntentExtractor", () => {
+  it("derives one intent per user turn and emits no claims", async () => {
+    const result = await new NaiveIntentExtractor().extract([
+      { role: "user", content: "Add OAuth login to my app" },
+      { role: "assistant", content: "ok" },
+      { role: "user", content: "Now write tests for it" },
+    ]);
+    expect(result.claims).toEqual([]);
+    expect(result.intents.map((i) => i.content)).toEqual([
+      "Add OAuth login to my app",
+      "Now write tests for it",
+    ]);
+  });
+
+  it("ignores empty user turns", async () => {
+    const result = await new NaiveIntentExtractor().extract([
+      { role: "user", content: "   " },
+      { role: "user", content: "real intent" },
+    ]);
+    expect(result.intents.map((i) => i.content)).toEqual(["real intent"]);
+  });
+});
+
+describe("createExtractor", () => {
+  it("builds an HttpIntentExtractor for provider http", () => {
+    const cfg: AnalysisConfig = { extractor: { provider: "http", endpoint: "http://x" } };
+    expect(createExtractor(cfg)).toBeInstanceOf(HttpIntentExtractor);
+  });
+
+  it("builds an HttpIntentExtractor for provider cloud", () => {
+    const cfg: AnalysisConfig = {
+      extractor: { provider: "cloud", endpoint: "http://cloud", apiKey: "k" },
+    };
+    expect(createExtractor(cfg)).toBeInstanceOf(HttpIntentExtractor);
+  });
+
+  it("builds a NaiveIntentExtractor for provider naive", () => {
+    const cfg: AnalysisConfig = { extractor: { provider: "naive" } };
+    expect(createExtractor(cfg)).toBeInstanceOf(NaiveIntentExtractor);
+  });
+
+  it("defaults to http when an endpoint is set but no provider", () => {
+    const cfg: AnalysisConfig = { extractor: { endpoint: "http://x" } };
+    expect(createExtractor(cfg)).toBeInstanceOf(HttpIntentExtractor);
+  });
+
+  it("falls back to naive when no endpoint and no provider", () => {
+    expect(createExtractor({})).toBeInstanceOf(NaiveIntentExtractor);
+  });
+});

--- a/packages/core/src/lib/intents/extractor.test.ts
+++ b/packages/core/src/lib/intents/extractor.test.ts
@@ -1,7 +1,14 @@
 import { describe, expect, it, vi } from "vitest";
 import type { AnalysisConfig } from "../config.js";
-import { createExtractor, HttpIntentExtractor, NaiveIntentExtractor } from "./extractor.js";
+import {
+  checkExtractorHealth,
+  createExtractor,
+  HttpIntentExtractor,
+  NaiveIntentExtractor,
+} from "./extractor.js";
 import type { ChatTurn } from "./types.js";
+
+const EXTRACT_PATH = "/orbitals/claim-extractor/extract";
 
 const TURNS: ChatTurn[] = [
   { role: "user", content: "Help me add OAuth login to my Next.js app" },
@@ -15,10 +22,20 @@ function jsonResponse(body: unknown, status = 200): Response {
   });
 }
 
+/** The orbitals/sidecar response shape: rows wrapped under `extractions`. */
+function extractResponse(extractions: { claims?: unknown[]; intents?: unknown[] }): Response {
+  return jsonResponse({
+    extractions: { claims: extractions.claims ?? [], intents: extractions.intents ?? [] },
+    model: "claim-extractor-pro",
+    usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+    time_taken: 0.1,
+  });
+}
+
 describe("HttpIntentExtractor", () => {
-  it("POSTs the conversation and normalizes the model response", async () => {
+  it("POSTs the conversation to the orbitals path and unwraps `extractions`", async () => {
     const fetchMock = vi.fn().mockResolvedValue(
-      jsonResponse({
+      extractResponse({
         claims: [{ subtype: "capability", content: "The app uses Next.js" }],
         intents: [{ content: "Add OAuth login to a Next.js app" }],
       }),
@@ -37,28 +54,58 @@ describe("HttpIntentExtractor", () => {
     });
     expect(fetchMock).toHaveBeenCalledTimes(1);
     const [url, init] = fetchMock.mock.calls[0];
-    expect(url).toBe("http://127.0.0.1:8723/v1/extract");
+    expect(url).toBe(`http://127.0.0.1:8723${EXTRACT_PATH}`);
     expect(init.method).toBe("POST");
     const sentBody = JSON.parse(init.body as string);
     expect(sentBody.model).toBe("claim-extractor-4B");
-    expect(sentBody.messages).toEqual([
+    expect(sentBody.conversation).toEqual([
       { role: "user", content: "Help me add OAuth login to my Next.js app" },
       { role: "assistant", content: "Sure, here is how..." },
     ]);
   });
 
+  it("still reads a top-level (unwrapped) response for back-compat", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      jsonResponse({
+        claims: [{ subtype: "factoid", content: "fact" }],
+        intents: [{ content: "do a thing" }],
+      }),
+    );
+    const extractor = new HttpIntentExtractor({ endpoint: "http://x" }, { fetch: fetchMock });
+    const result = await extractor.extract(TURNS);
+    expect(result.intents).toEqual([{ content: "do a thing" }]);
+    expect(result.claims).toEqual([{ subtype: "factoid", content: "fact" }]);
+  });
+
+  it("normalizes Title-case subtypes from the hosted endpoint", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      extractResponse({
+        claims: [
+          { subtype: "Factoid", content: "a" },
+          { subtype: "User Assertion", content: "b" },
+        ],
+      }),
+    );
+    const extractor = new HttpIntentExtractor({ endpoint: "http://x" }, { fetch: fetchMock });
+    const result = await extractor.extract(TURNS);
+    expect(result.claims).toEqual([
+      { subtype: "factoid", content: "a" },
+      { subtype: "user_assertion", content: "b" },
+    ]);
+  });
+
   it("trims a trailing slash on the endpoint", async () => {
-    const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ claims: [], intents: [] }));
+    const fetchMock = vi.fn().mockResolvedValue(extractResponse({}));
     const extractor = new HttpIntentExtractor(
       { endpoint: "http://127.0.0.1:8723/" },
       { fetch: fetchMock },
     );
     await extractor.extract(TURNS);
-    expect(fetchMock.mock.calls[0][0]).toBe("http://127.0.0.1:8723/v1/extract");
+    expect(fetchMock.mock.calls[0][0]).toBe(`http://127.0.0.1:8723${EXTRACT_PATH}`);
   });
 
   it("sends a bearer header when an apiKey is configured", async () => {
-    const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ claims: [], intents: [] }));
+    const fetchMock = vi.fn().mockResolvedValue(extractResponse({}));
     const extractor = new HttpIntentExtractor(
       { endpoint: "http://remote/api", apiKey: "sk-secret" },
       { fetch: fetchMock },
@@ -68,9 +115,37 @@ describe("HttpIntentExtractor", () => {
     expect(headers.get("Authorization")).toBe("Bearer sk-secret");
   });
 
+  it("sends a basic header (base64 username:password) for basic auth", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(extractResponse({}));
+    const extractor = new HttpIntentExtractor(
+      {
+        endpoint: "https://extractor.example/api",
+        authScheme: "basic",
+        username: "alice",
+        apiKey: "s3cret",
+      },
+      { fetch: fetchMock },
+    );
+    await extractor.extract(TURNS);
+    const headers = new Headers(fetchMock.mock.calls[0][1].headers);
+    // alice:s3cret → YWxpY2U6czNjcmV0
+    expect(headers.get("Authorization")).toBe("Basic YWxpY2U6czNjcmV0");
+  });
+
+  it("sends no auth header for a bare local sidecar", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(extractResponse({}));
+    const extractor = new HttpIntentExtractor(
+      { endpoint: "http://127.0.0.1:8723" },
+      { fetch: fetchMock },
+    );
+    await extractor.extract(TURNS);
+    const headers = new Headers(fetchMock.mock.calls[0][1].headers);
+    expect(headers.get("Authorization")).toBeNull();
+  });
+
   it("drops malformed claims/intents instead of throwing", async () => {
     const fetchMock = vi.fn().mockResolvedValue(
-      jsonResponse({
+      extractResponse({
         claims: [{ subtype: "bogus", content: "x" }, { content: "no subtype" }, 42],
         intents: [{ content: "valid" }, { nope: true }, "string-intent"],
       }),
@@ -89,6 +164,46 @@ describe("HttpIntentExtractor", () => {
 
   it("requires an endpoint", () => {
     expect(() => new HttpIntentExtractor({})).toThrow(/endpoint/i);
+  });
+});
+
+describe("checkExtractorHealth", () => {
+  it("GETs /health with the configured auth and reports ok", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ status: "ok" }));
+    const health = await checkExtractorHealth(
+      {
+        endpoint: "https://extractor.example/api/",
+        authScheme: "basic",
+        username: "alice",
+        apiKey: "s3cret",
+      },
+      { fetch: fetchMock },
+    );
+    expect(health).toEqual({ ok: true, status: 200, detail: "ok" });
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("https://extractor.example/api/health");
+    expect(init.method).toBe("GET");
+    expect(new Headers(init.headers).get("Authorization")).toBe("Basic YWxpY2U6czNjcmV0");
+  });
+
+  it("reports a credentials hint on 401", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response("nope", { status: 401 }));
+    const health = await checkExtractorHealth({ endpoint: "http://x" }, { fetch: fetchMock });
+    expect(health.ok).toBe(false);
+    expect(health.status).toBe(401);
+    expect(health.detail).toMatch(/credentials/i);
+  });
+
+  it("never throws on a network error", async () => {
+    const fetchMock = vi.fn().mockRejectedValue(new Error("ECONNREFUSED"));
+    const health = await checkExtractorHealth({ endpoint: "http://nope" }, { fetch: fetchMock });
+    expect(health.ok).toBe(false);
+    expect(health.detail).toMatch(/ECONNREFUSED/);
+  });
+
+  it("returns a clear message when no endpoint is set", async () => {
+    const health = await checkExtractorHealth({});
+    expect(health).toEqual({ ok: false, detail: "No endpoint configured" });
   });
 });
 

--- a/packages/core/src/lib/intents/extractor.ts
+++ b/packages/core/src/lib/intents/extractor.ts
@@ -22,6 +22,8 @@ export interface HttpExtractorDeps {
   /** Abort a single extract after this many ms so a hung/crashed sidecar can't
    *  stall the whole run forever (default 5 min). */
   timeoutMs?: number;
+  /** Backoff sleep between retries; injected so tests don't wait on real time. */
+  sleep?: (ms: number) => Promise<void>;
 }
 
 const DEFAULT_EXTRACT_TIMEOUT_MS = 300_000;
@@ -30,6 +32,26 @@ const DEFAULT_HEALTH_TIMEOUT_MS = 10_000;
 
 /** Path of the extract endpoint, shared by every deployment (sidecar and hosted). */
 const EXTRACT_PATH = "/orbitals/claim-extractor/extract";
+
+/**
+ * Default cap on the JSON size (chars) of the `conversation` sent in one request.
+ * The hosted model has a fixed context window and returns a fast 500 when the
+ * conversation overflows it (≈75KB in practice), so we keep each request well under
+ * that and merge per-chunk results. Conservative on purpose; override per-deployment
+ * via `extractor.maxRequestChars` for a sidecar with a larger window.
+ */
+const DEFAULT_MAX_REQUEST_CHARS = 48_000;
+
+/**
+ * Retry a chunk this many times on a transient failure (5xx or a network error —
+ * the host flakes under load). A 4xx is never retried: a client error won't fix
+ * itself. A timeout isn't retried either, to bound total run time.
+ */
+const MAX_ATTEMPTS = 3;
+/** Linear backoff base between retries (attempt N waits N × this). */
+const RETRY_BASE_DELAY_MS = 500;
+
+const realSleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
 
 /**
  * Talks to an extractor HTTP service over the orbitals claim-extractor contract:
@@ -45,6 +67,12 @@ const EXTRACT_PATH = "/orbitals/claim-extractor/extract";
  * sidecar needs none. Responses are normalized defensively: the wrapper may be
  * absent (older sidecar), `evidences` may be omitted, subtypes may be Title Case,
  * and rows can be partially shaped.
+ *
+ * A long conversation is split into size-bounded chunks (see {@link DEFAULT_MAX_REQUEST_CHARS})
+ * so it can't overflow the model's context window, and each chunk is retried on a
+ * transient 5xx/network failure. The per-chunk results are merged and de-duplicated,
+ * so chunking is invisible to callers (and to the runner's extraction cache, which
+ * keys on the full turn list).
  */
 export class HttpIntentExtractor implements IntentExtractor {
   private readonly endpoint: string;
@@ -52,6 +80,8 @@ export class HttpIntentExtractor implements IntentExtractor {
   private readonly model?: string;
   private readonly fetchImpl: typeof fetch;
   private readonly timeoutMs: number;
+  private readonly maxRequestChars: number;
+  private readonly sleep: (ms: number) => Promise<void>;
 
   constructor(config: ExtractorConfig, deps: HttpExtractorDeps = {}) {
     if (!config.endpoint) {
@@ -62,46 +92,147 @@ export class HttpIntentExtractor implements IntentExtractor {
     this.model = config.model;
     this.fetchImpl = deps.fetch ?? globalThis.fetch;
     this.timeoutMs = deps.timeoutMs ?? DEFAULT_EXTRACT_TIMEOUT_MS;
+    this.maxRequestChars =
+      config.maxRequestChars && config.maxRequestChars > 0
+        ? config.maxRequestChars
+        : DEFAULT_MAX_REQUEST_CHARS;
+    this.sleep = deps.sleep ?? realSleep;
   }
 
   async extract(
     turns: ChatTurn[],
     serviceDescription?: AIServiceDescription,
   ): Promise<ExtractionResult> {
-    const headers = new Headers({ "Content-Type": "application/json" });
-    if (this.authHeader) headers.set("Authorization", this.authHeader);
+    const chunks = chunkTurns(turns, this.maxRequestChars);
+    if (chunks.length <= 1) {
+      return this.extractChunk(turns, serviceDescription);
+    }
+    // Sequentially extract each chunk (gentle on the endpoint) and merge. One chunk's
+    // failure still aborts the session — consistent with the single-request path.
+    const results: ExtractionResult[] = [];
+    for (const chunk of chunks) {
+      results.push(await this.extractChunk(chunk, serviceDescription));
+    }
+    return mergeResults(results);
+  }
 
+  /** Extract a single, already-size-bounded slice of turns (with retry). */
+  private async extractChunk(
+    turns: ChatTurn[],
+    serviceDescription?: AIServiceDescription,
+  ): Promise<ExtractionResult> {
     const body: Record<string, unknown> = {
       conversation: turns.map((t) => ({ role: t.role, content: t.content })),
     };
     if (this.model) body.model = this.model;
     if (serviceDescription) body.ai_service_description = serviceDescription;
-
-    let res: Response;
-    try {
-      res = await this.fetchImpl(`${this.endpoint}${EXTRACT_PATH}`, {
-        method: "POST",
-        headers,
-        body: JSON.stringify(body),
-        signal: AbortSignal.timeout(this.timeoutMs),
-      });
-    } catch (err) {
-      if (err instanceof Error && err.name === "TimeoutError") {
-        throw new Error(`intent extractor timed out after ${this.timeoutMs}ms`);
-      }
-      throw err;
-    }
-    if (!res.ok) {
-      // Surface the server's body (e.g. a 422 validation message, or the cause of
-      // a 500) so failures are diagnosable instead of a bare status line.
-      const detail = (await res.text().catch(() => "")).trim().slice(0, 300);
-      throw new Error(
-        `intent extractor returned ${res.status} ${res.statusText}${detail ? `: ${detail}` : ""}`,
-      );
-    }
-    const payload = (await res.json()) as unknown;
+    const payload = await this.fetchWithRetry(JSON.stringify(body));
     return normalizeResult(payload);
   }
+
+  /**
+   * POST the request body, retrying a transient failure (5xx or network error) with
+   * linear backoff. A 4xx throws immediately (won't fix itself); a timeout throws
+   * immediately (to bound total run time). The thrown error surfaces the server's
+   * response body so a failure is diagnosable, not a bare status line.
+   */
+  private async fetchWithRetry(body: string): Promise<unknown> {
+    const headers = new Headers({ "Content-Type": "application/json" });
+    if (this.authHeader) headers.set("Authorization", this.authHeader);
+
+    let lastError: Error | undefined;
+    for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+      let res: Response;
+      try {
+        res = await this.fetchImpl(`${this.endpoint}${EXTRACT_PATH}`, {
+          method: "POST",
+          headers,
+          body,
+          signal: AbortSignal.timeout(this.timeoutMs),
+        });
+      } catch (err) {
+        if (err instanceof Error && err.name === "TimeoutError") {
+          throw new Error(`intent extractor timed out after ${this.timeoutMs}ms`);
+        }
+        lastError = err instanceof Error ? err : new Error(String(err));
+        if (attempt === MAX_ATTEMPTS) throw lastError;
+        await this.sleep(RETRY_BASE_DELAY_MS * attempt);
+        continue;
+      }
+      if (res.ok) return res.json();
+
+      const detail = (await res.text().catch(() => "")).trim().slice(0, 300);
+      const error = new Error(
+        `intent extractor returned ${res.status} ${res.statusText}${detail ? `: ${detail}` : ""}`,
+      );
+      // Only a 5xx is transient; retry it. A 4xx won't change on retry.
+      if (res.status >= 500 && attempt < MAX_ATTEMPTS) {
+        lastError = error;
+        await this.sleep(RETRY_BASE_DELAY_MS * attempt);
+        continue;
+      }
+      throw error;
+    }
+    throw lastError ?? new Error("intent extractor request failed");
+  }
+}
+
+/**
+ * Split turns into chunks whose serialized `conversation` stays under `maxChars`, so
+ * a long chat can't overflow the model's context window. A turn is never split, so a
+ * single turn larger than the budget still gets its own chunk (the capture layer caps
+ * each turn well below any sane budget, so this is a safety net). A non-empty input
+ * always yields at least one chunk.
+ */
+export function chunkTurns(turns: ChatTurn[], maxChars: number): ChatTurn[][] {
+  const chunks: ChatTurn[][] = [];
+  let current: ChatTurn[] = [];
+  let size = 0;
+  for (const turn of turns) {
+    const turnSize = turnJsonSize(turn);
+    if (current.length > 0 && size + turnSize > maxChars) {
+      chunks.push(current);
+      current = [];
+      size = 0;
+    }
+    current.push(turn);
+    size += turnSize;
+  }
+  if (current.length > 0) chunks.push(current);
+  return chunks;
+}
+
+/** Approximate the serialized size a turn contributes to the `conversation` array. */
+function turnJsonSize(turn: ChatTurn): number {
+  // +1 approximates the array comma separator between turns.
+  return JSON.stringify({ role: turn.role, content: turn.content }).length + 1;
+}
+
+/**
+ * Merge per-chunk extractions into one result, de-duplicating across chunk
+ * boundaries: claims by (subtype, content), intents by content — both normalized
+ * (trimmed, lower-cased). First occurrence wins, preserving original order.
+ */
+function mergeResults(results: ExtractionResult[]): ExtractionResult {
+  const claims: Claim[] = [];
+  const intents: Intent[] = [];
+  const seenClaims = new Set<string>();
+  const seenIntents = new Set<string>();
+  for (const result of results) {
+    for (const claim of result.claims) {
+      const key = `${claim.subtype} ${claim.content.trim().toLowerCase()}`;
+      if (seenClaims.has(key)) continue;
+      seenClaims.add(key);
+      claims.push(claim);
+    }
+    for (const intent of result.intents) {
+      const key = intent.content.trim().toLowerCase();
+      if (seenIntents.has(key)) continue;
+      seenIntents.add(key);
+      intents.push(intent);
+    }
+  }
+  return { claims, intents };
 }
 
 /** Outcome of an extractor `/health` probe, surfaced by the Settings "Test" button. */

--- a/packages/core/src/lib/intents/extractor.ts
+++ b/packages/core/src/lib/intents/extractor.ts
@@ -1,0 +1,165 @@
+import type { AnalysisConfig, ExtractorConfig } from "../config.js";
+import type {
+  AIServiceDescription,
+  ChatTurn,
+  Claim,
+  ClaimSubtype,
+  ExtractionResult,
+  Intent,
+  IntentExtractor,
+} from "./types.js";
+
+const CLAIM_SUBTYPES: readonly ClaimSubtype[] = [
+  "factoid",
+  "capability",
+  "user_assertion",
+  "unverifiable",
+];
+
+/** Injection seam so tests can supply a fake `fetch`. */
+export interface HttpExtractorDeps {
+  fetch?: typeof fetch;
+  /** Abort a single extract after this many ms so a hung/crashed sidecar can't
+   *  stall the whole run forever (default 5 min). */
+  timeoutMs?: number;
+}
+
+const DEFAULT_EXTRACT_TIMEOUT_MS = 300_000;
+
+/**
+ * Talks to an extractor HTTP service over a single JSON contract:
+ *
+ *   POST {endpoint}/v1/extract
+ *   { model?, messages: [{ role, content }], service_description? }
+ *   → { claims: Claim[], intents: Intent[] }
+ *
+ * The same client serves every deployment: a local Apple-Silicon sidecar, a
+ * Docker+GPU box, or a remote/cloud endpoint — only the URL (and optional
+ * apiKey) differ. Responses are normalized defensively; the model may omit
+ * `evidences` and can return partially-shaped rows.
+ */
+export class HttpIntentExtractor implements IntentExtractor {
+  private readonly endpoint: string;
+  private readonly apiKey?: string;
+  private readonly model?: string;
+  private readonly fetchImpl: typeof fetch;
+  private readonly timeoutMs: number;
+
+  constructor(config: ExtractorConfig, deps: HttpExtractorDeps = {}) {
+    if (!config.endpoint) {
+      throw new Error("HttpIntentExtractor requires an `endpoint`");
+    }
+    this.endpoint = config.endpoint.replace(/\/+$/, "");
+    this.apiKey = config.apiKey;
+    this.model = config.model;
+    this.fetchImpl = deps.fetch ?? globalThis.fetch;
+    this.timeoutMs = deps.timeoutMs ?? DEFAULT_EXTRACT_TIMEOUT_MS;
+  }
+
+  async extract(
+    turns: ChatTurn[],
+    serviceDescription?: AIServiceDescription,
+  ): Promise<ExtractionResult> {
+    const headers = new Headers({ "Content-Type": "application/json" });
+    if (this.apiKey) headers.set("Authorization", `Bearer ${this.apiKey}`);
+
+    const body: Record<string, unknown> = {
+      messages: turns.map((t) => ({ role: t.role, content: t.content })),
+    };
+    if (this.model) body.model = this.model;
+    if (serviceDescription) body.service_description = serviceDescription;
+
+    let res: Response;
+    try {
+      res = await this.fetchImpl(`${this.endpoint}/v1/extract`, {
+        method: "POST",
+        headers,
+        body: JSON.stringify(body),
+        signal: AbortSignal.timeout(this.timeoutMs),
+      });
+    } catch (err) {
+      if (err instanceof Error && err.name === "TimeoutError") {
+        throw new Error(`intent extractor timed out after ${this.timeoutMs}ms`);
+      }
+      throw err;
+    }
+    if (!res.ok) {
+      throw new Error(`intent extractor returned ${res.status} ${res.statusText}`);
+    }
+    const payload = (await res.json()) as unknown;
+    return normalizeResult(payload);
+  }
+}
+
+/**
+ * Model-free fallback: treats each non-empty user turn as a candidate intent and
+ * emits no claims. Deterministic and dependency-light — used for development,
+ * tests, and when no extractor endpoint is configured.
+ */
+export class NaiveIntentExtractor implements IntentExtractor {
+  async extract(turns: ChatTurn[]): Promise<ExtractionResult> {
+    const intents: Intent[] = turns
+      .filter((t) => t.role === "user")
+      .map((t) => t.content.trim())
+      .filter((c) => c.length > 0)
+      .map((content) => ({ content }));
+    return { claims: [], intents };
+  }
+}
+
+/** Select the extractor implementation from the `analysis` config block. */
+export function createExtractor(
+  analysis: AnalysisConfig | undefined,
+  deps: HttpExtractorDeps = {},
+): IntentExtractor {
+  const extractor = analysis?.extractor ?? {};
+  const provider = extractor.provider ?? (extractor.endpoint ? "http" : "naive");
+  if (provider === "naive") return new NaiveIntentExtractor();
+  // "http" and "cloud" share the same HTTP client; cloud is just a remote endpoint.
+  return new HttpIntentExtractor(extractor, deps);
+}
+
+function normalizeResult(payload: unknown): ExtractionResult {
+  if (typeof payload !== "object" || payload === null) {
+    return { claims: [], intents: [] };
+  }
+  const obj = payload as Record<string, unknown>;
+  return {
+    claims: Array.isArray(obj.claims) ? obj.claims.map(normalizeClaim).filter(isPresent) : [],
+    intents: Array.isArray(obj.intents) ? obj.intents.map(normalizeIntent).filter(isPresent) : [],
+  };
+}
+
+function normalizeClaim(raw: unknown): Claim | undefined {
+  if (typeof raw !== "object" || raw === null) return undefined;
+  const obj = raw as Record<string, unknown>;
+  const subtype = obj.subtype;
+  const content = obj.content;
+  if (typeof content !== "string" || content.trim().length === 0) return undefined;
+  if (!CLAIM_SUBTYPES.includes(subtype as ClaimSubtype)) return undefined;
+  const claim: Claim = { subtype: subtype as ClaimSubtype, content };
+  const evidences = normalizeEvidences(obj.evidences);
+  if (evidences) claim.evidences = evidences;
+  return claim;
+}
+
+function normalizeIntent(raw: unknown): Intent | undefined {
+  if (typeof raw !== "object" || raw === null) return undefined;
+  const obj = raw as Record<string, unknown>;
+  const content = obj.content;
+  if (typeof content !== "string" || content.trim().length === 0) return undefined;
+  const intent: Intent = { content };
+  const evidences = normalizeEvidences(obj.evidences);
+  if (evidences) intent.evidences = evidences;
+  return intent;
+}
+
+function normalizeEvidences(raw: unknown): string[] | undefined {
+  if (!Array.isArray(raw)) return undefined;
+  const evidences = raw.filter((e): e is string => typeof e === "string" && e.length > 0);
+  return evidences.length > 0 ? evidences : undefined;
+}
+
+function isPresent<T>(value: T | undefined): value is T {
+  return value !== undefined;
+}

--- a/packages/core/src/lib/intents/extractor.ts
+++ b/packages/core/src/lib/intents/extractor.ts
@@ -25,22 +25,30 @@ export interface HttpExtractorDeps {
 }
 
 const DEFAULT_EXTRACT_TIMEOUT_MS = 300_000;
+/** Health probes hit a trivial endpoint; fail fast so the UI's Test button stays snappy. */
+const DEFAULT_HEALTH_TIMEOUT_MS = 10_000;
+
+/** Path of the extract endpoint, shared by every deployment (sidecar and hosted). */
+const EXTRACT_PATH = "/orbitals/claim-extractor/extract";
 
 /**
- * Talks to an extractor HTTP service over a single JSON contract:
+ * Talks to an extractor HTTP service over the orbitals claim-extractor contract:
  *
- *   POST {endpoint}/v1/extract
- *   { model?, messages: [{ role, content }], service_description? }
- *   → { claims: Claim[], intents: Intent[] }
+ *   POST {endpoint}/orbitals/claim-extractor/extract
+ *   { conversation: [{ role, content }], model?, skip_evidences?, ai_service_description? }
+ *   → { extractions: { claims: Claim[], intents: Intent[] }, model, usage, time_taken }
  *
- * The same client serves every deployment: a local Apple-Silicon sidecar, a
- * Docker+GPU box, or a remote/cloud endpoint — only the URL (and optional
- * apiKey) differ. Responses are normalized defensively; the model may omit
- * `evidences` and can return partially-shaped rows.
+ * The same client serves every deployment — a local Apple-Silicon sidecar, a
+ * Docker+GPU box, or the hosted Principled endpoint — so switching deployments is
+ * only a change of `endpoint` (and auth). Auth is `bearer` (Authorization: Bearer
+ * <apiKey>) or `basic` (Authorization: Basic <base64(username:apiKey)>); a local
+ * sidecar needs none. Responses are normalized defensively: the wrapper may be
+ * absent (older sidecar), `evidences` may be omitted, subtypes may be Title Case,
+ * and rows can be partially shaped.
  */
 export class HttpIntentExtractor implements IntentExtractor {
   private readonly endpoint: string;
-  private readonly apiKey?: string;
+  private readonly authHeader?: string;
   private readonly model?: string;
   private readonly fetchImpl: typeof fetch;
   private readonly timeoutMs: number;
@@ -49,8 +57,8 @@ export class HttpIntentExtractor implements IntentExtractor {
     if (!config.endpoint) {
       throw new Error("HttpIntentExtractor requires an `endpoint`");
     }
-    this.endpoint = config.endpoint.replace(/\/+$/, "");
-    this.apiKey = config.apiKey;
+    this.endpoint = normalizeEndpoint(config.endpoint);
+    this.authHeader = buildAuthHeader(config);
     this.model = config.model;
     this.fetchImpl = deps.fetch ?? globalThis.fetch;
     this.timeoutMs = deps.timeoutMs ?? DEFAULT_EXTRACT_TIMEOUT_MS;
@@ -61,17 +69,17 @@ export class HttpIntentExtractor implements IntentExtractor {
     serviceDescription?: AIServiceDescription,
   ): Promise<ExtractionResult> {
     const headers = new Headers({ "Content-Type": "application/json" });
-    if (this.apiKey) headers.set("Authorization", `Bearer ${this.apiKey}`);
+    if (this.authHeader) headers.set("Authorization", this.authHeader);
 
     const body: Record<string, unknown> = {
-      messages: turns.map((t) => ({ role: t.role, content: t.content })),
+      conversation: turns.map((t) => ({ role: t.role, content: t.content })),
     };
     if (this.model) body.model = this.model;
-    if (serviceDescription) body.service_description = serviceDescription;
+    if (serviceDescription) body.ai_service_description = serviceDescription;
 
     let res: Response;
     try {
-      res = await this.fetchImpl(`${this.endpoint}/v1/extract`, {
+      res = await this.fetchImpl(`${this.endpoint}${EXTRACT_PATH}`, {
         method: "POST",
         headers,
         body: JSON.stringify(body),
@@ -84,11 +92,110 @@ export class HttpIntentExtractor implements IntentExtractor {
       throw err;
     }
     if (!res.ok) {
-      throw new Error(`intent extractor returned ${res.status} ${res.statusText}`);
+      // Surface the server's body (e.g. a 422 validation message, or the cause of
+      // a 500) so failures are diagnosable instead of a bare status line.
+      const detail = (await res.text().catch(() => "")).trim().slice(0, 300);
+      throw new Error(
+        `intent extractor returned ${res.status} ${res.statusText}${detail ? `: ${detail}` : ""}`,
+      );
     }
     const payload = (await res.json()) as unknown;
     return normalizeResult(payload);
   }
+}
+
+/** Outcome of an extractor `/health` probe, surfaced by the Settings "Test" button. */
+export interface ExtractorHealth {
+  ok: boolean;
+  /** HTTP status when a response came back (absent on a network/timeout failure). */
+  status?: number;
+  /** Short human-readable detail: the server's `status` field, the HTTP status text, or the error. */
+  detail?: string;
+}
+
+/**
+ * Probe an extractor endpoint's `GET /health` with the configured auth. Never
+ * throws — a network error, timeout, or non-2xx all resolve to `{ ok: false }`
+ * with a human-readable `detail`, so the UI can render the result directly.
+ */
+export async function checkExtractorHealth(
+  config: ExtractorConfig,
+  deps: HttpExtractorDeps = {},
+): Promise<ExtractorHealth> {
+  if (!config.endpoint) {
+    return { ok: false, detail: "No endpoint configured" };
+  }
+  const endpoint = normalizeEndpoint(config.endpoint);
+  const authHeader = buildAuthHeader(config);
+  const headers = new Headers({ Accept: "application/json" });
+  if (authHeader) headers.set("Authorization", authHeader);
+  const fetchImpl = deps.fetch ?? globalThis.fetch;
+  const timeoutMs = deps.timeoutMs ?? DEFAULT_HEALTH_TIMEOUT_MS;
+
+  let res: Response;
+  try {
+    res = await fetchImpl(`${endpoint}/health`, {
+      method: "GET",
+      headers,
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+  } catch (err) {
+    if (err instanceof Error && err.name === "TimeoutError") {
+      return { ok: false, detail: `Timed out after ${timeoutMs}ms` };
+    }
+    return { ok: false, detail: err instanceof Error ? err.message : String(err) };
+  }
+  if (!res.ok) {
+    // 401/403 most often means the auth (or its scheme) is wrong — say so plainly.
+    const hint = res.status === 401 || res.status === 403 ? " (check credentials)" : "";
+    return { ok: false, status: res.status, detail: `${res.status} ${res.statusText}${hint}` };
+  }
+  const detail = await readHealthDetail(res);
+  return { ok: true, status: res.status, detail };
+}
+
+/** Pull a short status string from a /health body; fall back to the HTTP status text. */
+async function readHealthDetail(res: Response): Promise<string> {
+  try {
+    const body = (await res.json()) as unknown;
+    if (
+      body &&
+      typeof body === "object" &&
+      typeof (body as { status?: unknown }).status === "string"
+    ) {
+      return (body as { status: string }).status;
+    }
+  } catch {
+    // non-JSON body — fall through to the status text
+  }
+  return res.statusText || "ok";
+}
+
+/** Trim trailing slashes so endpoint + path concatenation can't double up. */
+function normalizeEndpoint(endpoint: string): string {
+  return endpoint.replace(/\/+$/, "");
+}
+
+/**
+ * Build the `Authorization` header value from the extractor config, or undefined
+ * when no auth applies. Scheme defaults: `basic` when a username is set, else
+ * `bearer` when an apiKey is set, else none — so a bare local sidecar (no creds)
+ * sends no auth, and the common cases need no explicit `authScheme`.
+ */
+function buildAuthHeader(config: ExtractorConfig): string | undefined {
+  const scheme =
+    config.authScheme ?? (config.username ? "basic" : config.apiKey ? "bearer" : undefined);
+  if (scheme === "basic") {
+    const username = config.username ?? "";
+    const password = config.apiKey ?? "";
+    if (!username && !password) return undefined;
+    const token = Buffer.from(`${username}:${password}`, "utf8").toString("base64");
+    return `Basic ${token}`;
+  }
+  if (scheme === "bearer" && config.apiKey) {
+    return `Bearer ${config.apiKey}`;
+  }
+  return undefined;
 }
 
 /**
@@ -123,7 +230,11 @@ function normalizeResult(payload: unknown): ExtractionResult {
   if (typeof payload !== "object" || payload === null) {
     return { claims: [], intents: [] };
   }
-  const obj = payload as Record<string, unknown>;
+  // The orbitals contract wraps rows under `extractions`; older sidecars returned
+  // them at the top level. Read the wrapper when present, else the payload itself.
+  const root = payload as Record<string, unknown>;
+  const wrapper = root.extractions;
+  const obj = wrapper && typeof wrapper === "object" ? (wrapper as Record<string, unknown>) : root;
   return {
     claims: Array.isArray(obj.claims) ? obj.claims.map(normalizeClaim).filter(isPresent) : [],
     intents: Array.isArray(obj.intents) ? obj.intents.map(normalizeIntent).filter(isPresent) : [],
@@ -133,14 +244,30 @@ function normalizeResult(payload: unknown): ExtractionResult {
 function normalizeClaim(raw: unknown): Claim | undefined {
   if (typeof raw !== "object" || raw === null) return undefined;
   const obj = raw as Record<string, unknown>;
-  const subtype = obj.subtype;
+  const subtype = normalizeSubtype(obj.subtype);
   const content = obj.content;
   if (typeof content !== "string" || content.trim().length === 0) return undefined;
-  if (!CLAIM_SUBTYPES.includes(subtype as ClaimSubtype)) return undefined;
-  const claim: Claim = { subtype: subtype as ClaimSubtype, content };
+  if (!subtype) return undefined;
+  const claim: Claim = { subtype, content };
   const evidences = normalizeEvidences(obj.evidences);
   if (evidences) claim.evidences = evidences;
   return claim;
+}
+
+/**
+ * Map a raw subtype to a wire-contract value, tolerating the hosted endpoint's
+ * Title Case ("Factoid", "User Assertion") alongside the sidecar's
+ * lowercase_underscore form. Returns undefined for anything unrecognized.
+ */
+function normalizeSubtype(raw: unknown): ClaimSubtype | undefined {
+  if (typeof raw !== "string") return undefined;
+  const canonical = raw
+    .trim()
+    .toLowerCase()
+    .replace(/[\s-]+/g, "_");
+  return CLAIM_SUBTYPES.includes(canonical as ClaimSubtype)
+    ? (canonical as ClaimSubtype)
+    : undefined;
 }
 
 function normalizeIntent(raw: unknown): Intent | undefined {

--- a/packages/core/src/lib/intents/index.ts
+++ b/packages/core/src/lib/intents/index.ts
@@ -8,6 +8,7 @@ export {
 } from "./chat-source.js";
 export type { HttpExtractorDeps } from "./extractor.js";
 export { createExtractor, HttpIntentExtractor, NaiveIntentExtractor } from "./extractor.js";
+export { appendRunLog, readRunLog, runsLogPath } from "./observability.js";
 export type { IntentsPaths } from "./paths.js";
 export { intentsPaths, resolveRatelDir } from "./paths.js";
 export type {
@@ -36,9 +37,13 @@ export {
   INTENTS_INDEX_VERSION,
   mergeIntoIndex,
   normalizeIntentKey,
+  rankIntentRecords,
+  readAllSessionIntents,
   readIntentsIndex,
   readSessionIntents,
+  rebuildIndex,
   removeIntent,
+  removeIntentFromSessions,
   writeIntentsIndex,
   writeSessionIntents,
 } from "./store.js";
@@ -55,6 +60,8 @@ export type {
   IntentCoverage,
   IntentExtractor,
   IntentRecord,
+  RunLogEntry,
+  RunLogSessionEntry,
   SkillDraft,
   SkillGenContext,
   SkillGenerator,

--- a/packages/core/src/lib/intents/index.ts
+++ b/packages/core/src/lib/intents/index.ts
@@ -2,6 +2,7 @@ export type { ChatState, HookChatSourceOptions } from "./chat-source.js";
 export {
   CHAT_STATE_VERSION,
   HookChatSource,
+  markSessionsForReanalysis,
   readChatState,
   sessionTurnsPath,
   writeChatState,

--- a/packages/core/src/lib/intents/index.ts
+++ b/packages/core/src/lib/intents/index.ts
@@ -1,0 +1,61 @@
+export type { ChatState, HookChatSourceOptions } from "./chat-source.js";
+export {
+  CHAT_STATE_VERSION,
+  HookChatSource,
+  readChatState,
+  sessionTurnsPath,
+  writeChatState,
+} from "./chat-source.js";
+export type { HttpExtractorDeps } from "./extractor.js";
+export { createExtractor, HttpIntentExtractor, NaiveIntentExtractor } from "./extractor.js";
+export type { IntentsPaths } from "./paths.js";
+export { intentsPaths, resolveRatelDir } from "./paths.js";
+export type {
+  AnthropicDeps,
+  AnthropicGeneratorConfig,
+  ClaudeCliDeps,
+  ClaudeCliGeneratorConfig,
+  SpawnFn,
+  SpawnResult,
+} from "./skill-generator.js";
+export {
+  AnthropicApiSkillGenerator,
+  buildSkillPrompt,
+  ClaudeCliSkillGenerator,
+  createSkillGenerator,
+  parseSkillDraft,
+} from "./skill-generator.js";
+export type {
+  IntentsIndex,
+  SessionIntents,
+  SessionSummary,
+  StoredIntent,
+} from "./store.js";
+export {
+  emptyIndex,
+  INTENTS_INDEX_VERSION,
+  mergeIntoIndex,
+  normalizeIntentKey,
+  readIntentsIndex,
+  readSessionIntents,
+  removeIntent,
+  writeIntentsIndex,
+  writeSessionIntents,
+} from "./store.js";
+export type {
+  AIServiceDescription,
+  ChatRole,
+  ChatSessionMeta,
+  ChatSource,
+  ChatTurn,
+  Claim,
+  ClaimSubtype,
+  ExtractionResult,
+  Intent,
+  IntentCoverage,
+  IntentExtractor,
+  IntentRecord,
+  SkillDraft,
+  SkillGenContext,
+  SkillGenerator,
+} from "./types.js";

--- a/packages/core/src/lib/intents/index.ts
+++ b/packages/core/src/lib/intents/index.ts
@@ -6,8 +6,13 @@ export {
   sessionTurnsPath,
   writeChatState,
 } from "./chat-source.js";
-export type { HttpExtractorDeps } from "./extractor.js";
-export { createExtractor, HttpIntentExtractor, NaiveIntentExtractor } from "./extractor.js";
+export type { ExtractorHealth, HttpExtractorDeps } from "./extractor.js";
+export {
+  checkExtractorHealth,
+  createExtractor,
+  HttpIntentExtractor,
+  NaiveIntentExtractor,
+} from "./extractor.js";
 export { appendRunLog, readRunLog, runsLogPath } from "./observability.js";
 export type { IntentsPaths } from "./paths.js";
 export { intentsPaths, resolveRatelDir } from "./paths.js";

--- a/packages/core/src/lib/intents/observability.test.ts
+++ b/packages/core/src/lib/intents/observability.test.ts
@@ -1,0 +1,99 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { nodeJsonFs } from "../../io.js";
+import { appendRunLog, readRunLog, runsLogPath } from "./observability.js";
+import type { RunLogEntry } from "./types.js";
+
+let dir: string;
+
+beforeEach(async () => {
+  dir = await mkdtemp(join(tmpdir(), "ratel-runs-"));
+});
+
+afterEach(async () => {
+  await rm(dir, { recursive: true, force: true });
+});
+
+function entry(overrides: Partial<RunLogEntry> = {}): RunLogEntry {
+  return {
+    runId: "r1",
+    at: "2026-06-19T10:00:00.000Z",
+    trigger: "manual",
+    durationMs: 100,
+    totalIntents: 2,
+    totalGaps: 1,
+    sessions: [
+      {
+        sessionId: "s1",
+        ok: true,
+        intents: 2,
+        gaps: 1,
+        turns: 8,
+        latencyMs: 90,
+        cacheHit: false,
+      },
+    ],
+    ...overrides,
+  };
+}
+
+describe("runsLogPath", () => {
+  it("points at runs.jsonl under the intents dir", () => {
+    expect(runsLogPath(dir)).toBe(join(dir, "runs.jsonl"));
+  });
+});
+
+describe("appendRunLog + readRunLog", () => {
+  it("round-trips an appended entry", async () => {
+    await appendRunLog(nodeJsonFs, dir, entry());
+    const read = await readRunLog(nodeJsonFs, dir);
+    expect(read).toHaveLength(1);
+    expect(read[0].runId).toBe("r1");
+  });
+
+  it("returns [] when no log exists", async () => {
+    expect(await readRunLog(nodeJsonFs, dir)).toEqual([]);
+  });
+
+  it("returns entries newest-first", async () => {
+    await appendRunLog(nodeJsonFs, dir, entry({ runId: "r1" }));
+    await appendRunLog(nodeJsonFs, dir, entry({ runId: "r2" }));
+    await appendRunLog(nodeJsonFs, dir, entry({ runId: "r3" }));
+    const read = await readRunLog(nodeJsonFs, dir);
+    expect(read.map((e) => e.runId)).toEqual(["r3", "r2", "r1"]);
+  });
+
+  it("caps reads to the requested limit", async () => {
+    await appendRunLog(nodeJsonFs, dir, entry({ runId: "r1" }));
+    await appendRunLog(nodeJsonFs, dir, entry({ runId: "r2" }));
+    const read = await readRunLog(nodeJsonFs, dir, 1);
+    expect(read.map((e) => e.runId)).toEqual(["r2"]);
+  });
+
+  it("keeps only the last 200 entries on the log", async () => {
+    for (let i = 0; i < 205; i += 1) {
+      await appendRunLog(nodeJsonFs, dir, entry({ runId: `r${i}` }));
+    }
+    const all = await readRunLog(nodeJsonFs, dir, 1000);
+    expect(all).toHaveLength(200);
+    // newest-first: most recent is r204, oldest retained is r5
+    expect(all[0].runId).toBe("r204");
+    expect(all[all.length - 1].runId).toBe("r5");
+  });
+
+  it("tolerates malformed lines on read", async () => {
+    await appendRunLog(nodeJsonFs, dir, entry({ runId: "r1" }));
+    await writeFile(runsLogPath(dir), `not-json\n${JSON.stringify(entry({ runId: "r2" }))}\n`);
+    const read = await readRunLog(nodeJsonFs, dir);
+    expect(read.map((e) => e.runId)).toEqual(["r2"]);
+  });
+
+  it("tolerates a malformed existing line when appending", async () => {
+    await writeFile(runsLogPath(dir), "not-json\n");
+    await appendRunLog(nodeJsonFs, dir, entry({ runId: "r1" }));
+    const read = await readRunLog(nodeJsonFs, dir);
+    expect(read.map((e) => e.runId)).toEqual(["r1"]);
+  });
+});

--- a/packages/core/src/lib/intents/observability.ts
+++ b/packages/core/src/lib/intents/observability.ts
@@ -1,0 +1,56 @@
+import { join } from "node:path";
+import type { JsonFs } from "../../io.js";
+import type { RunLogEntry } from "./types.js";
+
+/** Keep the runs log bounded so it stays cheap to read and write. */
+const MAX_RUN_LOG_ENTRIES = 200;
+
+/** Default number of entries returned by {@link readRunLog}. */
+const DEFAULT_READ_LIMIT = 50;
+
+/** Path to the append-only run telemetry log: `<intentsDir>/runs.jsonl`. */
+export function runsLogPath(intentsDir: string): string {
+  return join(intentsDir, "runs.jsonl");
+}
+
+/** Split file contents into non-empty, trimmed JSONL lines. */
+function toLines(contents: string | null): string[] {
+  if (!contents) return [];
+  return contents.split("\n").filter((line) => line.trim().length > 0);
+}
+
+/**
+ * Append one run entry to the JSONL log, keeping only the most recent
+ * {@link MAX_RUN_LOG_ENTRIES} entries. Malformed pre-existing lines are kept
+ * verbatim (we only trim the count); the write is atomic.
+ */
+export async function appendRunLog(
+  fs: JsonFs,
+  intentsDir: string,
+  entry: RunLogEntry,
+): Promise<void> {
+  const existing = toLines(await fs.read(runsLogPath(intentsDir)));
+  const next = [...existing, JSON.stringify(entry)].slice(-MAX_RUN_LOG_ENTRIES);
+  await fs.writeAtomic(runsLogPath(intentsDir), `${next.join("\n")}\n`);
+}
+
+/**
+ * Read run entries newest-first, capped to `limit` (default
+ * {@link DEFAULT_READ_LIMIT}). Malformed lines are skipped rather than thrown.
+ */
+export async function readRunLog(
+  fs: JsonFs,
+  intentsDir: string,
+  limit = DEFAULT_READ_LIMIT,
+): Promise<RunLogEntry[]> {
+  const lines = toLines(await fs.read(runsLogPath(intentsDir)));
+  const entries: RunLogEntry[] = [];
+  for (const line of lines) {
+    try {
+      entries.push(JSON.parse(line) as RunLogEntry);
+    } catch {
+      // skip malformed line
+    }
+  }
+  return entries.reverse().slice(0, limit);
+}

--- a/packages/core/src/lib/intents/paths.ts
+++ b/packages/core/src/lib/intents/paths.ts
@@ -1,0 +1,28 @@
+import { join } from "node:path";
+
+export interface IntentsPaths {
+  /** The `.ratel` home directory. */
+  ratelDir: string;
+  /** Where the capture hook writes chat turns + state. */
+  chatDir: string;
+  /** Where the runner writes the cumulative index + per-session results. */
+  intentsDir: string;
+}
+
+/** Derive the chat + intents directories from a resolved `.ratel` home. */
+export function intentsPaths(ratelDir: string): IntentsPaths {
+  return {
+    ratelDir,
+    chatDir: join(ratelDir, "chat"),
+    intentsDir: join(ratelDir, "intents"),
+  };
+}
+
+/**
+ * Resolve the `.ratel` home directory, honoring `RATEL_HOME` exactly as the
+ * capture hook (`log-tool-usage.mjs` / `capture-chat.mjs`) does so the runner
+ * reads from the same place the hooks write.
+ */
+export function resolveRatelDir(env: { RATEL_HOME?: string }, homeDir: string): string {
+  return env.RATEL_HOME || join(homeDir, ".ratel");
+}

--- a/packages/core/src/lib/intents/skill-generator.test.ts
+++ b/packages/core/src/lib/intents/skill-generator.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import type { AnalysisConfig } from "../config.js";
 import {
   AnthropicApiSkillGenerator,
+  buildSkillPrompt,
   ClaudeCliSkillGenerator,
   createSkillGenerator,
   parseSkillDraft,
@@ -15,6 +16,62 @@ const DRAFT_JSON = JSON.stringify({
   description: "Add OAuth login to a Next.js app",
   tags: ["nextjs", "auth", "oauth"],
   body: "# OAuth in Next.js\n\nUse the App Router...",
+});
+
+describe("buildSkillPrompt", () => {
+  it("always asks for a single JSON object", () => {
+    const prompt = buildSkillPrompt(INTENT);
+    expect(prompt).toMatch(/Respond with ONLY a single JSON object/);
+    expect(prompt).toContain('"name"');
+    expect(prompt).toContain('"body"');
+  });
+
+  it("omits the evidence and related sections when absent", () => {
+    const prompt = buildSkillPrompt(INTENT);
+    expect(prompt).not.toMatch(/What the user actually did/i);
+    expect(prompt).not.toMatch(/Related things the user repeatedly asks/i);
+  });
+
+  it("includes the evidence section with bullets when evidences provided", () => {
+    const prompt = buildSkillPrompt(INTENT, {
+      evidences: ["ran `npm run build`", "asked how to wire OAuth callback"],
+    });
+    expect(prompt).toMatch(/What the user actually did/i);
+    expect(prompt).toContain("- ran `npm run build`");
+    expect(prompt).toContain("- asked how to wire OAuth callback");
+  });
+
+  it("includes the related section with bullets when relatedIntents provided", () => {
+    const prompt = buildSkillPrompt(INTENT, {
+      relatedIntents: ["add logout flow", "refresh tokens"],
+    });
+    expect(prompt).toMatch(/Related things the user repeatedly asks/i);
+    expect(prompt).toContain("- add logout flow");
+    expect(prompt).toContain("- refresh tokens");
+  });
+
+  it("keeps the existing existingSkillIds dedup line", () => {
+    const prompt = buildSkillPrompt(INTENT, { existingSkillIds: ["api-design"] });
+    expect(prompt).toMatch(/do not duplicate these/i);
+    expect(prompt).toContain("api-design");
+  });
+
+  it("caps the number of evidence bullets", () => {
+    const evidences = Array.from({ length: 50 }, (_, i) => `evidence number ${i}`);
+    const prompt = buildSkillPrompt(INTENT, { evidences });
+    const bulletCount = prompt.split("\n").filter((l) => l.startsWith("- evidence number")).length;
+    expect(bulletCount).toBeLessThanOrEqual(12);
+    expect(bulletCount).toBeGreaterThan(0);
+  });
+
+  it("caps the length of each evidence bullet", () => {
+    const long = "x".repeat(5000);
+    const prompt = buildSkillPrompt(INTENT, { evidences: [long] });
+    const bullet = prompt.split("\n").find((l) => l.startsWith("- xxx"));
+    expect(bullet).toBeDefined();
+    // bullet = "- " + capped content (+ optional ellipsis); stay well under the raw length.
+    expect((bullet as string).length).toBeLessThanOrEqual(2 + 300 + 1);
+  });
 });
 
 describe("parseSkillDraft", () => {
@@ -114,5 +171,34 @@ describe("createSkillGenerator", () => {
   it("honors an explicit claude-cli provider even with an apiKey", () => {
     const cfg: AnalysisConfig = { skillGen: { provider: "claude-cli", apiKey: "sk" } };
     expect(createSkillGenerator(cfg)).toBeInstanceOf(ClaudeCliSkillGenerator);
+  });
+
+  it("passes the configured model through the API path", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ content: [{ type: "text", text: DRAFT_JSON }] }), {
+        status: 200,
+      }),
+    );
+    const cfg: AnalysisConfig = {
+      skillGen: { provider: "auto", apiKey: "sk-ant", model: "claude-opus-4-6" },
+    };
+    const gen = createSkillGenerator(cfg, { anthropic: { fetch: fetchMock } });
+    expect(gen).toBeInstanceOf(AnthropicApiSkillGenerator);
+    await gen.generate(INTENT);
+    const [, init] = fetchMock.mock.calls[0];
+    expect(JSON.parse(init.body as string).model).toBe("claude-opus-4-6");
+  });
+
+  it("passes the configured model through the claude-cli path", async () => {
+    const spawnMock = vi.fn().mockResolvedValue({ stdout: DRAFT_JSON, stderr: "", code: 0 });
+    const cfg: AnalysisConfig = {
+      skillGen: { provider: "claude-cli", model: "sonnet" },
+    };
+    const gen = createSkillGenerator(cfg, { cli: { spawn: spawnMock } });
+    expect(gen).toBeInstanceOf(ClaudeCliSkillGenerator);
+    await gen.generate(INTENT);
+    const [, args] = spawnMock.mock.calls[0];
+    expect(args).toContain("--model");
+    expect(args[args.indexOf("--model") + 1]).toBe("sonnet");
   });
 });

--- a/packages/core/src/lib/intents/skill-generator.test.ts
+++ b/packages/core/src/lib/intents/skill-generator.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it, vi } from "vitest";
+import type { AnalysisConfig } from "../config.js";
+import {
+  AnthropicApiSkillGenerator,
+  ClaudeCliSkillGenerator,
+  createSkillGenerator,
+  parseSkillDraft,
+} from "./skill-generator.js";
+import type { Intent } from "./types.js";
+
+const INTENT: Intent = { content: "Add OAuth login to a Next.js app" };
+
+const DRAFT_JSON = JSON.stringify({
+  name: "nextjs-oauth-login",
+  description: "Add OAuth login to a Next.js app",
+  tags: ["nextjs", "auth", "oauth"],
+  body: "# OAuth in Next.js\n\nUse the App Router...",
+});
+
+describe("parseSkillDraft", () => {
+  it("parses a bare JSON object", () => {
+    const draft = parseSkillDraft(DRAFT_JSON);
+    expect(draft.name).toBe("nextjs-oauth-login");
+    expect(draft.tags).toEqual(["nextjs", "auth", "oauth"]);
+  });
+
+  it("extracts JSON wrapped in markdown fences and prose", () => {
+    const wrapped = `Here is the skill:\n\n\`\`\`json\n${DRAFT_JSON}\n\`\`\`\nHope it helps!`;
+    const draft = parseSkillDraft(wrapped);
+    expect(draft.name).toBe("nextjs-oauth-login");
+  });
+
+  it("slugifies an unsafe name", () => {
+    const draft = parseSkillDraft(
+      JSON.stringify({ name: "OAuth Login!!", description: "d", body: "b" }),
+    );
+    expect(draft.name).toBe("oauth-login");
+  });
+
+  it("throws when no JSON object is present", () => {
+    expect(() => parseSkillDraft("sorry, I cannot")).toThrow(/draft/i);
+  });
+
+  it("throws when required fields are missing", () => {
+    expect(() => parseSkillDraft(JSON.stringify({ name: "x" }))).toThrow(/description|body/i);
+  });
+});
+
+describe("AnthropicApiSkillGenerator", () => {
+  it("calls the messages API and returns a parsed draft", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ content: [{ type: "text", text: DRAFT_JSON }] }), {
+        status: 200,
+      }),
+    );
+    const gen = new AnthropicApiSkillGenerator(
+      { apiKey: "sk-ant", model: "claude-sonnet-4-6" },
+      { fetch: fetchMock },
+    );
+    const draft = await gen.generate(INTENT, { existingSkillIds: ["api-design"] });
+    expect(draft.name).toBe("nextjs-oauth-login");
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toContain("/v1/messages");
+    const headers = new Headers(init.headers);
+    expect(headers.get("x-api-key")).toBe("sk-ant");
+    expect(JSON.parse(init.body as string).model).toBe("claude-sonnet-4-6");
+  });
+
+  it("requires an apiKey", () => {
+    expect(() => new AnthropicApiSkillGenerator({})).toThrow(/apiKey/i);
+  });
+});
+
+describe("ClaudeCliSkillGenerator", () => {
+  it("spawns claude -p and parses stdout", async () => {
+    const spawnMock = vi.fn().mockResolvedValue({ stdout: DRAFT_JSON, stderr: "", code: 0 });
+    const gen = new ClaudeCliSkillGenerator({}, { spawn: spawnMock });
+    const draft = await gen.generate(INTENT);
+    expect(draft.name).toBe("nextjs-oauth-login");
+    const [cmd, args] = spawnMock.mock.calls[0];
+    expect(cmd).toBe("claude");
+    expect(args).toContain("-p");
+    // Skips loading the user's MCP servers, which otherwise boot on every call.
+    expect(args).toContain("--strict-mcp-config");
+  });
+
+  it("throws when the CLI exits non-zero", async () => {
+    const spawnMock = vi.fn().mockResolvedValue({ stdout: "", stderr: "not found", code: 127 });
+    const gen = new ClaudeCliSkillGenerator({}, { spawn: spawnMock });
+    await expect(gen.generate(INTENT)).rejects.toThrow(/claude/i);
+  });
+});
+
+describe("createSkillGenerator", () => {
+  it("auto → anthropic-api when an apiKey is configured", () => {
+    const cfg: AnalysisConfig = { skillGen: { provider: "auto", apiKey: "sk-ant" } };
+    expect(createSkillGenerator(cfg)).toBeInstanceOf(AnthropicApiSkillGenerator);
+  });
+
+  it("auto → claude-cli when no apiKey is configured", () => {
+    const cfg: AnalysisConfig = { skillGen: { provider: "auto" } };
+    expect(createSkillGenerator(cfg)).toBeInstanceOf(ClaudeCliSkillGenerator);
+  });
+
+  it("defaults to auto when skillGen is absent", () => {
+    expect(createSkillGenerator({})).toBeInstanceOf(ClaudeCliSkillGenerator);
+  });
+
+  it("honors an explicit anthropic-api provider", () => {
+    const cfg: AnalysisConfig = { skillGen: { provider: "anthropic-api", apiKey: "sk" } };
+    expect(createSkillGenerator(cfg)).toBeInstanceOf(AnthropicApiSkillGenerator);
+  });
+
+  it("honors an explicit claude-cli provider even with an apiKey", () => {
+    const cfg: AnalysisConfig = { skillGen: { provider: "claude-cli", apiKey: "sk" } };
+    expect(createSkillGenerator(cfg)).toBeInstanceOf(ClaudeCliSkillGenerator);
+  });
+});

--- a/packages/core/src/lib/intents/skill-generator.test.ts
+++ b/packages/core/src/lib/intents/skill-generator.test.ts
@@ -56,6 +56,46 @@ describe("buildSkillPrompt", () => {
     expect(prompt).toContain("api-design");
   });
 
+  it("mandates the structured SKILL.md section layout", () => {
+    const prompt = buildSkillPrompt(INTENT);
+    for (const heading of [
+      "## When to use",
+      "## Prerequisites",
+      "## Steps",
+      "## Constraints",
+      "## Verification",
+    ]) {
+      expect(prompt).toContain(heading);
+    }
+  });
+
+  it("spells out the quality bar: grounded, with a contract, procedure and constraints", () => {
+    const prompt = buildSkillPrompt(INTENT);
+    expect(prompt).toMatch(/GROUNDED/);
+    expect(prompt).toMatch(/CONTRACT/);
+    expect(prompt).toMatch(/PROCEDURE/);
+    expect(prompt).toMatch(/CONSTRAINTS/);
+    // Still forbids the generic filler that wrecks BM25 matching.
+    expect(prompt).toContain("'the user'");
+  });
+
+  it("requires safe, portable output (no secrets or machine-specific paths)", () => {
+    const prompt = buildSkillPrompt(INTENT);
+    expect(prompt).toMatch(/No secrets/i);
+    expect(prompt).toMatch(/absolute paths/i);
+  });
+
+  it("delimits supplied context with XML tags", () => {
+    const prompt = buildSkillPrompt(INTENT, {
+      evidences: ["ran `npm run build`"],
+      relatedIntents: ["add logout flow"],
+    });
+    expect(prompt).toContain("<evidence>");
+    expect(prompt).toContain("</evidence>");
+    expect(prompt).toContain("<related_requests>");
+    expect(prompt).toContain("<uncovered_request>");
+  });
+
   it("caps the number of evidence bullets", () => {
     const evidences = Array.from({ length: 50 }, (_, i) => `evidence number ${i}`);
     const prompt = buildSkillPrompt(INTENT, { evidences });

--- a/packages/core/src/lib/intents/skill-generator.ts
+++ b/packages/core/src/lib/intents/skill-generator.ts
@@ -5,7 +5,10 @@ import type { Intent, SkillDraft, SkillGenContext, SkillGenerator } from "./type
 const DEFAULT_ANTHROPIC_MODEL = "claude-sonnet-4-6";
 const ANTHROPIC_MESSAGES_URL = "https://api.anthropic.com/v1/messages";
 const ANTHROPIC_VERSION = "2023-06-01";
-const MAX_TOKENS = 2048;
+const MAX_TOKENS = 4096;
+/** Keep prompts bounded: cap how much real-context evidence we inline. */
+const MAX_EVIDENCE_BULLETS = 12;
+const MAX_EVIDENCE_LINE_LEN = 300;
 /** Bound both generators so a hung CLI/API call can't freeze the Offer dialog. */
 const DEFAULT_SKILLGEN_TIMEOUT_MS = 120_000;
 
@@ -17,6 +20,14 @@ export function buildSkillPrompt(intent: Intent, context?: SkillGenContext): str
   const existing = context?.existingSkillIds?.length
     ? `\nExisting skills (do not duplicate these): ${context.existingSkillIds.join(", ")}.`
     : "";
+  const evidenceSection = buildBulletSection(
+    "What the user actually did/asked (ground the skill in THIS, not a generic guess):",
+    context?.evidences,
+  );
+  const relatedSection = buildBulletSection(
+    "Related things the user repeatedly asks for (the skill may cover these too):",
+    context?.relatedIntents,
+  );
   return [
     "You are authoring a reusable Agent Skill for the Ratel MCP gateway.",
     `The user repeatedly tries to do this, but no skill covers it: "${intent.content}".${existing}`,
@@ -25,6 +36,10 @@ export function buildSkillPrompt(intent: Intent, context?: SkillGenContext): str
     "(BM25) against future requests, so use precise, distinctive wording — concrete",
     "nouns/verbs from this task — and AVOID generic filler ('the user', 'assistant',",
     "'help', 'task', 'do this') that would make it match unrelated intents.",
+    ...evidenceSection,
+    ...relatedSection,
+    "",
+    "The skill MUST reflect the real workflow shown above, not a generic best-practice guess.",
     "",
     "Respond with ONLY a single JSON object, no prose, no markdown fences:",
     "{",
@@ -34,6 +49,25 @@ export function buildSkillPrompt(intent: Intent, context?: SkillGenContext): str
     '  "body": "<Markdown instructions for SKILL.md, excluding frontmatter>"',
     "}",
   ].join("\n");
+}
+
+/**
+ * Render a labelled, bullet-listed prompt section from real context, or nothing
+ * when there is no content. Bounds both the count and per-line length so the
+ * prompt stays well-sized regardless of how noisy the captured evidence is.
+ */
+function buildBulletSection(label: string, items?: string[]): string[] {
+  const bullets = (items ?? [])
+    .map((item) => item.trim())
+    .filter((item) => item.length > 0)
+    .slice(0, MAX_EVIDENCE_BULLETS)
+    .map((item) =>
+      item.length > MAX_EVIDENCE_LINE_LEN
+        ? `- ${item.slice(0, MAX_EVIDENCE_LINE_LEN)}…`
+        : `- ${item}`,
+    );
+  if (bullets.length === 0) return [];
+  return ["", label, ...bullets];
 }
 
 /** Parse a model response into a validated {@link SkillDraft}, tolerating fences/prose. */
@@ -187,10 +221,13 @@ export function createSkillGenerator(
   const skillGen = analysis?.skillGen ?? {};
   const provider = skillGen.provider ?? "auto";
   const useApi = provider === "anthropic-api" || (provider === "auto" && Boolean(skillGen.apiKey));
+  // Treat an empty/whitespace model as "use the generator's default" — the UI's
+  // "Default" choice persists "", which must not become a literal model id.
+  const model = skillGen.model?.trim() ? skillGen.model.trim() : undefined;
   if (useApi) {
-    return new AnthropicApiSkillGenerator({ apiKey: skillGen.apiKey }, deps.anthropic);
+    return new AnthropicApiSkillGenerator({ apiKey: skillGen.apiKey, model }, deps.anthropic);
   }
-  return new ClaudeCliSkillGenerator({}, deps.cli);
+  return new ClaudeCliSkillGenerator({ model }, deps.cli);
 }
 
 function defaultSpawn(

--- a/packages/core/src/lib/intents/skill-generator.ts
+++ b/packages/core/src/lib/intents/skill-generator.ts
@@ -1,0 +1,270 @@
+import { spawn as nodeSpawn } from "node:child_process";
+import type { AnalysisConfig } from "../config.js";
+import type { Intent, SkillDraft, SkillGenContext, SkillGenerator } from "./types.js";
+
+const DEFAULT_ANTHROPIC_MODEL = "claude-sonnet-4-6";
+const ANTHROPIC_MESSAGES_URL = "https://api.anthropic.com/v1/messages";
+const ANTHROPIC_VERSION = "2023-06-01";
+const MAX_TOKENS = 2048;
+/** Bound both generators so a hung CLI/API call can't freeze the Offer dialog. */
+const DEFAULT_SKILLGEN_TIMEOUT_MS = 120_000;
+
+/**
+ * Build the shared instruction that asks a Claude model to author a SKILL.md
+ * draft for an uncovered intent, returned as a single JSON object.
+ */
+export function buildSkillPrompt(intent: Intent, context?: SkillGenContext): string {
+  const existing = context?.existingSkillIds?.length
+    ? `\nExisting skills (do not duplicate these): ${context.existingSkillIds.join(", ")}.`
+    : "";
+  return [
+    "You are authoring a reusable Agent Skill for the Ratel MCP gateway.",
+    `The user repeatedly tries to do this, but no skill covers it: "${intent.content}".${existing}`,
+    "",
+    "Make the skill SPECIFIC to this exact task. The description and tags are matched",
+    "(BM25) against future requests, so use precise, distinctive wording — concrete",
+    "nouns/verbs from this task — and AVOID generic filler ('the user', 'assistant',",
+    "'help', 'task', 'do this') that would make it match unrelated intents.",
+    "",
+    "Respond with ONLY a single JSON object, no prose, no markdown fences:",
+    "{",
+    '  "name": "<kebab-case-id, specific to the task>",',
+    '  "description": "<one sentence: what it does and exactly when to use it>",',
+    '  "tags": ["<distinctive trigger phrase>", "..."],',
+    '  "body": "<Markdown instructions for SKILL.md, excluding frontmatter>"',
+    "}",
+  ].join("\n");
+}
+
+/** Parse a model response into a validated {@link SkillDraft}, tolerating fences/prose. */
+export function parseSkillDraft(text: string): SkillDraft {
+  const json = extractJsonObject(text);
+  if (!json) throw new Error("could not find a skill draft JSON object in the model response");
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(json);
+  } catch {
+    throw new Error("skill draft was not valid JSON");
+  }
+  if (typeof parsed !== "object" || parsed === null) {
+    throw new Error("skill draft must be a JSON object");
+  }
+  const obj = parsed as Record<string, unknown>;
+  const name = slugify(typeof obj.name === "string" ? obj.name : "");
+  const description = typeof obj.description === "string" ? obj.description.trim() : "";
+  const body = typeof obj.body === "string" ? obj.body.trim() : "";
+  if (!name) throw new Error("skill draft is missing a usable name");
+  if (!description) throw new Error("skill draft is missing a description");
+  if (!body) throw new Error("skill draft is missing a body");
+  const draft: SkillDraft = { name, description, body };
+  if (Array.isArray(obj.tags)) {
+    const tags = obj.tags.filter((t): t is string => typeof t === "string" && t.trim().length > 0);
+    if (tags.length > 0) draft.tags = tags;
+  }
+  return draft;
+}
+
+/** Injection seam for tests. */
+export interface AnthropicDeps {
+  fetch?: typeof fetch;
+}
+
+export interface AnthropicGeneratorConfig {
+  apiKey?: string;
+  model?: string;
+}
+
+/** Generates a skill draft via the Anthropic Messages API. */
+export class AnthropicApiSkillGenerator implements SkillGenerator {
+  private readonly apiKey: string;
+  private readonly model: string;
+  private readonly fetchImpl: typeof fetch;
+
+  constructor(config: AnthropicGeneratorConfig, deps: AnthropicDeps = {}) {
+    if (!config.apiKey) throw new Error("AnthropicApiSkillGenerator requires an `apiKey`");
+    this.apiKey = config.apiKey;
+    this.model = config.model ?? DEFAULT_ANTHROPIC_MODEL;
+    this.fetchImpl = deps.fetch ?? globalThis.fetch;
+  }
+
+  async generate(intent: Intent, context?: SkillGenContext): Promise<SkillDraft> {
+    const res = await this.fetchImpl(ANTHROPIC_MESSAGES_URL, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-api-key": this.apiKey,
+        "anthropic-version": ANTHROPIC_VERSION,
+      },
+      body: JSON.stringify({
+        model: this.model,
+        max_tokens: MAX_TOKENS,
+        messages: [{ role: "user", content: buildSkillPrompt(intent, context) }],
+      }),
+      signal: AbortSignal.timeout(DEFAULT_SKILLGEN_TIMEOUT_MS),
+    });
+    if (!res.ok) {
+      throw new Error(`Anthropic API returned ${res.status} ${res.statusText}`);
+    }
+    const payload = (await res.json()) as { content?: Array<{ type: string; text?: string }> };
+    const text = (payload.content ?? [])
+      .filter((b) => b.type === "text" && typeof b.text === "string")
+      .map((b) => b.text)
+      .join("");
+    return parseSkillDraft(text);
+  }
+}
+
+export interface SpawnResult {
+  stdout: string;
+  stderr: string;
+  code: number;
+}
+
+export interface SpawnOptions {
+  /** Kill the child and reject after this many ms. */
+  timeoutMs?: number;
+}
+
+/** Injection seam for tests; runs a command with the prompt on stdin. */
+export type SpawnFn = (
+  cmd: string,
+  args: string[],
+  input: string,
+  opts?: SpawnOptions,
+) => Promise<SpawnResult>;
+
+export interface ClaudeCliDeps {
+  spawn?: SpawnFn;
+}
+
+export interface ClaudeCliGeneratorConfig {
+  /** Path to the `claude` binary (default: "claude" on PATH). */
+  bin?: string;
+  /** Kill the CLI after this many ms (default 2 min). */
+  timeoutMs?: number;
+  /** Model alias/id for `claude -p` (default "haiku" — fast; drafts are reviewed anyway). */
+  model?: string;
+}
+
+/**
+ * Generates a skill draft by shelling out to a local `claude -p` (print mode).
+ * `--strict-mcp-config` skips loading the user's MCP servers (the Ratel gateway,
+ * etc.), which otherwise boot on every call and make this slow/appear stuck.
+ */
+export class ClaudeCliSkillGenerator implements SkillGenerator {
+  private readonly bin: string;
+  private readonly timeoutMs: number;
+  private readonly model: string;
+  private readonly spawnImpl: SpawnFn;
+
+  constructor(config: ClaudeCliGeneratorConfig = {}, deps: ClaudeCliDeps = {}) {
+    this.bin = config.bin ?? "claude";
+    this.timeoutMs = config.timeoutMs ?? DEFAULT_SKILLGEN_TIMEOUT_MS;
+    this.model = config.model ?? "haiku";
+    this.spawnImpl = deps.spawn ?? defaultSpawn;
+  }
+
+  async generate(intent: Intent, context?: SkillGenContext): Promise<SkillDraft> {
+    const prompt = buildSkillPrompt(intent, context);
+    const result = await this.spawnImpl(
+      this.bin,
+      ["-p", "--strict-mcp-config", "--model", this.model],
+      prompt,
+      { timeoutMs: this.timeoutMs },
+    );
+    if (result.code !== 0) {
+      throw new Error(`claude -p exited with code ${result.code}: ${result.stderr.trim()}`);
+    }
+    return parseSkillDraft(result.stdout);
+  }
+}
+
+/** Select the skill-draft generator from the `analysis` config block. */
+export function createSkillGenerator(
+  analysis: AnalysisConfig | undefined,
+  deps: { anthropic?: AnthropicDeps; cli?: ClaudeCliDeps } = {},
+): SkillGenerator {
+  const skillGen = analysis?.skillGen ?? {};
+  const provider = skillGen.provider ?? "auto";
+  const useApi = provider === "anthropic-api" || (provider === "auto" && Boolean(skillGen.apiKey));
+  if (useApi) {
+    return new AnthropicApiSkillGenerator({ apiKey: skillGen.apiKey }, deps.anthropic);
+  }
+  return new ClaudeCliSkillGenerator({}, deps.cli);
+}
+
+function defaultSpawn(
+  cmd: string,
+  args: string[],
+  input: string,
+  opts: SpawnOptions = {},
+): Promise<SpawnResult> {
+  return new Promise((resolve, reject) => {
+    // RATEL_SKIP_CAPTURE stops the nested `claude -p` (and its hooks) from
+    // recording this prompt as chat — otherwise the skill-gen prompt leaks back
+    // in as bogus "intents".
+    const child = nodeSpawn(cmd, args, {
+      stdio: ["pipe", "pipe", "pipe"],
+      env: { ...process.env, RATEL_SKIP_CAPTURE: "1" },
+    });
+    let stdout = "";
+    let stderr = "";
+    const timer = opts.timeoutMs
+      ? setTimeout(() => {
+          child.kill("SIGKILL");
+          reject(new Error(`${cmd} timed out after ${opts.timeoutMs}ms`));
+        }, opts.timeoutMs)
+      : undefined;
+    const done = () => {
+      if (timer) clearTimeout(timer);
+    };
+    child.stdout.on("data", (d) => {
+      stdout += d.toString();
+    });
+    child.stderr.on("data", (d) => {
+      stderr += d.toString();
+    });
+    child.on("error", (err) => {
+      done();
+      reject(err);
+    });
+    child.on("close", (code) => {
+      done();
+      resolve({ stdout, stderr, code: code ?? 0 });
+    });
+    child.stdin.end(input);
+  });
+}
+
+/** Extract the first balanced top-level JSON object from arbitrary text. */
+function extractJsonObject(text: string): string | undefined {
+  const start = text.indexOf("{");
+  if (start === -1) return undefined;
+  let depth = 0;
+  let inString = false;
+  let escaped = false;
+  for (let i = start; i < text.length; i++) {
+    const ch = text[i];
+    if (inString) {
+      if (escaped) escaped = false;
+      else if (ch === "\\") escaped = true;
+      else if (ch === '"') inString = false;
+      continue;
+    }
+    if (ch === '"') inString = true;
+    else if (ch === "{") depth++;
+    else if (ch === "}") {
+      depth--;
+      if (depth === 0) return text.slice(start, i + 1);
+    }
+  }
+  return undefined;
+}
+
+function slugify(value: string): string {
+  return value
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}

--- a/packages/core/src/lib/intents/skill-generator.ts
+++ b/packages/core/src/lib/intents/skill-generator.ts
@@ -15,48 +15,91 @@ const DEFAULT_SKILLGEN_TIMEOUT_MS = 120_000;
 /**
  * Build the shared instruction that asks a Claude model to author a SKILL.md
  * draft for an uncovered intent, returned as a single JSON object.
+ *
+ * The prompt does the quality work itself: it spells out a quality bar (grounded,
+ * specific, with a contract / environment / procedure / constraints / safety) and
+ * mandates a fixed SKILL.md section structure, so the model returns a high-signal
+ * skill rather than generic boilerplate. Context is delimited with XML tags per
+ * Anthropic's prompting guidance, and the output contract stays a single JSON
+ * object so {@link parseSkillDraft} and the downstream create-skill route are
+ * unchanged.
  */
 export function buildSkillPrompt(intent: Intent, context?: SkillGenContext): string {
-  const existing = context?.existingSkillIds?.length
-    ? `\nExisting skills (do not duplicate these): ${context.existingSkillIds.join(", ")}.`
-    : "";
-  const evidenceSection = buildBulletSection(
-    "What the user actually did/asked (ground the skill in THIS, not a generic guess):",
+  const existingSection = context?.existingSkillIds?.length
+    ? [
+        "<existing_skills>",
+        `Do not duplicate these existing skills: ${context.existingSkillIds.join(", ")}.`,
+        "</existing_skills>",
+        "",
+      ]
+    : [];
+  const evidenceSection = buildTaggedSection(
+    "evidence",
+    "What the user actually did/asked. Ground the skill in THIS, not a generic guess:",
     context?.evidences,
   );
-  const relatedSection = buildBulletSection(
+  const relatedSection = buildTaggedSection(
+    "related_requests",
     "Related things the user repeatedly asks for (the skill may cover these too):",
     context?.relatedIntents,
   );
   return [
-    "You are authoring a reusable Agent Skill for the Ratel MCP gateway.",
-    `The user repeatedly tries to do this, but no skill covers it: "${intent.content}".${existing}`,
+    "You are an expert author of reusable Agent Skills for the Ratel MCP gateway.",
+    "A skill is a SKILL.md file whose `description` and `tags` are matched (BM25) against",
+    "future user requests; once matched, its body instructs an AI agent how to do the task.",
+    "Author ONE high-quality skill for the recurring request that no existing skill covers.",
     "",
-    "Make the skill SPECIFIC to this exact task. The description and tags are matched",
-    "(BM25) against future requests, so use precise, distinctive wording — concrete",
-    "nouns/verbs from this task — and AVOID generic filler ('the user', 'assistant',",
-    "'help', 'task', 'do this') that would make it match unrelated intents.",
+    "<uncovered_request>",
+    intent.content,
+    "</uncovered_request>",
+    "",
+    ...existingSection,
     ...evidenceSection,
     ...relatedSection,
+    "Author the skill to satisfy ALL of these requirements:",
     "",
-    "The skill MUST reflect the real workflow shown above, not a generic best-practice guess.",
+    "1. GROUNDED. Build the skill from the evidence above: reuse the concrete nouns, verbs,",
+    "   tools, file names, and commands the user actually used. Do NOT invent details or pad",
+    "   with generic advice. If the evidence is thin, keep the skill narrow instead of guessing.",
+    "2. SPECIFIC AND MATCHABLE. The description states in one sentence exactly what the skill",
+    "   does and precisely WHEN to use it, using distinctive wording from this task. AVOID",
+    "   generic filler ('the user', 'assistant', 'help', 'task', 'do this') that would make it",
+    "   match unrelated requests.",
+    "3. CONTRACT. State the expected inputs and outputs, and how to verify success.",
+    "4. ENVIRONMENT. List any prerequisites, dependencies, or setup needed before the steps",
+    "   (omit only if there are genuinely none).",
+    "5. PROCEDURE. Give concrete, ordered, numbered steps that carry out the task end to end,",
+    "   including how to handle the obvious failure and edge cases.",
+    "6. CONSTRAINTS. Call out the rules and limits that must be respected (the must / never /",
+    "   only conditions implied by the task).",
+    "7. SAFE AND PORTABLE. No secrets, API keys, or tokens. No machine-specific absolute paths",
+    "   or one-off literal values; parameterize them. Be concise, with no filler sections.",
+    "",
+    "Structure the `body` as Markdown with these sections, in this order (omit a section ONLY",
+    "if it genuinely does not apply):",
+    "",
+    "## When to use",
+    "## Prerequisites",
+    "## Steps",
+    "## Constraints",
+    "## Verification",
     "",
     "Respond with ONLY a single JSON object, no prose, no markdown fences:",
     "{",
     '  "name": "<kebab-case-id, specific to the task>",',
     '  "description": "<one sentence: what it does and exactly when to use it>",',
     '  "tags": ["<distinctive trigger phrase>", "..."],',
-    '  "body": "<Markdown instructions for SKILL.md, excluding frontmatter>"',
+    '  "body": "<the structured Markdown body described above, excluding YAML frontmatter>"',
     "}",
   ].join("\n");
 }
 
 /**
- * Render a labelled, bullet-listed prompt section from real context, or nothing
- * when there is no content. Bounds both the count and per-line length so the
- * prompt stays well-sized regardless of how noisy the captured evidence is.
+ * Render an XML-tagged, bullet-listed context block from real evidence, or
+ * nothing when there is no content. Bounds both the count and per-line length so
+ * the prompt stays well-sized regardless of how noisy the captured evidence is.
  */
-function buildBulletSection(label: string, items?: string[]): string[] {
+function buildTaggedSection(tag: string, label: string, items?: string[]): string[] {
   const bullets = (items ?? [])
     .map((item) => item.trim())
     .filter((item) => item.length > 0)
@@ -67,7 +110,7 @@ function buildBulletSection(label: string, items?: string[]): string[] {
         : `- ${item}`,
     );
   if (bullets.length === 0) return [];
-  return ["", label, ...bullets];
+  return [`<${tag}>`, label, ...bullets, `</${tag}>`, ""];
 }
 
 /** Parse a model response into a validated {@link SkillDraft}, tolerating fences/prose. */

--- a/packages/core/src/lib/intents/store.test.ts
+++ b/packages/core/src/lib/intents/store.test.ts
@@ -1,0 +1,205 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { nodeJsonFs } from "../../io.js";
+import {
+  emptyIndex,
+  type IntentsIndex,
+  mergeIntoIndex,
+  normalizeIntentKey,
+  readIntentsIndex,
+  readSessionIntents,
+  removeIntent,
+  type SessionIntents,
+  writeIntentsIndex,
+  writeSessionIntents,
+} from "./store.js";
+
+let dir: string;
+
+beforeEach(async () => {
+  dir = await mkdtemp(join(tmpdir(), "ratel-intents-"));
+});
+
+afterEach(async () => {
+  await rm(dir, { recursive: true, force: true });
+});
+
+function session(overrides: Partial<SessionIntents> = {}): SessionIntents {
+  return {
+    sessionId: "s1",
+    host: "claude-code",
+    analyzedAt: "2026-06-19T10:00:00.000Z",
+    claims: [],
+    intents: [
+      { content: "Add OAuth login", coverage: { status: "gap" } },
+      {
+        content: "Write tests",
+        coverage: { status: "covered", skills: [{ skillId: "tdd", score: 4.2 }] },
+      },
+    ],
+    ...overrides,
+  };
+}
+
+describe("normalizeIntentKey", () => {
+  it("lowercases, collapses whitespace, and strips trailing punctuation", () => {
+    expect(normalizeIntentKey("  Add   OAuth login!! ")).toBe("add oauth login");
+    expect(normalizeIntentKey("Add OAuth login")).toBe(normalizeIntentKey("add oauth   login."));
+  });
+});
+
+describe("mergeIntoIndex", () => {
+  it("adds new intents and a session summary", () => {
+    const merged = mergeIntoIndex(emptyIndex(), session(), "2026-06-19T10:00:00.000Z");
+    expect(merged.intents).toHaveLength(2);
+    expect(merged.sessions).toEqual([
+      {
+        sessionId: "s1",
+        host: "claude-code",
+        cwd: undefined,
+        analyzedAt: "2026-06-19T10:00:00.000Z",
+        intentCount: 2,
+        gapCount: 1,
+      },
+    ]);
+  });
+
+  it("de-dupes a repeated intent across sessions and refreshes coverage", () => {
+    const first = mergeIntoIndex(emptyIndex(), session(), "2026-06-19T10:00:00.000Z");
+    const second = mergeIntoIndex(
+      first,
+      session({
+        sessionId: "s2",
+        analyzedAt: "2026-06-19T11:00:00.000Z",
+        intents: [
+          // same intent, now covered by a freshly-added skill
+          {
+            content: "add oauth login.",
+            coverage: { status: "covered", skills: [{ skillId: "oauth", score: 5 }] },
+          },
+        ],
+      }),
+      "2026-06-19T11:00:00.000Z",
+    );
+    const oauth = second.intents.find((i) => normalizeIntentKey(i.content) === "add oauth login");
+    expect(oauth?.sessions).toEqual(["s1", "s2"]);
+    expect(oauth?.coverage).toEqual({
+      status: "covered",
+      skills: [{ skillId: "oauth", score: 5 }],
+    });
+    expect(oauth?.firstSeen).toBe("2026-06-19T10:00:00.000Z");
+    expect(oauth?.lastSeen).toBe("2026-06-19T11:00:00.000Z");
+  });
+
+  it("replaces a session's intents on re-analysis instead of accumulating them", () => {
+    const first = mergeIntoIndex(
+      emptyIndex(),
+      session({
+        intents: [
+          { content: "Add OAuth login", coverage: { status: "gap" } },
+          { content: "Old reworded intent", coverage: { status: "gap" } },
+        ],
+      }),
+      "2026-06-19T10:00:00.000Z",
+    );
+    // Re-run of the SAME session returns one shared intent + one new phrasing.
+    const second = mergeIntoIndex(
+      first,
+      session({
+        analyzedAt: "2026-06-19T11:00:00.000Z",
+        intents: [
+          { content: "Add OAuth login", coverage: { status: "gap" } },
+          { content: "Newly phrased intent", coverage: { status: "gap" } },
+        ],
+      }),
+      "2026-06-19T11:00:00.000Z",
+    );
+    const contents = second.intents.map((i) => i.content).sort();
+    expect(contents).toEqual(["Add OAuth login", "Newly phrased intent"]);
+    // The stale phrasing from the first run is gone; no accumulation.
+    expect(contents).not.toContain("Old reworded intent");
+    // firstSeen is preserved for the recurring intent.
+    const oauth = second.intents.find((i) => i.content === "Add OAuth login");
+    expect(oauth?.firstSeen).toBe("2026-06-19T10:00:00.000Z");
+  });
+
+  it("keeps another session's intents when one session is re-analyzed", () => {
+    const withTwo = mergeIntoIndex(
+      mergeIntoIndex(emptyIndex(), session({ sessionId: "s1" }), "2026-06-19T10:00:00.000Z"),
+      session({
+        sessionId: "s2",
+        intents: [{ content: "s2-only intent", coverage: { status: "gap" } }],
+      }),
+      "2026-06-19T10:30:00.000Z",
+    );
+    // Re-analyze s1 with no intents; s2's intent must survive.
+    const after = mergeIntoIndex(
+      withTwo,
+      session({ sessionId: "s1", intents: [] }),
+      "2026-06-19T11:00:00.000Z",
+    );
+    expect(after.intents.map((i) => i.content)).toContain("s2-only intent");
+  });
+
+  it("upserts the session summary instead of duplicating it", () => {
+    const first = mergeIntoIndex(emptyIndex(), session(), "2026-06-19T10:00:00.000Z");
+    const reanalyzed = mergeIntoIndex(
+      first,
+      session({ analyzedAt: "2026-06-19T12:00:00.000Z", intents: [] }),
+      "2026-06-19T12:00:00.000Z",
+    );
+    expect(reanalyzed.sessions).toHaveLength(1);
+    expect(reanalyzed.sessions[0].analyzedAt).toBe("2026-06-19T12:00:00.000Z");
+  });
+});
+
+describe("removeIntent", () => {
+  it("removes a matching intent (normalized) and updates the session counts", () => {
+    const index = mergeIntoIndex(emptyIndex(), session(), "2026-06-19T10:00:00.000Z");
+    expect(index.intents).toHaveLength(2);
+    const after = removeIntent(index, "  add OAUTH login!! ");
+    expect(after.intents.map((i) => i.content)).toEqual(["Write tests"]);
+    expect(after.sessions[0]).toMatchObject({ intentCount: 1, gapCount: 0 });
+  });
+
+  it("drops a session whose last intent was removed", () => {
+    const index = mergeIntoIndex(
+      emptyIndex(),
+      session({ intents: [{ content: "only intent", coverage: { status: "gap" } }] }),
+      "2026-06-19T10:00:00.000Z",
+    );
+    const after = removeIntent(index, "only intent");
+    expect(after.intents).toHaveLength(0);
+    expect(after.sessions).toHaveLength(0);
+  });
+
+  it("is a no-op for an unknown intent", () => {
+    const index = mergeIntoIndex(emptyIndex(), session(), "2026-06-19T10:00:00.000Z");
+    expect(removeIntent(index, "never said this").intents).toHaveLength(2);
+  });
+});
+
+describe("index + session persistence", () => {
+  it("round-trips the index", async () => {
+    const index: IntentsIndex = mergeIntoIndex(emptyIndex(), session(), "2026-06-19T10:00:00.000Z");
+    await writeIntentsIndex(nodeJsonFs, dir, index);
+    const read = await readIntentsIndex(nodeJsonFs, dir);
+    expect(read.intents).toHaveLength(2);
+  });
+
+  it("returns an empty index when none exists", async () => {
+    expect(await readIntentsIndex(nodeJsonFs, dir)).toEqual(emptyIndex());
+  });
+
+  it("round-trips a session file", async () => {
+    await writeSessionIntents(nodeJsonFs, dir, session());
+    const read = await readSessionIntents(nodeJsonFs, dir, "s1");
+    expect(read?.intents).toHaveLength(2);
+  });
+
+  it("returns null for a missing session file", async () => {
+    expect(await readSessionIntents(nodeJsonFs, dir, "missing")).toBeNull();
+  });
+});

--- a/packages/core/src/lib/intents/store.test.ts
+++ b/packages/core/src/lib/intents/store.test.ts
@@ -8,13 +8,18 @@ import {
   type IntentsIndex,
   mergeIntoIndex,
   normalizeIntentKey,
+  rankIntentRecords,
+  readAllSessionIntents,
   readIntentsIndex,
   readSessionIntents,
+  rebuildIndex,
   removeIntent,
+  removeIntentFromSessions,
   type SessionIntents,
   writeIntentsIndex,
   writeSessionIntents,
 } from "./store.js";
+import type { IntentRecord } from "./types.js";
 
 let dir: string;
 
@@ -178,6 +183,213 @@ describe("removeIntent", () => {
   it("is a no-op for an unknown intent", () => {
     const index = mergeIntoIndex(emptyIndex(), session(), "2026-06-19T10:00:00.000Z");
     expect(removeIntent(index, "never said this").intents).toHaveLength(2);
+  });
+});
+
+describe("rebuildIndex", () => {
+  it("dedupes intents across sessions by normalized key", () => {
+    const sessions: SessionIntents[] = [
+      session({
+        sessionId: "s1",
+        analyzedAt: "2026-06-19T10:00:00.000Z",
+        intents: [{ content: "Add OAuth login", coverage: { status: "gap" } }],
+      }),
+      session({
+        sessionId: "s2",
+        analyzedAt: "2026-06-19T11:00:00.000Z",
+        intents: [{ content: "add oauth login.", coverage: { status: "gap" } }],
+      }),
+    ];
+    const index = rebuildIndex(sessions);
+    expect(index.intents).toHaveLength(1);
+    expect(index.intents[0].sessions).toEqual(["s1", "s2"]);
+    expect(index.version).toBe(1);
+  });
+
+  it("computes firstSeen/lastSeen across the sessions containing an intent", () => {
+    const sessions: SessionIntents[] = [
+      session({
+        sessionId: "s1",
+        analyzedAt: "2026-06-19T10:00:00.000Z",
+        intents: [{ content: "Add OAuth login", coverage: { status: "gap" } }],
+      }),
+      session({
+        sessionId: "s2",
+        analyzedAt: "2026-06-19T12:00:00.000Z",
+        intents: [{ content: "Add OAuth login", coverage: { status: "gap" } }],
+      }),
+    ];
+    const index = rebuildIndex(sessions);
+    const oauth = index.intents[0];
+    expect(oauth.firstSeen).toBe("2026-06-19T10:00:00.000Z");
+    expect(oauth.lastSeen).toBe("2026-06-19T12:00:00.000Z");
+  });
+
+  it("takes content and coverage from the most-recently-analyzed session", () => {
+    const sessions: SessionIntents[] = [
+      session({
+        sessionId: "s1",
+        analyzedAt: "2026-06-19T10:00:00.000Z",
+        intents: [{ content: "Add OAuth login", coverage: { status: "gap" } }],
+      }),
+      session({
+        sessionId: "s2",
+        analyzedAt: "2026-06-19T12:00:00.000Z",
+        intents: [
+          {
+            content: "Add OAuth login NOW",
+            coverage: { status: "covered", skills: [{ skillId: "oauth", score: 5 }] },
+          },
+        ],
+      }),
+    ];
+    const index = rebuildIndex(sessions);
+    const oauth = index.intents[0];
+    expect(oauth.content).toBe("Add OAuth login NOW");
+    expect(oauth.coverage).toEqual({ status: "covered", skills: [{ skillId: "oauth", score: 5 }] });
+  });
+
+  it("emits one session summary per input session with correct counts", () => {
+    const sessions: SessionIntents[] = [
+      session({
+        sessionId: "s1",
+        analyzedAt: "2026-06-19T10:00:00.000Z",
+        intents: [
+          { content: "Add OAuth login", coverage: { status: "gap" } },
+          {
+            content: "Write tests",
+            coverage: { status: "covered", skills: [{ skillId: "tdd", score: 4.2 }] },
+          },
+        ],
+      }),
+    ];
+    const index = rebuildIndex(sessions);
+    expect(index.sessions).toEqual([
+      {
+        sessionId: "s1",
+        host: "claude-code",
+        cwd: undefined,
+        analyzedAt: "2026-06-19T10:00:00.000Z",
+        intentCount: 2,
+        gapCount: 1,
+      },
+    ]);
+  });
+
+  it("skips empty-key intents", () => {
+    const sessions: SessionIntents[] = [
+      session({
+        sessionId: "s1",
+        intents: [
+          { content: "  ", coverage: { status: "gap" } },
+          { content: "Add OAuth login", coverage: { status: "gap" } },
+        ],
+      }),
+    ];
+    const index = rebuildIndex(sessions);
+    expect(index.intents).toHaveLength(1);
+    expect(index.intents[0].content).toBe("Add OAuth login");
+  });
+
+  it("returns intents already ranked by frequency", () => {
+    const sessions: SessionIntents[] = [
+      session({
+        sessionId: "s1",
+        analyzedAt: "2026-06-19T10:00:00.000Z",
+        intents: [
+          { content: "rare intent", coverage: { status: "gap" } },
+          { content: "frequent intent", coverage: { status: "gap" } },
+        ],
+      }),
+      session({
+        sessionId: "s2",
+        analyzedAt: "2026-06-19T11:00:00.000Z",
+        intents: [{ content: "frequent intent", coverage: { status: "gap" } }],
+      }),
+    ];
+    const index = rebuildIndex(sessions);
+    expect(index.intents[0].content).toBe("frequent intent");
+    expect(index.intents[0].score).toBe(2);
+  });
+});
+
+describe("rankIntentRecords", () => {
+  function record(overrides: Partial<IntentRecord> = {}): IntentRecord {
+    return {
+      content: "x",
+      coverage: { status: "gap" },
+      sessions: ["s1"],
+      firstSeen: "2026-06-19T10:00:00.000Z",
+      lastSeen: "2026-06-19T10:00:00.000Z",
+      ...overrides,
+    };
+  }
+
+  it("ranks by frequency desc, then recency desc, then content asc", () => {
+    const ranked = rankIntentRecords([
+      record({ content: "one session", sessions: ["a"], lastSeen: "2026-06-19T10:00:00.000Z" }),
+      record({ content: "many sessions", sessions: ["a", "b", "c"] }),
+      record({ content: "b recent", sessions: ["a", "b"], lastSeen: "2026-06-19T12:00:00.000Z" }),
+      record({ content: "a older", sessions: ["a", "b"], lastSeen: "2026-06-19T09:00:00.000Z" }),
+    ]);
+    expect(ranked.map((r) => r.content)).toEqual([
+      "many sessions",
+      "b recent",
+      "a older",
+      "one session",
+    ]);
+  });
+
+  it("sets score to the session count and does not mutate inputs", () => {
+    const input = [record({ sessions: ["a", "b"] })];
+    const ranked = rankIntentRecords(input);
+    expect(ranked[0].score).toBe(2);
+    expect(input[0].score).toBeUndefined();
+  });
+});
+
+describe("removeIntentFromSessions", () => {
+  it("strips a matching intent (normalized) from each session without mutating inputs", () => {
+    const input: SessionIntents[] = [
+      session({
+        sessionId: "s1",
+        intents: [
+          { content: "Add OAuth login", coverage: { status: "gap" } },
+          { content: "Write tests", coverage: { status: "gap" } },
+        ],
+      }),
+      session({
+        sessionId: "s2",
+        intents: [{ content: "add oauth login!", coverage: { status: "gap" } }],
+      }),
+    ];
+    const after = removeIntentFromSessions(input, "  ADD oauth login. ");
+    expect(after[0].intents.map((i) => i.content)).toEqual(["Write tests"]);
+    expect(after[1].intents).toHaveLength(0);
+    // inputs untouched
+    expect(input[0].intents).toHaveLength(2);
+    expect(input[1].intents).toHaveLength(1);
+  });
+});
+
+describe("readAllSessionIntents", () => {
+  it("reads and sorts session files by analyzedAt ascending", async () => {
+    await writeSessionIntents(
+      nodeJsonFs,
+      dir,
+      session({ sessionId: "s2", analyzedAt: "2026-06-19T12:00:00.000Z" }),
+    );
+    await writeSessionIntents(
+      nodeJsonFs,
+      dir,
+      session({ sessionId: "s1", analyzedAt: "2026-06-19T10:00:00.000Z" }),
+    );
+    const all = await readAllSessionIntents(nodeJsonFs, dir);
+    expect(all.map((s) => s.sessionId)).toEqual(["s1", "s2"]);
+  });
+
+  it("returns [] when the sessions directory does not exist", async () => {
+    expect(await readAllSessionIntents(nodeJsonFs, dir)).toEqual([]);
   });
 });
 

--- a/packages/core/src/lib/intents/store.ts
+++ b/packages/core/src/lib/intents/store.ts
@@ -1,3 +1,4 @@
+import { readdir } from "node:fs/promises";
 import { join } from "node:path";
 import { type JsonFs, readJson, writeJson } from "../../io.js";
 import type { Claim, IntentCoverage, IntentRecord } from "./types.js";
@@ -182,4 +183,127 @@ export function mergeIntoIndex(
   const sessions = [...index.sessions.filter((s) => s.sessionId !== session.sessionId), summary];
 
   return { version: INTENTS_INDEX_VERSION, intents: [...byKey.values()], sessions };
+}
+
+/**
+ * Read every per-session file under `<intentsDir>/sessions/*.json`. Missing or
+ * malformed files are skipped (a missing directory yields `[]`). The result is
+ * sorted by `analyzedAt` ascending for deterministic downstream rebuilds.
+ */
+export async function readAllSessionIntents(
+  fs: JsonFs,
+  intentsDir: string,
+): Promise<SessionIntents[]> {
+  let entries: string[];
+  try {
+    entries = await readdir(join(intentsDir, "sessions"));
+  } catch {
+    return [];
+  }
+  const sessionIds = entries
+    .filter((name) => name.endsWith(".json"))
+    .map((name) => name.slice(0, -".json".length));
+  const sessions: SessionIntents[] = [];
+  for (const sessionId of sessionIds) {
+    const session = await readSessionIntents(fs, intentsDir, sessionId);
+    if (session && Array.isArray(session.intents)) sessions.push(session);
+  }
+  return [...sessions].sort((a, b) => a.analyzedAt.localeCompare(b.analyzedAt));
+}
+
+/**
+ * Rank intent records (pure): primary by session frequency DESC ("showed up in
+ * 8 sessions" first), then `lastSeen` DESC, then `content` ASC for stability.
+ * Returns a new array with `score` set to each record's session count.
+ */
+export function rankIntentRecords(records: IntentRecord[]): IntentRecord[] {
+  return [...records]
+    .map((r) => ({ ...r, score: r.sessions.length }))
+    .sort((a, b) => {
+      if (b.sessions.length !== a.sessions.length) return b.sessions.length - a.sessions.length;
+      if (b.lastSeen !== a.lastSeen) return b.lastSeen.localeCompare(a.lastSeen);
+      return a.content.localeCompare(b.content);
+    });
+}
+
+/**
+ * Rebuild the entire cumulative index from per-session files (pure). Deriving
+ * the index from the durable per-session artifacts means it can always be
+ * regenerated and never silently loses sessions or intents.
+ *
+ * Intents are de-duped by {@link normalizeIntentKey}. For each distinct key the
+ * `sessions` list is every containing session (ordered by first appearance);
+ * `firstSeen`/`lastSeen` span their `analyzedAt`; `content` and `coverage` come
+ * from the most-recently-analyzed containing session (newest wins, since skills
+ * change over time). Empty-key intents are skipped. `intents` is returned ranked
+ * (see {@link rankIntentRecords}).
+ */
+export function rebuildIndex(sessions: SessionIntents[]): IntentsIndex {
+  // Sessions sorted oldest → newest so "first appearance" ordering and
+  // "newest wins" for content/coverage both fall out naturally.
+  const ordered = [...sessions].sort((a, b) => a.analyzedAt.localeCompare(b.analyzedAt));
+  const byKey = new Map<string, IntentRecord>();
+
+  for (const session of ordered) {
+    for (const intent of session.intents) {
+      const key = normalizeIntentKey(intent.content);
+      if (key.length === 0) continue;
+      const existing = byKey.get(key);
+      if (existing) {
+        byKey.set(key, {
+          ...existing,
+          // newest containing session wins for content + coverage + evidence
+          content: intent.content,
+          coverage: intent.coverage,
+          evidences: intent.evidences ?? existing.evidences,
+          sessions: existing.sessions.includes(session.sessionId)
+            ? existing.sessions
+            : [...existing.sessions, session.sessionId],
+          firstSeen:
+            session.analyzedAt < existing.firstSeen ? session.analyzedAt : existing.firstSeen,
+          lastSeen: session.analyzedAt > existing.lastSeen ? session.analyzedAt : existing.lastSeen,
+        });
+      } else {
+        byKey.set(key, {
+          content: intent.content,
+          coverage: intent.coverage,
+          evidences: intent.evidences,
+          sessions: [session.sessionId],
+          firstSeen: session.analyzedAt,
+          lastSeen: session.analyzedAt,
+        });
+      }
+    }
+  }
+
+  const summaries: SessionSummary[] = ordered.map((session) => ({
+    sessionId: session.sessionId,
+    host: session.host,
+    cwd: session.cwd,
+    analyzedAt: session.analyzedAt,
+    intentCount: session.intents.length,
+    gapCount: session.intents.filter((i) => i.coverage.status === "gap").length,
+  }));
+
+  return {
+    version: INTENTS_INDEX_VERSION,
+    intents: rankIntentRecords([...byKey.values()]),
+    sessions: summaries,
+  };
+}
+
+/**
+ * Strip an intent (matched by {@link normalizeIntentKey}) from every session's
+ * `intents` array (pure), so a later {@link rebuildIndex} won't resurrect a
+ * deleted intent. Inputs are never mutated.
+ */
+export function removeIntentFromSessions(
+  sessions: SessionIntents[],
+  content: string,
+): SessionIntents[] {
+  const key = normalizeIntentKey(content);
+  return sessions.map((session) => ({
+    ...session,
+    intents: session.intents.filter((i) => normalizeIntentKey(i.content) !== key),
+  }));
 }

--- a/packages/core/src/lib/intents/store.ts
+++ b/packages/core/src/lib/intents/store.ts
@@ -1,0 +1,185 @@
+import { join } from "node:path";
+import { type JsonFs, readJson, writeJson } from "../../io.js";
+import type { Claim, IntentCoverage, IntentRecord } from "./types.js";
+
+export const INTENTS_INDEX_VERSION = 1;
+
+/** One intent within a session result, annotated with skill coverage. */
+export interface StoredIntent {
+  content: string;
+  evidences?: string[];
+  coverage: IntentCoverage;
+}
+
+/** Full per-session extraction result, persisted at `<intentsDir>/<sessionId>.json`. */
+export interface SessionIntents {
+  sessionId: string;
+  host?: string;
+  cwd?: string;
+  analyzedAt: string;
+  claims: Claim[];
+  intents: StoredIntent[];
+}
+
+/** Compact per-session entry in the cumulative index, for UI session grouping. */
+export interface SessionSummary {
+  sessionId: string;
+  host?: string;
+  cwd?: string;
+  analyzedAt: string;
+  intentCount: number;
+  gapCount: number;
+}
+
+/**
+ * The cumulative, de-duplicated index the UI reads — a single artifact that
+ * supports both the cumulative list (`intents`) and per-session grouping
+ * (`sessions`), so the UI never needs to enumerate per-session files.
+ */
+export interface IntentsIndex {
+  version: number;
+  intents: IntentRecord[];
+  sessions: SessionSummary[];
+}
+
+function indexPath(intentsDir: string): string {
+  return join(intentsDir, "index.json");
+}
+
+function sessionPath(intentsDir: string, sessionId: string): string {
+  return join(intentsDir, "sessions", `${sessionId}.json`);
+}
+
+export function emptyIndex(): IntentsIndex {
+  return { version: INTENTS_INDEX_VERSION, intents: [], sessions: [] };
+}
+
+/** Read the cumulative index; recovers to an empty index when missing or malformed. */
+export async function readIntentsIndex(fs: JsonFs, intentsDir: string): Promise<IntentsIndex> {
+  try {
+    const index = await readJson<IntentsIndex>(fs, indexPath(intentsDir));
+    if (index && Array.isArray(index.intents) && Array.isArray(index.sessions)) return index;
+  } catch {
+    // malformed — fall through to an empty index
+  }
+  return emptyIndex();
+}
+
+export async function writeIntentsIndex(
+  fs: JsonFs,
+  intentsDir: string,
+  index: IntentsIndex,
+): Promise<void> {
+  await writeJson(fs, indexPath(intentsDir), index);
+}
+
+export async function readSessionIntents(
+  fs: JsonFs,
+  intentsDir: string,
+  sessionId: string,
+): Promise<SessionIntents | null> {
+  try {
+    return await readJson<SessionIntents>(fs, sessionPath(intentsDir, sessionId));
+  } catch {
+    return null;
+  }
+}
+
+export async function writeSessionIntents(
+  fs: JsonFs,
+  intentsDir: string,
+  session: SessionIntents,
+): Promise<void> {
+  await writeJson(fs, sessionPath(intentsDir, session.sessionId), session);
+}
+
+/** Remove a single intent (matched by normalized content) from the index. */
+export function removeIntent(index: IntentsIndex, content: string): IntentsIndex {
+  const key = normalizeIntentKey(content);
+  const intents = index.intents.filter((i) => normalizeIntentKey(i.content) !== key);
+  return reindexSessions({ ...index, intents });
+}
+
+/** Recompute each session summary's counts from the surviving intents; drop now-empty sessions. */
+function reindexSessions(index: IntentsIndex): IntentsIndex {
+  const sessions = index.sessions
+    .map((s) => {
+      const own = index.intents.filter((i) => i.sessions.includes(s.sessionId));
+      return {
+        ...s,
+        intentCount: own.length,
+        gapCount: own.filter((i) => i.coverage.status === "gap").length,
+      };
+    })
+    .filter((s) => s.intentCount > 0);
+  return { ...index, sessions };
+}
+
+/** Normalize intent text into a de-dup key: lowercased, whitespace-collapsed, depunctuated. */
+export function normalizeIntentKey(content: string): string {
+  return content
+    .toLowerCase()
+    .replace(/\s+/g, " ")
+    .trim()
+    .replace(/[.!?,;:]+$/g, "")
+    .trim();
+}
+
+/**
+ * Fold one session's analyzed intents into the cumulative index (pure). Intents
+ * are de-duped by {@link normalizeIntentKey}: a repeat updates `lastSeen`,
+ * appends the session to `sessions`, and refreshes `coverage` (skills may have
+ * been added since); `firstSeen` is preserved. The session summary is upserted.
+ */
+export function mergeIntoIndex(
+  index: IntentsIndex,
+  session: SessionIntents,
+  now: string,
+): IntentsIndex {
+  // Replace this session's prior contribution: strip it from every record and
+  // drop records left with no sessions, so re-analyzing a session (Run now)
+  // refreshes its intents instead of accumulating stale or re-worded phrasings.
+  const priorByKey = new Map(index.intents.map((r) => [normalizeIntentKey(r.content), r]));
+  const retained = index.intents
+    .map((r) => ({ ...r, sessions: r.sessions.filter((s) => s !== session.sessionId) }))
+    .filter((r) => r.sessions.length > 0);
+  const byKey = new Map(retained.map((r) => [normalizeIntentKey(r.content), r]));
+
+  for (const intent of session.intents) {
+    const key = normalizeIntentKey(intent.content);
+    if (key.length === 0) continue;
+    const existing = byKey.get(key);
+    if (existing) {
+      const sessions = existing.sessions.includes(session.sessionId)
+        ? existing.sessions
+        : [...existing.sessions, session.sessionId];
+      byKey.set(key, {
+        ...existing,
+        coverage: intent.coverage,
+        sessions,
+        lastSeen: now,
+      });
+    } else {
+      byKey.set(key, {
+        content: intent.content,
+        coverage: intent.coverage,
+        sessions: [session.sessionId],
+        // Preserve the original firstSeen when an intent recurs across re-runs.
+        firstSeen: priorByKey.get(key)?.firstSeen ?? now,
+        lastSeen: now,
+      });
+    }
+  }
+
+  const summary: SessionSummary = {
+    sessionId: session.sessionId,
+    host: session.host,
+    cwd: session.cwd,
+    analyzedAt: session.analyzedAt,
+    intentCount: session.intents.length,
+    gapCount: session.intents.filter((i) => i.coverage.status === "gap").length,
+  };
+  const sessions = [...index.sessions.filter((s) => s.sessionId !== session.sessionId), summary];
+
+  return { version: INTENTS_INDEX_VERSION, intents: [...byKey.values()], sessions };
+}

--- a/packages/core/src/lib/intents/types.ts
+++ b/packages/core/src/lib/intents/types.ts
@@ -33,6 +33,13 @@ export interface ChatSessionMeta {
   updatedAt?: string;
   /** True once the session has gone idle (set by the Stop hook); drives the idle trigger. */
   idle?: boolean;
+  /**
+   * Set when this session's analysis output was deleted (e.g. "clear all"), so a run
+   * treats it as due again even without new turns — otherwise the bookkeeping claims
+   * "already analyzed" while the store is empty and a re-run would skip it. Cleared
+   * once the session is analyzed.
+   */
+  needsReanalysis?: boolean;
 }
 
 /** Claim subtypes emitted by the ClaimExtractor model. */

--- a/packages/core/src/lib/intents/types.ts
+++ b/packages/core/src/lib/intents/types.ts
@@ -1,0 +1,129 @@
+/**
+ * Data model + provider seams for the chat → intent extraction pipeline.
+ *
+ * Three swappable seams, each selected by the `analysis` config block:
+ *  - {@link ChatSource}     — where captured chat comes from (hooks today; api/cloud later)
+ *  - {@link IntentExtractor} — what turns conversation into claims + intents
+ *  - {@link SkillGenerator}  — what drafts a new skill for an uncovered intent
+ *
+ * The shapes mirror the ClaimExtractor model output: `{ claims, intents }`.
+ */
+
+export type ChatRole = "user" | "assistant";
+
+/** One conversation turn captured from a host (Claude Code / Codex). */
+export interface ChatTurn {
+  role: ChatRole;
+  content: string;
+  /** ISO timestamp when the turn was captured, if known. */
+  ts?: string;
+}
+
+/** Per-session bookkeeping the capture layer maintains in `~/.ratel/chat/state.json`. */
+export interface ChatSessionMeta {
+  sessionId: string;
+  /** Originating host: "claude-code" | "codex" | "unknown". */
+  host: string;
+  cwd?: string;
+  /** Turns captured since the last analysis run (drives the every-N-messages trigger). */
+  newTurnCount: number;
+  /** ISO timestamp of the last completed analysis for this session. */
+  lastAnalyzedAt?: string;
+  /** ISO timestamp of the most recent captured turn. */
+  updatedAt?: string;
+  /** True once the session has gone idle (set by the Stop hook); drives the idle trigger. */
+  idle?: boolean;
+}
+
+/** Claim subtypes emitted by the ClaimExtractor model. */
+export type ClaimSubtype = "factoid" | "capability" | "user_assertion" | "unverifiable";
+
+export interface Claim {
+  subtype: ClaimSubtype;
+  content: string;
+  /** Supporting spans; the current model release does not populate these yet. */
+  evidences?: string[];
+}
+
+/** A user goal/request extracted from the conversation. */
+export interface Intent {
+  content: string;
+  evidences?: string[];
+}
+
+/** Structured output of an {@link IntentExtractor}. */
+export interface ExtractionResult {
+  claims: Claim[];
+  intents: Intent[];
+}
+
+/** Optional description of the AI service being analyzed (passed through to the model). */
+export interface AIServiceDescription {
+  name?: string;
+  description?: string;
+  capabilities?: string[];
+}
+
+/** Reads captured chat. Implementations: hook files (v1), remote API/cloud (future). */
+export interface ChatSource {
+  /** All sessions known to this source, with per-session bookkeeping. */
+  listSessions(): Promise<ChatSessionMeta[]>;
+  /** The full ordered turn list for one session. */
+  readSession(sessionId: string): Promise<ChatTurn[]>;
+  /**
+   * Record that a session was just analyzed: reset its new-turn counter, stamp
+   * `lastAnalyzedAt`, and clear the idle flag. Optional so read-only sources can
+   * omit it; the runner calls it after each successful analysis.
+   */
+  markAnalyzed?(sessionId: string, at: string): Promise<void>;
+}
+
+/** Turns conversation into claims + intents. Implementations: http sidecar/remote, naive fallback. */
+export interface IntentExtractor {
+  extract(turns: ChatTurn[], serviceDescription?: AIServiceDescription): Promise<ExtractionResult>;
+}
+
+/** A generated skill draft, shaped for the existing create-skill route. */
+export interface SkillDraft {
+  /** kebab-case skill id / folder name. */
+  name: string;
+  description: string;
+  tags?: string[];
+  /** Markdown body for SKILL.md (excluding frontmatter). */
+  body: string;
+}
+
+/** Context handed to a {@link SkillGenerator} so drafts avoid duplicating existing skills. */
+export interface SkillGenContext {
+  existingSkillIds?: string[];
+  cwd?: string;
+}
+
+/** Drafts a new skill for an uncovered intent. Implementations: anthropic-api, claude-cli. */
+export interface SkillGenerator {
+  generate(intent: Intent, context?: SkillGenContext): Promise<SkillDraft>;
+}
+
+/** A skill that matches an intent, with its BM25 relevance score. */
+export interface CoveredSkill {
+  skillId: string;
+  score: number;
+}
+
+/**
+ * Whether managed skills cover an intent. `skills` is the BM25-ranked list of
+ * matches (best first), mirroring the gateway's capability search — an intent
+ * can be covered by more than one skill.
+ */
+export type IntentCoverage = { status: "covered"; skills: CoveredSkill[] } | { status: "gap" };
+
+/** A de-duplicated intent in the cumulative index, with coverage and session provenance. */
+export interface IntentRecord {
+  /** Normalized intent text used as the de-dup key. */
+  content: string;
+  coverage: IntentCoverage;
+  /** Session ids this intent was observed in. */
+  sessions: string[];
+  firstSeen: string;
+  lastSeen: string;
+}

--- a/packages/core/src/lib/intents/types.ts
+++ b/packages/core/src/lib/intents/types.ts
@@ -97,6 +97,13 @@ export interface SkillDraft {
 export interface SkillGenContext {
   existingSkillIds?: string[];
   cwd?: string;
+  /**
+   * Representative evidence snippets/turns for the intent, so a generator can
+   * ground the skill in what the user actually did.
+   */
+  evidences?: string[];
+  /** Other intents seen in the same session(s), for additional context. */
+  relatedIntents?: string[];
 }
 
 /** Drafts a new skill for an uncovered intent. Implementations: anthropic-api, claude-cli. */
@@ -126,4 +133,35 @@ export interface IntentRecord {
   sessions: string[];
   firstSeen: string;
   lastSeen: string;
+  /** Ranking score (currently session frequency), for ranking transparency. */
+  score?: number;
+  /** Evidence spans/turns that support this intent (from the newest session), as proof. */
+  evidences?: string[];
+}
+
+/** One session's outcome within a single analysis run, for run telemetry. */
+export interface RunLogSessionEntry {
+  sessionId: string;
+  host?: string;
+  ok: boolean;
+  error?: string;
+  intents: number;
+  gaps: number;
+  turns: number;
+  latencyMs: number;
+  cacheHit: boolean;
+}
+
+/** A single analysis run, appended to the runs telemetry log. */
+export interface RunLogEntry {
+  runId: string;
+  /** ISO timestamp. */
+  at: string;
+  /** "manual" | "idle" | "cadence" | "all" | "session" */
+  trigger: string;
+  model?: string;
+  durationMs: number;
+  totalIntents: number;
+  totalGaps: number;
+  sessions: RunLogSessionEntry[];
 }

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -6,6 +6,7 @@ import {
   FolderOpen,
   House,
   LinkIcon,
+  MessagesSquare,
   Plus,
   Server,
   Settings2,
@@ -265,7 +266,7 @@ export function AppShell() {
   );
 
   const goTo = useCallback(
-    (to: "/" | "/agent-setup" | "/skills" | "/intents") => {
+    (to: "/" | "/agent-setup" | "/skills" | "/intents" | "/chats") => {
       const tokenizedPath = token ? `${to}?t=${encodeURIComponent(token)}` : to;
       void navigate({ to: tokenizedPath } as never);
     },
@@ -372,7 +373,7 @@ export function AppShell() {
 
 function ProductSidebar(props: {
   config: ConfigResponse | null;
-  onNavigate: (to: "/" | "/agent-setup" | "/skills" | "/intents") => void;
+  onNavigate: (to: "/" | "/agent-setup" | "/skills" | "/intents" | "/chats") => void;
   pathname: string;
 }) {
   return (
@@ -413,6 +414,12 @@ function ProductSidebar(props: {
                 icon={<Target />}
                 label="Intents"
                 onClick={() => props.onNavigate("/intents")}
+              />
+              <ProductSidebarItem
+                active={props.pathname === "/chats"}
+                icon={<MessagesSquare />}
+                label="Chats"
+                onClick={() => props.onNavigate("/chats")}
               />
             </SidebarMenu>
           </SidebarGroupContent>
@@ -543,7 +550,7 @@ function CommandMenu(props: {
   onAddToolSource: () => void;
   onImport: () => void;
   onLink: () => void;
-  onNavigate: (to: "/" | "/agent-setup" | "/skills" | "/intents") => void;
+  onNavigate: (to: "/" | "/agent-setup" | "/skills" | "/intents" | "/chats") => void;
   onSelectAgent: (kind: AgentHostKind) => void;
   onSelectToolSource: (scope: RatelScope, name: string) => void;
   open: boolean;
@@ -581,6 +588,10 @@ function CommandMenu(props: {
               <CommandItem onSelect={() => props.onNavigate("/intents")}>
                 <Target />
                 Intents
+              </CommandItem>
+              <CommandItem onSelect={() => props.onNavigate("/chats")}>
+                <MessagesSquare />
+                Chats
               </CommandItem>
             </CommandGroup>
             {agentItems.length > 0 && (
@@ -765,6 +776,11 @@ export function toolSourcePath(scope: RatelScope, name: string, token?: string) 
 
 export function skillPath(id: string, token?: string) {
   const path = `/skills/${encodeURIComponent(id)}`;
+  return token ? `${path}?t=${encodeURIComponent(token)}` : path;
+}
+
+export function chatPath(sessionId: string, token?: string) {
+  const path = `/chats/${encodeURIComponent(sessionId)}`;
   return token ? `${path}?t=${encodeURIComponent(token)}` : path;
 }
 

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -10,6 +10,7 @@ import {
   Server,
   Settings2,
   Sparkles,
+  Target,
   UserCircle,
 } from "lucide-react";
 import { createContext, type ReactNode, useCallback, useContext, useEffect, useState } from "react";
@@ -264,7 +265,7 @@ export function AppShell() {
   );
 
   const goTo = useCallback(
-    (to: "/" | "/agent-setup" | "/skills") => {
+    (to: "/" | "/agent-setup" | "/skills" | "/intents") => {
       const tokenizedPath = token ? `${to}?t=${encodeURIComponent(token)}` : to;
       void navigate({ to: tokenizedPath } as never);
     },
@@ -371,7 +372,7 @@ export function AppShell() {
 
 function ProductSidebar(props: {
   config: ConfigResponse | null;
-  onNavigate: (to: "/" | "/agent-setup" | "/skills") => void;
+  onNavigate: (to: "/" | "/agent-setup" | "/skills" | "/intents") => void;
   pathname: string;
 }) {
   return (
@@ -406,6 +407,12 @@ function ProductSidebar(props: {
                 icon={<Sparkles />}
                 label="Skills"
                 onClick={() => props.onNavigate("/skills")}
+              />
+              <ProductSidebarItem
+                active={props.pathname === "/intents"}
+                icon={<Target />}
+                label="Intents"
+                onClick={() => props.onNavigate("/intents")}
               />
             </SidebarMenu>
           </SidebarGroupContent>
@@ -536,7 +543,7 @@ function CommandMenu(props: {
   onAddToolSource: () => void;
   onImport: () => void;
   onLink: () => void;
-  onNavigate: (to: "/" | "/agent-setup" | "/skills") => void;
+  onNavigate: (to: "/" | "/agent-setup" | "/skills" | "/intents") => void;
   onSelectAgent: (kind: AgentHostKind) => void;
   onSelectToolSource: (scope: RatelScope, name: string) => void;
   open: boolean;
@@ -570,6 +577,10 @@ function CommandMenu(props: {
               <CommandItem onSelect={() => props.onNavigate("/skills")}>
                 <Sparkles />
                 Skills
+              </CommandItem>
+              <CommandItem onSelect={() => props.onNavigate("/intents")}>
+                <Target />
+                Intents
               </CommandItem>
             </CommandGroup>
             {agentItems.length > 0 && (

--- a/packages/ui/src/components/dotmatrix-loader.css
+++ b/packages/ui/src/components/dotmatrix-loader.css
@@ -5,7 +5,7 @@
   vertical-align: middle;
   /* One base loop at speed=1; --dmx-speed from JS scales inversely with the speed prop */
   --dmx-cycle: 1500ms;
-  /* Rest / mid / bright — override via opacityBase, opacityMid, opacityPeak on the component */
+  /* Rest / mid / bright - override via opacityBase, opacityMid, opacityPeak on the component */
   --dmx-opacity-base: 0.16;
   --dmx-opacity-mid: 0.32;
   --dmx-opacity-peak: 1;

--- a/packages/ui/src/components/import-skills-dialog.tsx
+++ b/packages/ui/src/components/import-skills-dialog.tsx
@@ -35,8 +35,8 @@ const PAGE_SIZE = 6;
 
 /**
  * Bring unmanaged Claude Code / Codex skills into Ratel's managed folder. A
- * single screen: pick skills, then import. There is no conflict step — a name
- * already managed by Ratel is excluded from `available` upstream — so unlike the
+ * single screen: pick skills, then import. There is no conflict step - a name
+ * already managed by Ratel is excluded from `available` upstream - so unlike the
  * MCP import this stays a simple checkbox list.
  */
 export function ImportSkillsDialog(props: ImportSkillsDialogProps) {

--- a/packages/ui/src/components/intent-stream.test.ts
+++ b/packages/ui/src/components/intent-stream.test.ts
@@ -3,42 +3,42 @@ import { reconcileStreamOrder } from "./intent-stream";
 
 describe("reconcileStreamOrder", () => {
   it("adopts the incoming order on a first reconcile (empty prior)", () => {
-    const { order, appended } = reconcileStreamOrder([], ["a", "b", "c"]);
+    const { order, added } = reconcileStreamOrder([], ["a", "b", "c"]);
     expect(order).toEqual(["a", "b", "c"]);
-    expect(appended).toEqual(["a", "b", "c"]);
+    expect(added).toEqual(["a", "b", "c"]);
   });
 
-  it("keeps survivors in their prior slot and appends newcomers at the end", () => {
-    // Server re-ranks to [c, a, b, d] but a/b/c already shown — they must NOT move;
-    // only the genuinely new "d" is appended (and flagged for the enter animation).
-    const { order, appended } = reconcileStreamOrder(["a", "b", "c"], ["c", "a", "b", "d"]);
-    expect(order).toEqual(["a", "b", "c", "d"]);
-    expect(appended).toEqual(["d"]);
+  it("keeps survivors in their prior slot and prepends newcomers at the top", () => {
+    // Server re-ranks to [c, a, b, d] but a/b/c already shown — they must NOT reshuffle;
+    // only the genuinely new "d" is added, and it arrives at the TOP.
+    const { order, added } = reconcileStreamOrder(["a", "b", "c"], ["c", "a", "b", "d"]);
+    expect(order).toEqual(["d", "a", "b", "c"]);
+    expect(added).toEqual(["d"]);
   });
 
-  it("reports nothing appended when the set is unchanged", () => {
-    const { order, appended } = reconcileStreamOrder(["a", "b"], ["b", "a"]);
+  it("reports nothing added when the set is unchanged", () => {
+    const { order, added } = reconcileStreamOrder(["a", "b"], ["b", "a"]);
     expect(order).toEqual(["a", "b"]);
-    expect(appended).toEqual([]);
+    expect(added).toEqual([]);
   });
 
   it("drops contents that have gone away", () => {
-    const { order, appended } = reconcileStreamOrder(["a", "b", "c"], ["a", "c"]);
+    const { order, added } = reconcileStreamOrder(["a", "b", "c"], ["a", "c"]);
     expect(order).toEqual(["a", "c"]);
-    expect(appended).toEqual([]);
+    expect(added).toEqual([]);
   });
 
-  it("re-appends a content that left and came back (treated as new)", () => {
+  it("re-adds a content that left and came back at the top (treated as new)", () => {
     const afterLeaving = reconcileStreamOrder(["a", "b"], ["a"]);
     expect(afterLeaving.order).toEqual(["a"]);
     const afterReturn = reconcileStreamOrder(afterLeaving.order, ["a", "b"]);
-    expect(afterReturn.order).toEqual(["a", "b"]);
-    expect(afterReturn.appended).toEqual(["b"]);
+    expect(afterReturn.order).toEqual(["b", "a"]);
+    expect(afterReturn.added).toEqual(["b"]);
   });
 
-  it("preserves incoming order among multiple newcomers", () => {
-    const { order, appended } = reconcileStreamOrder(["a"], ["a", "x", "y", "z"]);
-    expect(order).toEqual(["a", "x", "y", "z"]);
-    expect(appended).toEqual(["x", "y", "z"]);
+  it("prepends multiple newcomers ahead of survivors, in incoming order", () => {
+    const { order, added } = reconcileStreamOrder(["a"], ["a", "x", "y", "z"]);
+    expect(order).toEqual(["x", "y", "z", "a"]);
+    expect(added).toEqual(["x", "y", "z"]);
   });
 });

--- a/packages/ui/src/components/intent-stream.test.ts
+++ b/packages/ui/src/components/intent-stream.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { reconcileStreamOrder } from "./intent-stream";
+
+describe("reconcileStreamOrder", () => {
+  it("adopts the incoming order on a first reconcile (empty prior)", () => {
+    const { order, appended } = reconcileStreamOrder([], ["a", "b", "c"]);
+    expect(order).toEqual(["a", "b", "c"]);
+    expect(appended).toEqual(["a", "b", "c"]);
+  });
+
+  it("keeps survivors in their prior slot and appends newcomers at the end", () => {
+    // Server re-ranks to [c, a, b, d] but a/b/c already shown — they must NOT move;
+    // only the genuinely new "d" is appended (and flagged for the enter animation).
+    const { order, appended } = reconcileStreamOrder(["a", "b", "c"], ["c", "a", "b", "d"]);
+    expect(order).toEqual(["a", "b", "c", "d"]);
+    expect(appended).toEqual(["d"]);
+  });
+
+  it("reports nothing appended when the set is unchanged", () => {
+    const { order, appended } = reconcileStreamOrder(["a", "b"], ["b", "a"]);
+    expect(order).toEqual(["a", "b"]);
+    expect(appended).toEqual([]);
+  });
+
+  it("drops contents that have gone away", () => {
+    const { order, appended } = reconcileStreamOrder(["a", "b", "c"], ["a", "c"]);
+    expect(order).toEqual(["a", "c"]);
+    expect(appended).toEqual([]);
+  });
+
+  it("re-appends a content that left and came back (treated as new)", () => {
+    const afterLeaving = reconcileStreamOrder(["a", "b"], ["a"]);
+    expect(afterLeaving.order).toEqual(["a"]);
+    const afterReturn = reconcileStreamOrder(afterLeaving.order, ["a", "b"]);
+    expect(afterReturn.order).toEqual(["a", "b"]);
+    expect(afterReturn.appended).toEqual(["b"]);
+  });
+
+  it("preserves incoming order among multiple newcomers", () => {
+    const { order, appended } = reconcileStreamOrder(["a"], ["a", "x", "y", "z"]);
+    expect(order).toEqual(["a", "x", "y", "z"]);
+    expect(appended).toEqual(["x", "y", "z"]);
+  });
+});

--- a/packages/ui/src/components/intent-stream.tsx
+++ b/packages/ui/src/components/intent-stream.tsx
@@ -9,20 +9,20 @@ const ENTER_MS = 520;
 export const PLACEHOLDER_EXIT_MS = 320;
 
 /**
- * Pure core of {@link useStreamingOrder}'s ordering: survivors keep their prior slot
- * (so nothing reshuffles under the user mid-run), and brand-new contents are appended
- * at the end. A content that has gone away is dropped. Returns the next order and the
- * contents that were appended (the ones to animate in).
+ * Pure core of {@link useStreamingOrder}'s ordering: survivors keep their prior
+ * relative slot (so nothing reshuffles under the user mid-run), and brand-new contents
+ * are prepended at the TOP so results stream in from the top. A content that has gone
+ * away is dropped. Returns the next order and the new contents (the ones to animate in).
  */
 export function reconcileStreamOrder(
   prevOrder: readonly string[],
   incoming: readonly string[],
-): { order: string[]; appended: string[] } {
+): { order: string[]; added: string[] } {
   const incomingSet = new Set(incoming);
   const kept = prevOrder.filter((content) => incomingSet.has(content));
   const keptSet = new Set(kept);
-  const appended = incoming.filter((content) => !keptSet.has(content));
-  return { order: [...kept, ...appended], appended };
+  const added = incoming.filter((content) => !keptSet.has(content));
+  return { order: [...added, ...kept], added };
 }
 
 /**
@@ -46,14 +46,14 @@ export function useStreamingOrder(
 
   useEffect(() => {
     const incoming = intents.map((i) => i.content);
-    const { order: nextOrder, appended } = reconcileStreamOrder(orderRef.current, incoming);
+    const { order: nextOrder, added: newcomers } = reconcileStreamOrder(orderRef.current, incoming);
     orderRef.current = nextOrder;
     setOrder(nextOrder);
 
     const firstSnapshot = !seeded.current;
     seeded.current = true;
     // On a plain (non-streaming) first load, don't animate the existing list in.
-    const added = firstSnapshot && !streaming ? [] : appended;
+    const added = firstSnapshot && !streaming ? [] : newcomers;
     if (added.length === 0) return;
 
     setEntering((prev) => {

--- a/packages/ui/src/components/intent-stream.tsx
+++ b/packages/ui/src/components/intent-stream.tsx
@@ -1,0 +1,150 @@
+import { useEffect, useRef, useState } from "react";
+import { PrismSweep } from "@/components/ui/prism-sweep";
+import type { IntentRecord } from "@/lib/intents";
+import { cn } from "@/lib/utils";
+
+/** Row enter animation duration; the "new" flag is cleared just after it finishes. */
+const ENTER_MS = 520;
+/** Searching placeholder collapse duration; keep it mounted until the exit plays out. */
+export const PLACEHOLDER_EXIT_MS = 320;
+
+/**
+ * Pure core of {@link useStreamingOrder}'s ordering: survivors keep their prior slot
+ * (so nothing reshuffles under the user mid-run), and brand-new contents are appended
+ * at the end. A content that has gone away is dropped. Returns the next order and the
+ * contents that were appended (the ones to animate in).
+ */
+export function reconcileStreamOrder(
+  prevOrder: readonly string[],
+  incoming: readonly string[],
+): { order: string[]; appended: string[] } {
+  const incomingSet = new Set(incoming);
+  const kept = prevOrder.filter((content) => incomingSet.has(content));
+  const keptSet = new Set(kept);
+  const appended = incoming.filter((content) => !keptSet.has(content));
+  return { order: [...kept, ...appended], appended };
+}
+
+/**
+ * Keep a list of intents in a STABLE display order while results stream in during a
+ * run: survivors stay put, newcomers append at the end, and each newcomer is flagged
+ * `entering` just long enough to play its grow-in animation once. Without streaming the
+ * first render adopts the server order silently — a plain page load shouldn't animate
+ * the whole list.
+ */
+export function useStreamingOrder(
+  intents: IntentRecord[],
+  streaming: boolean,
+): { items: IntentRecord[]; entering: ReadonlySet<string> } {
+  const [order, setOrder] = useState<string[]>([]);
+  const [entering, setEntering] = useState<ReadonlySet<string>>(() => new Set());
+  // Mirror of `order` for synchronous reconciliation; `seeded` distinguishes a fresh
+  // load from a streamed update so a plain load doesn't animate everything.
+  const orderRef = useRef<string[]>([]);
+  const seeded = useRef(false);
+  const timers = useRef<Map<string, number>>(new Map());
+
+  useEffect(() => {
+    const incoming = intents.map((i) => i.content);
+    const { order: nextOrder, appended } = reconcileStreamOrder(orderRef.current, incoming);
+    orderRef.current = nextOrder;
+    setOrder(nextOrder);
+
+    const firstSnapshot = !seeded.current;
+    seeded.current = true;
+    // On a plain (non-streaming) first load, don't animate the existing list in.
+    const added = firstSnapshot && !streaming ? [] : appended;
+    if (added.length === 0) return;
+
+    setEntering((prev) => {
+      const next = new Set(prev);
+      for (const content of added) next.add(content);
+      return next;
+    });
+    // Drop each flag once the animation has played so a later re-render can't replay it.
+    for (const content of added) {
+      const existing = timers.current.get(content);
+      if (existing) window.clearTimeout(existing);
+      const id = window.setTimeout(() => {
+        timers.current.delete(content);
+        setEntering((prev) => {
+          if (!prev.has(content)) return prev;
+          const next = new Set(prev);
+          next.delete(content);
+          return next;
+        });
+      }, ENTER_MS);
+      timers.current.set(content, id);
+    }
+  }, [intents, streaming]);
+
+  useEffect(() => {
+    const map = timers.current;
+    return () => {
+      for (const id of map.values()) window.clearTimeout(id);
+    };
+  }, []);
+
+  const byContent = new Map(intents.map((i) => [i.content, i]));
+  const items: IntentRecord[] = [];
+  for (const content of order) {
+    const record = byContent.get(content);
+    if (record) items.push(record);
+  }
+  return { items, entering };
+}
+
+/**
+ * Keep a soon-to-unmount element alive through its exit animation: it stays `mounted`
+ * for `exitMs` after `active` flips false (so a closing animation can play), reporting
+ * `exiting` in the meantime.
+ */
+export function usePresence(
+  active: boolean,
+  exitMs: number,
+): { mounted: boolean; exiting: boolean } {
+  const [mounted, setMounted] = useState(active);
+  const [exiting, setExiting] = useState(false);
+
+  useEffect(() => {
+    if (active) {
+      setMounted(true);
+      setExiting(false);
+      return;
+    }
+    if (!mounted) return;
+    setExiting(true);
+    const id = window.setTimeout(() => {
+      setMounted(false);
+      setExiting(false);
+    }, exitMs);
+    return () => window.clearTimeout(id);
+  }, [active, mounted, exitMs]);
+
+  return { mounted, exiting };
+}
+
+/**
+ * The "slot" where the next intent will land: a dashed skeleton row with a small pixel
+ * loader, shown at the foot of the list while a run streams results in. It grows in on
+ * mount and collapses out (rather than blinking away) when the run ends.
+ */
+export function IntentSearchingRow({ exiting }: { exiting: boolean }) {
+  return (
+    <li
+      aria-hidden
+      className={cn("grid", exiting ? "animate-intent-collapse" : "animate-intent-enter")}
+    >
+      <div className="overflow-hidden">
+        <div className="flex items-center gap-3 rounded-md border border-border border-dashed bg-muted/20 p-3">
+          <PrismSweep dotSize={3} size={22} speed={1.3} />
+          <div className="min-w-0 flex-1">
+            <div className="h-3 w-2/5 animate-pulse rounded-[2px] bg-muted-foreground/15" />
+            <div className="mt-2 h-2.5 w-1/4 animate-pulse rounded-[2px] bg-muted-foreground/10" />
+          </div>
+          <span className="shrink-0 text-muted-foreground text-xs">Searching for intents…</span>
+        </div>
+      </div>
+    </li>
+  );
+}

--- a/packages/ui/src/components/markdown.tsx
+++ b/packages/ui/src/components/markdown.tsx
@@ -5,7 +5,7 @@ import { cn } from "@/lib/utils";
 /**
  * Render Markdown with the app's design tokens. HTML in the source is NOT
  * rendered (no rehype-raw) and react-markdown sanitizes dangerous URLs, so a
- * skill body — even an untrusted one — can't inject markup or `javascript:`
+ * skill body - even an untrusted one - can't inject markup or `javascript:`
  * links. Used to preview skill instructions in read mode; edit mode shows raw.
  *
  * Each override forwards only the props it needs (children / href / className)

--- a/packages/ui/src/components/ui/pixel-progress.tsx
+++ b/packages/ui/src/components/ui/pixel-progress.tsx
@@ -1,0 +1,30 @@
+import { cn } from "@/lib/utils";
+
+const CELLS = 28;
+const CELL_KEYS = Array.from({ length: CELLS }, (_, i) => `cell-${i}`);
+
+/** A blocky, pixel-art progress bar: discrete cells light up as `progress` (0–100) climbs. */
+export function PixelProgress({ progress, className }: { progress: number; className?: string }) {
+  const clamped = Math.max(0, Math.min(100, progress));
+  const filled = Math.round((clamped / 100) * CELLS);
+  return (
+    <div
+      aria-label={`Loading ${Math.round(clamped)}%`}
+      aria-valuemax={100}
+      aria-valuemin={0}
+      aria-valuenow={Math.round(clamped)}
+      className={cn("flex gap-px", className)}
+      role="progressbar"
+    >
+      {CELL_KEYS.map((key, i) => (
+        <span
+          className={cn(
+            "h-3.5 flex-1 rounded-[1px] transition-colors duration-150",
+            i < filled ? "bg-brand-green" : "bg-muted",
+          )}
+          key={key}
+        />
+      ))}
+    </div>
+  );
+}

--- a/packages/ui/src/components/ui/prism-sweep.tsx
+++ b/packages/ui/src/components/ui/prism-sweep.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import type { CSSProperties } from "react";
+import {
+  type DotAnimationResolver,
+  DotMatrixBase,
+  type DotMatrixCommonProps,
+  MATRIX_SIZE,
+} from "@/lib/dotmatrix-core";
+import { useDotMatrixPhases, usePrefersReducedMotion } from "@/lib/dotmatrix-hooks";
+
+// Longest anti-diagonal index (row+col) on the grid — used to normalize the sweep.
+const DIAGONAL_SPAN = (MATRIX_SIZE - 1) * 2;
+
+/**
+ * "Prism Sweep": a diagonal wave (`dmx-diagonal-alt-sweep`) rendered with the
+ * `grad-prism` gradient. Each dot's sweep delay comes from its anti-diagonal
+ * position, with alternating diagonals offset half a cycle for the interleaved
+ * sweep. A lively, clearly-animated loader (not a blank spinner).
+ */
+const animationResolver: DotAnimationResolver = ({ isActive, row, col, reducedMotion, phase }) => {
+  if (!isActive) return { className: "dmx-inactive" };
+  const diagonal = row + col;
+  const style = {
+    "--dmx-path": diagonal / DIAGONAL_SPAN,
+    "--dmx-diagonal-parity": diagonal % 2,
+  } as CSSProperties;
+  if (reducedMotion || phase === "idle") {
+    return { style: { ...style, opacity: 0.2 + (diagonal / DIAGONAL_SPAN) * 0.7 } };
+  }
+  return { className: "dmx-diagonal-alt-sweep", style };
+};
+
+export function PrismSweep({
+  speed = 1.2,
+  pattern = "full",
+  animated = true,
+  ...rest
+}: DotMatrixCommonProps) {
+  const reducedMotion = usePrefersReducedMotion();
+  const { phase, onMouseEnter, onMouseLeave } = useDotMatrixPhases({
+    animated: Boolean(animated && !reducedMotion),
+    speed,
+  });
+
+  return (
+    <DotMatrixBase
+      {...rest}
+      ariaLabel={rest.ariaLabel ?? "Loading"}
+      size={rest.size ?? 40}
+      dotSize={rest.dotSize ?? 5}
+      speed={speed}
+      pattern={pattern}
+      colorPreset={rest.colorPreset ?? "grad-prism"}
+      animated={animated}
+      phase={phase}
+      onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
+      reducedMotion={reducedMotion}
+      animationResolver={animationResolver}
+    />
+  );
+}

--- a/packages/ui/src/components/ui/prism-sweep.tsx
+++ b/packages/ui/src/components/ui/prism-sweep.tsx
@@ -9,7 +9,7 @@ import {
 } from "@/lib/dotmatrix-core";
 import { useDotMatrixPhases, usePrefersReducedMotion } from "@/lib/dotmatrix-hooks";
 
-// Longest anti-diagonal index (row+col) on the grid — used to normalize the sweep.
+// Longest anti-diagonal index (row+col) on the grid - used to normalize the sweep.
 const DIAGONAL_SPAN = (MATRIX_SIZE - 1) * 2;
 
 /**

--- a/packages/ui/src/index.css
+++ b/packages/ui/src/index.css
@@ -147,6 +147,47 @@ textarea {
   }
 }
 
+/* Intent list streaming: a newly-found intent grows into its slot (rather than
+   popping in), and the "searching" placeholder collapses out (rather than blinking
+   away). Animating grid-template-rows 0fr<->1fr gives a real height transition; the
+   inner wrapper must be overflow-hidden to clip during the grow/collapse. */
+@keyframes intent-enter {
+  from {
+    grid-template-rows: 0fr;
+    opacity: 0;
+  }
+  to {
+    grid-template-rows: 1fr;
+    opacity: 1;
+  }
+}
+
+@keyframes intent-collapse {
+  from {
+    grid-template-rows: 1fr;
+    opacity: 1;
+  }
+  to {
+    grid-template-rows: 0fr;
+    opacity: 0;
+  }
+}
+
+@utility animate-intent-enter {
+  animation: intent-enter 0.42s cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+
+@utility animate-intent-collapse {
+  animation: intent-collapse 0.3s cubic-bezier(0.4, 0, 1, 1) forwards;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .animate-intent-enter,
+  .animate-intent-collapse {
+    animation: none !important;
+  }
+}
+
 @supports (animation-timeline: scroll()) {
   :where([class^="scroll-mask-"], [class*=" scroll-mask-"]) {
     --scroll-mask-t: linear-gradient(

--- a/packages/ui/src/lib/dotmatrix-core.tsx
+++ b/packages/ui/src/lib/dotmatrix-core.tsx
@@ -620,7 +620,7 @@ export function dmxBloomRootActive(bloom: boolean, halo: number | undefined): bo
   return bloom || clampHalo(halo) > 0;
 }
 
-/** Root class when `halo` > 0 — CSS widens drop-shadow falloff for a softer, more diffuse glow. */
+/** Root class when `halo` > 0 - CSS widens drop-shadow falloff for a softer, more diffuse glow. */
 export function dmxBloomHaloSpreadClass(halo: number | undefined): "dmx-bloom-halo" | false {
   return clampHalo(halo) > 0 ? "dmx-bloom-halo" : false;
 }

--- a/packages/ui/src/lib/intents.ts
+++ b/packages/ui/src/lib/intents.ts
@@ -13,6 +13,10 @@ export interface IntentRecord {
   sessions: string[];
   firstSeen: string;
   lastSeen: string;
+  /** Server-computed ranking score (frequency + recency). Higher = suggest first. */
+  score?: number;
+  /** Evidence spans/turns that support this intent — the "proof". */
+  evidences?: string[];
 }
 
 export interface SessionSummary {
@@ -40,6 +44,10 @@ export interface IntentsIndex {
   enabled?: boolean;
   /** True while a fire-and-forget analysis run is in progress on the server. */
   running?: boolean;
+  /** The session a per-chat run is processing (null for batch runs); drives per-chat indicators. */
+  runningSessionId?: string | null;
+  /** Sessions queued behind the running one (chained per-chat analyses). */
+  queuedSessionIds?: string[];
   /** Message from the last background run that failed, else null. */
   lastError?: string | null;
 }
@@ -48,6 +56,8 @@ export interface IntentsIndex {
 export interface RunKickoff {
   started: boolean;
   alreadyRunning?: boolean;
+  queued?: boolean;
+  disabled?: boolean;
 }
 
 export type ChatSourceKind = "hooks" | "api" | "cloud";
@@ -64,12 +74,16 @@ export interface AnalysisSettings {
     model?: string;
   };
   cadence?: {
+    auto?: boolean;
     everyNMessages?: number;
     onIdle?: boolean;
+    recentHours?: number;
   };
   skillGen?: {
     provider?: SkillGenProvider;
     apiKey?: string;
+    /** Model used to author skills; also sets the expected authoring time in the UI. */
+    model?: string;
   };
   coverage?: {
     minScore?: number;
@@ -91,6 +105,99 @@ export interface SkillDraft {
   body: string;
 }
 
+/** Result of starting a background skill-authoring job. */
+export interface OfferStart {
+  started: boolean;
+  alreadyRunning?: boolean;
+  intent: string;
+  model: string;
+}
+
+/** Polled status of a background skill-authoring job. */
+export interface OfferStatus {
+  status: "idle" | "running" | "done" | "error";
+  draft?: SkillDraft;
+  error?: string;
+  model?: string;
+  startedAt?: string;
+}
+
+/** One entry in the server's live offer-job registry (survives UI navigation). */
+export interface OfferJobSummary {
+  intent: string;
+  status: "running" | "done" | "error";
+  model: string;
+  startedAt: string;
+  error?: string;
+  hasDraft: boolean;
+}
+
+export interface ChatTurn {
+  role: "user" | "assistant";
+  content: string;
+  ts?: string;
+}
+
+export interface ChatSummary {
+  sessionId: string;
+  host: string;
+  cwd?: string;
+  title: string;
+  turnCount: number;
+  updatedAt?: string;
+  lastAnalyzedAt?: string;
+  idle: boolean;
+  intentCount: number;
+  gapCount: number;
+  analyzed: boolean;
+}
+
+export interface ChatDetail {
+  sessionId: string;
+  host: string;
+  cwd?: string;
+  title: string;
+  /** The loaded window of turns (the most recent `turns.length` of `total`). */
+  turns: ChatTurn[];
+  /** Total turns in the conversation, so the UI knows whether earlier ones can be loaded. */
+  total: number;
+}
+
+export interface RunLogSessionEntry {
+  sessionId: string;
+  host?: string;
+  ok: boolean;
+  error?: string;
+  intents: number;
+  gaps: number;
+  turns: number;
+  latencyMs: number;
+  cacheHit: boolean;
+}
+
+export interface RunLogEntry {
+  runId: string;
+  at: string;
+  trigger: string;
+  model?: string;
+  durationMs: number;
+  totalIntents: number;
+  totalGaps: number;
+  sessions: RunLogSessionEntry[];
+}
+
+export interface ObservabilitySummary {
+  totalRuns: number;
+  lastRunAt: string | null;
+  avgDurationMs: number;
+  avgGapsPerRun: number;
+}
+
+export interface ObservabilityResponse {
+  runs: RunLogEntry[];
+  summary: ObservabilitySummary;
+}
+
 type Request = <T>(path: string, init?: JsonRequestInit) => Promise<T>;
 
 export function fetchIntents(request: Request): Promise<IntentsIndex> {
@@ -102,6 +209,11 @@ export function runIntents(request: Request, sessionId?: string): Promise<RunKic
     method: "POST",
     body: sessionId ? { sessionId } : {},
   });
+}
+
+/** Re-analyze every captured chat (ignores the new-activity/recency filters). */
+export function runAllIntents(request: Request): Promise<RunKickoff> {
+  return request<RunKickoff>("/api/intents/run", { method: "POST", body: { all: true } });
 }
 
 export function fetchAnalysisSettings(request: Request): Promise<AnalysisSettingsResponse> {
@@ -118,11 +230,92 @@ export function saveAnalysisSettings(
   });
 }
 
-export function offerSkill(request: Request, intent: string): Promise<{ draft: SkillDraft }> {
-  return request<{ draft: SkillDraft }>("/api/skills/offer", {
+/** Starts a BACKGROUND authoring job; poll {@link offerSkillStatus} for the draft. */
+export function offerSkill(request: Request, intent: string): Promise<OfferStart> {
+  return request<OfferStart>("/api/skills/offer", {
     method: "POST",
     body: { intent },
   });
+}
+
+export function offerSkillStatus(request: Request, intent: string): Promise<OfferStatus> {
+  return request<OfferStatus>(`/api/skills/offer/status?intent=${encodeURIComponent(intent)}`);
+}
+
+/** All in-flight/finished authoring jobs, so a returning user can still reach a result. */
+export function listOfferJobs(request: Request): Promise<{ jobs: OfferJobSummary[] }> {
+  return request<{ jobs: OfferJobSummary[] }>("/api/skills/offer/jobs");
+}
+
+/** Drop a finished/declined authoring job so it stops surfacing as "Skill ready". */
+export function clearOfferJob(request: Request, intent: string): Promise<{ cleared: boolean }> {
+  return request<{ cleared: boolean }>(`/api/skills/offer?intent=${encodeURIComponent(intent)}`, {
+    method: "DELETE",
+  });
+}
+
+export function fetchObservability(request: Request): Promise<ObservabilityResponse> {
+  return request<ObservabilityResponse>("/api/intents/observability");
+}
+
+export function fetchChats(request: Request): Promise<{ chats: ChatSummary[] }> {
+  return request<{ chats: ChatSummary[] }>("/api/chats");
+}
+
+/** Load a chat's most recent `limit` turns (plus `total`, so the UI can offer "load earlier"). */
+export function fetchChat(
+  request: Request,
+  sessionId: string,
+  limit?: number,
+): Promise<ChatDetail> {
+  const q = limit ? `?limit=${encodeURIComponent(String(limit))}` : "";
+  return request<ChatDetail>(`/api/chats/${encodeURIComponent(sessionId)}${q}`);
+}
+
+export function deleteChat(request: Request, sessionId: string): Promise<{ deleted: string }> {
+  return request<{ deleted: string }>(`/api/chats/${encodeURIComponent(sessionId)}`, {
+    method: "DELETE",
+  });
+}
+
+/**
+ * Expected skill-generation duration (ms) for a model, used to pace the progress
+ * animation. Matched by substring on the lowercased model name.
+ */
+export function estimateGenMs(model?: string): number {
+  const m = (model ?? "").toLowerCase();
+  if (m.includes("haiku")) return 12000;
+  if (m.includes("opus")) return 55000;
+  if (m.includes("sonnet")) return 30000;
+  return 30000;
+}
+
+export interface ModelOption {
+  value: string;
+  label: string;
+}
+
+/**
+ * Preconfigured skill-generation model choices for the Settings dropdown. CLI
+ * uses `claude --model` aliases; the API uses full model ids. `""` = the
+ * provider's built-in default.
+ */
+export function skillGenModelOptions(provider: SkillGenProvider): ModelOption[] {
+  const base: ModelOption[] = [{ value: "", label: "Default (recommended)" }];
+  if (provider === "claude-cli") {
+    return [
+      ...base,
+      { value: "haiku", label: "Haiku — fastest" },
+      { value: "sonnet", label: "Sonnet — balanced" },
+      { value: "opus", label: "Opus — most capable" },
+    ];
+  }
+  return [
+    ...base,
+    { value: "claude-haiku-4-5-20251001", label: "Haiku 4.5 — fastest" },
+    { value: "claude-sonnet-4-6", label: "Sonnet 4.6 — balanced (default)" },
+    { value: "claude-opus-4-8", label: "Opus 4.8 — most capable" },
+  ];
 }
 
 export function deleteIntent(request: Request, content: string): Promise<unknown> {

--- a/packages/ui/src/lib/intents.ts
+++ b/packages/ui/src/lib/intents.ts
@@ -62,6 +62,7 @@ export interface RunKickoff {
 
 export type ChatSourceKind = "hooks" | "api" | "cloud";
 export type ExtractorProvider = "http" | "naive" | "cloud";
+export type ExtractorAuthScheme = "bearer" | "basic";
 export type SkillGenProvider = "auto" | "anthropic-api" | "claude-cli";
 
 export interface AnalysisSettings {
@@ -70,6 +71,11 @@ export interface AnalysisSettings {
   extractor?: {
     provider?: ExtractorProvider;
     endpoint?: string;
+    /** How the endpoint is authenticated. Omitted = auto (basic if username set, else bearer). */
+    authScheme?: ExtractorAuthScheme;
+    /** Username for basic auth (not secret). */
+    username?: string;
+    /** Bearer token or basic-auth password. Secret — echoed back masked. */
     apiKey?: string;
     model?: string;
   };
@@ -227,6 +233,28 @@ export function saveAnalysisSettings(
   return request<AnalysisSettingsResponse>("/api/analysis/settings", {
     method: "PUT",
     body: { analysis },
+  });
+}
+
+/** Verdict from probing the extractor endpoint's `/health`. */
+export interface ExtractorHealth {
+  ok: boolean;
+  status?: number;
+  detail?: string;
+}
+
+/**
+ * Probe the extractor endpoint's `/health` with the given (possibly unsaved)
+ * extractor settings. A masked apiKey resolves to the stored secret server-side,
+ * so the password need not be retyped to test a saved endpoint.
+ */
+export function testExtractor(
+  request: Request,
+  extractor: AnalysisSettings["extractor"],
+): Promise<ExtractorHealth> {
+  return request<ExtractorHealth>("/api/analysis/extractor/test", {
+    method: "POST",
+    body: { extractor: extractor ?? {} },
   });
 }
 

--- a/packages/ui/src/lib/intents.ts
+++ b/packages/ui/src/lib/intents.ts
@@ -1,0 +1,141 @@
+import type { JsonRequestInit } from "@/App";
+
+export interface CoveredSkill {
+  skillId: string;
+  score: number;
+}
+
+export type IntentCoverage = { status: "covered"; skills: CoveredSkill[] } | { status: "gap" };
+
+export interface IntentRecord {
+  content: string;
+  coverage: IntentCoverage;
+  sessions: string[];
+  firstSeen: string;
+  lastSeen: string;
+}
+
+export interface SessionSummary {
+  sessionId: string;
+  host?: string;
+  cwd?: string;
+  analyzedAt: string;
+  intentCount: number;
+  gapCount: number;
+  /** New captured messages since this session was last analyzed. */
+  newTurnCount?: number;
+}
+
+export interface Cadence {
+  everyNMessages: number;
+  onIdle: boolean;
+}
+
+export interface IntentsIndex {
+  version: number;
+  intents: IntentRecord[];
+  sessions: SessionSummary[];
+  cadence?: Cadence;
+  /** Master switch: false means capture + analysis are turned off. */
+  enabled?: boolean;
+  /** True while a fire-and-forget analysis run is in progress on the server. */
+  running?: boolean;
+  /** Message from the last background run that failed, else null. */
+  lastError?: string | null;
+}
+
+/** The run is fire-and-forget; the server returns immediately and the UI polls for `running`. */
+export interface RunKickoff {
+  started: boolean;
+  alreadyRunning?: boolean;
+}
+
+export type ChatSourceKind = "hooks" | "api" | "cloud";
+export type ExtractorProvider = "http" | "naive" | "cloud";
+export type SkillGenProvider = "auto" | "anthropic-api" | "claude-cli";
+
+export interface AnalysisSettings {
+  enabled?: boolean;
+  chatSource?: ChatSourceKind;
+  extractor?: {
+    provider?: ExtractorProvider;
+    endpoint?: string;
+    apiKey?: string;
+    model?: string;
+  };
+  cadence?: {
+    everyNMessages?: number;
+    onIdle?: boolean;
+  };
+  skillGen?: {
+    provider?: SkillGenProvider;
+    apiKey?: string;
+  };
+  coverage?: {
+    minScore?: number;
+    relativeRatio?: number;
+    maxSkills?: number;
+  };
+}
+
+export interface AnalysisSettingsResponse {
+  analysis: AnalysisSettings;
+  /** Sentinel the server returns for stored secrets; echo it back to keep them. */
+  secretMask: string;
+}
+
+export interface SkillDraft {
+  name: string;
+  description: string;
+  tags?: string[];
+  body: string;
+}
+
+type Request = <T>(path: string, init?: JsonRequestInit) => Promise<T>;
+
+export function fetchIntents(request: Request): Promise<IntentsIndex> {
+  return request<IntentsIndex>("/api/intents");
+}
+
+export function runIntents(request: Request, sessionId?: string): Promise<RunKickoff> {
+  return request<RunKickoff>("/api/intents/run", {
+    method: "POST",
+    body: sessionId ? { sessionId } : {},
+  });
+}
+
+export function fetchAnalysisSettings(request: Request): Promise<AnalysisSettingsResponse> {
+  return request<AnalysisSettingsResponse>("/api/analysis/settings");
+}
+
+export function saveAnalysisSettings(
+  request: Request,
+  analysis: AnalysisSettings,
+): Promise<AnalysisSettingsResponse> {
+  return request<AnalysisSettingsResponse>("/api/analysis/settings", {
+    method: "PUT",
+    body: { analysis },
+  });
+}
+
+export function offerSkill(request: Request, intent: string): Promise<{ draft: SkillDraft }> {
+  return request<{ draft: SkillDraft }>("/api/skills/offer", {
+    method: "POST",
+    body: { intent },
+  });
+}
+
+export function deleteIntent(request: Request, content: string): Promise<unknown> {
+  return request("/api/intents/delete", { method: "POST", body: { content } });
+}
+
+export function clearIntents(request: Request): Promise<unknown> {
+  return request("/api/intents/clear", { method: "POST", body: {} });
+}
+
+/** Short, human label for a coverage verdict. */
+export function coverageLabel(coverage: IntentCoverage): string {
+  return coverage.status === "covered"
+    ? `Covered by ${coverage.skills.map((s) => s.skillId).join(", ")}`
+    : "No matching skill";
+}

--- a/packages/ui/src/lib/intents.ts
+++ b/packages/ui/src/lib/intents.ts
@@ -15,7 +15,7 @@ export interface IntentRecord {
   lastSeen: string;
   /** Server-computed ranking score (frequency + recency). Higher = suggest first. */
   score?: number;
-  /** Evidence spans/turns that support this intent — the "proof". */
+  /** Evidence spans/turns that support this intent - the "proof". */
   evidences?: string[];
 }
 
@@ -305,16 +305,16 @@ export function skillGenModelOptions(provider: SkillGenProvider): ModelOption[] 
   if (provider === "claude-cli") {
     return [
       ...base,
-      { value: "haiku", label: "Haiku — fastest" },
-      { value: "sonnet", label: "Sonnet — balanced" },
-      { value: "opus", label: "Opus — most capable" },
+      { value: "haiku", label: "Haiku - fastest" },
+      { value: "sonnet", label: "Sonnet - balanced" },
+      { value: "opus", label: "Opus - most capable" },
     ];
   }
   return [
     ...base,
-    { value: "claude-haiku-4-5-20251001", label: "Haiku 4.5 — fastest" },
-    { value: "claude-sonnet-4-6", label: "Sonnet 4.6 — balanced (default)" },
-    { value: "claude-opus-4-8", label: "Opus 4.8 — most capable" },
+    { value: "claude-haiku-4-5-20251001", label: "Haiku 4.5 - fastest" },
+    { value: "claude-sonnet-4-6", label: "Sonnet 4.6 - balanced (default)" },
+    { value: "claude-opus-4-8", label: "Opus 4.8 - most capable" },
   ];
 }
 

--- a/packages/ui/src/lib/skills.ts
+++ b/packages/ui/src/lib/skills.ts
@@ -39,7 +39,7 @@ export function fetchSkills(
 /**
  * Map an Agent Setup host kind to the skill `source` used by `/api/skills`.
  * The agent pages speak in host kinds ("claude-code"), while skills are tagged
- * with the shorter agent source ("claude") — this is the one bit of glue.
+ * with the shorter agent source ("claude") - this is the one bit of glue.
  */
 export function agentKindToSkillSource(kind: AgentHostKind): SkillSource {
   return kind === "codex" ? "codex" : "claude";

--- a/packages/ui/src/pages/ChatDetailPage.tsx
+++ b/packages/ui/src/pages/ChatDetailPage.tsx
@@ -1,0 +1,268 @@
+import { useNavigate } from "@tanstack/react-router";
+import { ArrowLeft, ChevronUp, Loader2 } from "lucide-react";
+import { useCallback, useEffect, useState } from "react";
+import { useRatelApp } from "@/App";
+import { Markdown } from "@/components/markdown";
+import {
+  PageHeader,
+  PageHeaderActions,
+  PageHeaderBackRow,
+  PageHeaderContent,
+  PageHeaderDescription,
+  PageHeaderSidebarTrigger,
+  PageHeaderTitle,
+} from "@/components/page-header";
+import { Button } from "@/components/ui/button";
+import { type ChatDetail, type ChatTurn, fetchChat } from "@/lib/intents";
+import { cn } from "@/lib/utils";
+
+/** Turns loaded on first open. */
+const INITIAL_LIMIT = 40;
+/** How many additional turns each "Load earlier" click reveals. */
+const LOAD_STEP = 60;
+
+type LoadState =
+  | { status: "loading" }
+  | { status: "error"; message: string }
+  | { status: "ready"; data: ChatDetail };
+
+/** A run of consecutive turns that all share the same role. */
+interface TurnGroup {
+  role: ChatTurn["role"];
+  turns: ChatTurn[];
+}
+
+/**
+ * Collapse consecutive same-role turns into a single group so a long assistant
+ * monologue renders as one block instead of a card per message. A role change
+ * starts a new group.
+ */
+function groupTurns(turns: ChatTurn[]): TurnGroup[] {
+  const groups: TurnGroup[] = [];
+  for (const turn of turns) {
+    const last = groups[groups.length - 1];
+    if (last && last.role === turn.role) {
+      // Build a new group object rather than mutating the existing one.
+      groups[groups.length - 1] = { role: last.role, turns: [...last.turns, turn] };
+    } else {
+      groups.push({ role: turn.role, turns: [turn] });
+    }
+  }
+  return groups;
+}
+
+export function ChatDetailPage(props: { sessionId: string }) {
+  const navigate = useNavigate();
+  const { request, token } = useRatelApp();
+  const [state, setState] = useState<LoadState>({ status: "loading" });
+  const [limit, setLimit] = useState(INITIAL_LIMIT);
+  // Distinct from the full-page "loading" status so the transcript stays
+  // visible while older turns are fetched in the background.
+  const [loadingEarlier, setLoadingEarlier] = useState(false);
+
+  const backPath = token ? `/chats?t=${encodeURIComponent(token)}` : "/chats";
+  const goBack = () => {
+    void navigate({ to: backPath } as never);
+  };
+
+  const load = useCallback(
+    async (nextLimit: number, signal?: { cancelled: boolean }) => {
+      try {
+        const data = await fetchChat(request, props.sessionId, nextLimit);
+        if (!signal?.cancelled) setState({ status: "ready", data });
+      } catch (err) {
+        if (!signal?.cancelled) {
+          setState({
+            status: "error",
+            message: err instanceof Error ? err.message : "Failed to load conversation",
+          });
+        }
+      }
+    },
+    [request, props.sessionId],
+  );
+
+  // Initial load (and reload when the session changes). Cancel a superseded
+  // load so a stale response can't clobber a newer one.
+  useEffect(() => {
+    const signal = { cancelled: false };
+    setState({ status: "loading" });
+    setLimit(INITIAL_LIMIT);
+    void load(INITIAL_LIMIT, signal);
+    return () => {
+      signal.cancelled = true;
+    };
+  }, [load]);
+
+  const detail = state.status === "ready" ? state.data : null;
+
+  const loadEarlier = useCallback(async () => {
+    if (!detail) return;
+    const nextLimit = Math.min(limit + LOAD_STEP, detail.total);
+    setLimit(nextLimit);
+    setLoadingEarlier(true);
+    await load(nextLimit);
+    setLoadingEarlier(false);
+  }, [detail, limit, load]);
+
+  const retry = () => {
+    setState({ status: "loading" });
+    void load(limit);
+  };
+
+  const hasMore = detail ? detail.turns.length < detail.total : false;
+  const olderCount = detail ? detail.total - detail.turns.length : 0;
+  const groups = detail ? groupTurns(detail.turns) : [];
+
+  return (
+    <main className="grid w-full gap-5 px-4 py-5 sm:px-6">
+      <PageHeader className="sm:grid-cols-[minmax(0,1fr)_auto] sm:items-start">
+        <PageHeaderContent>
+          <PageHeaderBackRow>
+            <Button onClick={goBack} size="sm" type="button" variant="ghost">
+              <ArrowLeft />
+              Chats
+            </Button>
+            <div className="flex items-center gap-1 sm:hidden">
+              <PageHeaderSidebarTrigger />
+            </div>
+          </PageHeaderBackRow>
+          <PageHeaderTitle className="mt-4 truncate text-2xl">
+            {detail?.title ?? props.sessionId}
+          </PageHeaderTitle>
+          <PageHeaderDescription className="mt-2 truncate">
+            {detail ? (
+              <>
+                {detail.host} · <span className="font-mono">{detail.sessionId}</span>
+                {detail.cwd ? ` · ${detail.cwd}` : ""}
+              </>
+            ) : (
+              props.sessionId
+            )}
+          </PageHeaderDescription>
+        </PageHeaderContent>
+        <PageHeaderActions className="hidden sm:flex">
+          <PageHeaderSidebarTrigger className="hidden sm:inline-flex" />
+        </PageHeaderActions>
+      </PageHeader>
+
+      {state.status === "loading" && (
+        <p className="px-1 text-muted-foreground text-sm">Loading conversation…</p>
+      )}
+
+      {state.status === "error" && (
+        <div className="grid gap-3">
+          <p className="text-destructive text-sm">{state.message}</p>
+          <div>
+            <Button onClick={retry} size="sm" variant="outline">
+              Retry
+            </Button>
+          </div>
+        </div>
+      )}
+
+      {detail && detail.turns.length === 0 && (
+        <p className="px-1 text-muted-foreground text-sm">No turns in this conversation.</p>
+      )}
+
+      {detail && detail.turns.length > 0 && (
+        <div className="grid max-w-3xl gap-4">
+          <p className="px-1 text-muted-foreground text-xs">
+            Showing last {detail.turns.length} of {detail.total} turn
+            {detail.total === 1 ? "" : "s"}
+          </p>
+
+          {hasMore && (
+            <div className="flex justify-center">
+              <Button
+                disabled={loadingEarlier}
+                onClick={() => void loadEarlier()}
+                size="sm"
+                type="button"
+                variant="outline"
+              >
+                {loadingEarlier ? <Loader2 className="animate-spin" /> : <ChevronUp />}
+                Load earlier ({olderCount} older)
+              </Button>
+            </div>
+          )}
+
+          <div className="grid gap-4">
+            {groups.map((group, index) => (
+              <TurnGroupBlock
+                group={group}
+                // Groups derive from an ordered, append-only transcript and
+                // never reorder, so the index is a safe, stable key.
+                // biome-ignore lint/suspicious/noArrayIndexKey: ordered, append-only transcript
+                key={index}
+              />
+            ))}
+          </div>
+        </div>
+      )}
+    </main>
+  );
+}
+
+function TurnGroupBlock(props: { group: TurnGroup }) {
+  const isUser = props.group.role === "user";
+  // Show the timestamp of the latest message in the group, if any.
+  const lastTs = [...props.group.turns].reverse().find((t) => t.ts)?.ts;
+
+  return (
+    <div
+      className={cn(
+        "rounded-md border bg-card",
+        isUser
+          ? "border-sky-500/30 border-l-2 border-l-sky-500 bg-sky-500/5 sm:ml-8"
+          : "border-border border-l-2 border-l-brand-green sm:mr-8",
+      )}
+    >
+      <div className="flex items-center gap-2 border-border/60 border-b px-3 py-2 text-xs">
+        <span
+          className={cn(
+            "inline-flex items-center gap-1.5 font-medium",
+            isUser ? "text-sky-600 dark:text-sky-400" : "text-brand-green",
+          )}
+        >
+          <span className={cn("size-1.5 rounded-full", isUser ? "bg-sky-500" : "bg-brand-green")} />
+          {isUser ? "User" : "Assistant"}
+        </span>
+        {props.group.turns.length > 1 && (
+          <span className="text-muted-foreground">{props.group.turns.length} messages</span>
+        )}
+        {lastTs && <span className="ml-auto text-muted-foreground">{relativeTime(lastTs)}</span>}
+      </div>
+      <div className="grid gap-3 p-3">
+        {props.group.turns.map((turn, index) => (
+          <div
+            className={cn(
+              // Separate stacked messages within a group with a hairline.
+              index > 0 && "border-border/40 border-t pt-3",
+            )}
+            // Stacked messages share the group's role and order; index is stable here.
+            // biome-ignore lint/suspicious/noArrayIndexKey: ordered, append-only transcript
+            key={index}
+          >
+            <Markdown>{turn.content || "_(empty)_"}</Markdown>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+/** "just now" / "5m ago" / "3h ago" / "2d ago" / a date for older timestamps. */
+function relativeTime(iso: string): string {
+  const then = new Date(iso).getTime();
+  if (Number.isNaN(then)) return iso;
+  const diffMs = Date.now() - then;
+  const minutes = Math.round(diffMs / 60000);
+  if (minutes < 1) return "just now";
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.round(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.round(hours / 24);
+  if (days < 7) return `${days}d ago`;
+  return new Date(then).toLocaleDateString();
+}

--- a/packages/ui/src/pages/ChatDetailPage.tsx
+++ b/packages/ui/src/pages/ChatDetailPage.tsx
@@ -1,6 +1,6 @@
 import { useNavigate } from "@tanstack/react-router";
 import { ArrowLeft, ChevronUp, Loader2 } from "lucide-react";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useRatelApp } from "@/App";
 import { Markdown } from "@/components/markdown";
 import {
@@ -60,6 +60,11 @@ export function ChatDetailPage(props: { sessionId: string }) {
   // visible while older turns are fetched in the background.
   const [loadingEarlier, setLoadingEarlier] = useState(false);
 
+  // The scrollable transcript area; we pin it to the newest message on first
+  // load (like a messaging app) but never fight the user's manual scrolling.
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const pinnedSessionRef = useRef<string | null>(null);
+
   const backPath = token ? `/chats?t=${encodeURIComponent(token)}` : "/chats";
   const goBack = () => {
     void navigate({ to: backPath } as never);
@@ -96,6 +101,18 @@ export function ChatDetailPage(props: { sessionId: string }) {
 
   const detail = state.status === "ready" ? state.data : null;
 
+  // On the first ready render for a session, jump to the newest message (bottom).
+  // We pin per-session so "Load earlier" (which prepends) and manual scrolling are
+  // left alone; switching sessions re-pins to the bottom.
+  useEffect(() => {
+    if (state.status !== "ready") return;
+    if (pinnedSessionRef.current === props.sessionId) return;
+    const el = scrollRef.current;
+    if (!el) return;
+    el.scrollTop = el.scrollHeight;
+    pinnedSessionRef.current = props.sessionId;
+  }, [state.status, props.sessionId]);
+
   const loadEarlier = useCallback(async () => {
     if (!detail) return;
     const nextLimit = Math.min(limit + LOAD_STEP, detail.total);
@@ -115,43 +132,47 @@ export function ChatDetailPage(props: { sessionId: string }) {
   const groups = detail ? groupTurns(detail.turns) : [];
 
   return (
-    <main className="grid w-full gap-5 px-4 py-5 sm:px-6">
-      <PageHeader className="sm:grid-cols-[minmax(0,1fr)_auto] sm:items-start">
-        <PageHeaderContent>
-          <PageHeaderBackRow>
-            <Button onClick={goBack} size="sm" type="button" variant="ghost">
-              <ArrowLeft />
-              Chats
-            </Button>
-            <div className="flex items-center gap-1 sm:hidden">
-              <PageHeaderSidebarTrigger />
-            </div>
-          </PageHeaderBackRow>
-          <PageHeaderTitle className="mt-4 truncate text-2xl">
-            {detail?.title ?? props.sessionId}
-          </PageHeaderTitle>
-          <PageHeaderDescription className="mt-2 truncate">
-            {detail ? (
-              <>
-                {detail.host} · <span className="font-mono">{detail.sessionId}</span>
-                {detail.cwd ? ` · ${detail.cwd}` : ""}
-              </>
-            ) : (
-              props.sessionId
-            )}
-          </PageHeaderDescription>
-        </PageHeaderContent>
-        <PageHeaderActions className="hidden sm:flex">
-          <PageHeaderSidebarTrigger className="hidden sm:inline-flex" />
-        </PageHeaderActions>
-      </PageHeader>
+    // Fill the sidebar inset exactly so the transcript scrolls on its own (bottom
+    // pinned), instead of growing the whole page like a document.
+    <div className="absolute inset-0 flex flex-col">
+      <div className="shrink-0 px-4 pt-5 sm:px-6">
+        <PageHeader className="sm:grid-cols-[minmax(0,1fr)_auto] sm:items-start">
+          <PageHeaderContent>
+            <PageHeaderBackRow>
+              <Button onClick={goBack} size="sm" type="button" variant="ghost">
+                <ArrowLeft />
+                Chats
+              </Button>
+              <div className="flex items-center gap-1 sm:hidden">
+                <PageHeaderSidebarTrigger />
+              </div>
+            </PageHeaderBackRow>
+            <PageHeaderTitle className="mt-4 truncate text-2xl">
+              {detail?.title ?? props.sessionId}
+            </PageHeaderTitle>
+            <PageHeaderDescription className="mt-2 truncate">
+              {detail ? (
+                <>
+                  {detail.host} · <span className="font-mono">{detail.sessionId}</span>
+                  {detail.cwd ? ` · ${detail.cwd}` : ""}
+                </>
+              ) : (
+                props.sessionId
+              )}
+            </PageHeaderDescription>
+          </PageHeaderContent>
+          <PageHeaderActions className="hidden sm:flex">
+            <PageHeaderSidebarTrigger className="hidden sm:inline-flex" />
+          </PageHeaderActions>
+        </PageHeader>
+      </div>
 
       {state.status === "loading" && (
-        <p className="px-1 text-muted-foreground text-sm">Loading conversation…</p>
+        <p className="px-4 py-4 text-muted-foreground text-sm sm:px-6">Loading conversation…</p>
       )}
 
       {state.status === "error" && (
-        <div className="grid gap-3">
+        <div className="grid gap-3 px-4 py-4 sm:px-6">
           <p className="text-destructive text-sm">{state.message}</p>
           <div>
             <Button onClick={retry} size="sm" variant="outline">
@@ -162,32 +183,33 @@ export function ChatDetailPage(props: { sessionId: string }) {
       )}
 
       {detail && detail.turns.length === 0 && (
-        <p className="px-1 text-muted-foreground text-sm">No turns in this conversation.</p>
+        <p className="px-4 py-4 text-muted-foreground text-sm sm:px-6">
+          No turns in this conversation.
+        </p>
       )}
 
       {detail && detail.turns.length > 0 && (
-        <div className="grid max-w-3xl gap-4">
-          <p className="px-1 text-muted-foreground text-xs">
-            Showing last {detail.turns.length} of {detail.total} turn
-            {detail.total === 1 ? "" : "s"}
-          </p>
+        <div ref={scrollRef} className="min-h-0 flex-1 overflow-y-auto px-4 pb-6 sm:px-6">
+          <div className="flex w-full flex-col gap-4 pt-2">
+            {hasMore ? (
+              <div className="flex justify-center">
+                <Button
+                  disabled={loadingEarlier}
+                  onClick={() => void loadEarlier()}
+                  size="sm"
+                  type="button"
+                  variant="outline"
+                >
+                  {loadingEarlier ? <Loader2 className="animate-spin" /> : <ChevronUp />}
+                  Load earlier ({olderCount} older)
+                </Button>
+              </div>
+            ) : (
+              <p className="text-center text-muted-foreground text-xs">
+                Start of conversation · {detail.total} turn{detail.total === 1 ? "" : "s"}
+              </p>
+            )}
 
-          {hasMore && (
-            <div className="flex justify-center">
-              <Button
-                disabled={loadingEarlier}
-                onClick={() => void loadEarlier()}
-                size="sm"
-                type="button"
-                variant="outline"
-              >
-                {loadingEarlier ? <Loader2 className="animate-spin" /> : <ChevronUp />}
-                Load earlier ({olderCount} older)
-              </Button>
-            </div>
-          )}
-
-          <div className="grid gap-4">
             {groups.map((group, index) => (
               <TurnGroupBlock
                 group={group}
@@ -200,7 +222,7 @@ export function ChatDetailPage(props: { sessionId: string }) {
           </div>
         </div>
       )}
-    </main>
+    </div>
   );
 }
 

--- a/packages/ui/src/pages/ChatsPage.tsx
+++ b/packages/ui/src/pages/ChatsPage.tsx
@@ -1,0 +1,405 @@
+import { useNavigate } from "@tanstack/react-router";
+import { MessagesSquare, RefreshCw, SearchIcon, Sparkles, Trash2 } from "lucide-react";
+import { type ReactNode, useCallback, useEffect, useState } from "react";
+import { chatPath, useRatelApp } from "@/App";
+import {
+  PageHeader,
+  PageHeaderActions,
+  PageHeaderBackRow,
+  PageHeaderContent,
+  PageHeaderDescription,
+  PageHeaderSidebarTrigger,
+  PageHeaderTitle,
+} from "@/components/page-header";
+import { ResponsiveToolbar, ResponsiveToolbarButton } from "@/components/responsive-toolbar";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { PrismSweep } from "@/components/ui/prism-sweep";
+import { type ChatSummary, deleteChat, fetchChats, fetchIntents, runIntents } from "@/lib/intents";
+
+type LoadState =
+  | { status: "loading" }
+  | { status: "error"; message: string }
+  | { status: "ready"; chats: ChatSummary[] };
+
+export function ChatsPage() {
+  const { request, openCommandMenu } = useRatelApp();
+  const [state, setState] = useState<LoadState>({ status: "loading" });
+  // Run status from the server, so a per-chat "Analyzing…" indicator survives
+  // navigating away and back (the flag lives on the server, not in the button).
+  const [run, setRun] = useState<{
+    running: boolean;
+    sessionId: string | null;
+    queued: string[];
+  }>({
+    running: false,
+    sessionId: null,
+    queued: [],
+  });
+
+  const load = useCallback(async () => {
+    setState({ status: "loading" });
+    try {
+      const { chats } = await fetchChats(request);
+      setState({ status: "ready", chats });
+    } catch (err) {
+      setState({
+        status: "error",
+        message: err instanceof Error ? err.message : "Failed to load chats",
+      });
+    }
+  }, [request]);
+
+  // void-returning wrapper for child `onReload` props.
+  const reload = useCallback(async () => {
+    await load();
+  }, [load]);
+
+  // Refetch without the full-page "Loading…" flip, for the auto-refresh + button.
+  const quietRefresh = useCallback(async () => {
+    try {
+      const { chats } = await fetchChats(request);
+      setState({ status: "ready", chats });
+    } catch {
+      // keep whatever's on screen; the next refresh may succeed
+    }
+  }, [request]);
+
+  // New conversations are captured by the plugin as you use your agent; pick them
+  // up automatically so the list stays current without a manual reload.
+  useEffect(() => {
+    const id = window.setInterval(() => void quietRefresh(), 15000);
+    return () => window.clearInterval(id);
+  }, [quietRefresh]);
+
+  const refreshRun = useCallback(async () => {
+    try {
+      const data = await fetchIntents(request);
+      const queued = data.queuedSessionIds ?? [];
+      setRun({
+        running: data.running ?? false,
+        sessionId: data.runningSessionId ?? null,
+        queued,
+      });
+      // Keep polling while anything is still running OR waiting in the queue.
+      return (data.running ?? false) || queued.length > 0;
+    } catch {
+      return false;
+    }
+  }, [request]);
+
+  useEffect(() => {
+    void load();
+    void refreshRun();
+  }, [load, refreshRun]);
+
+  // While a run is in flight, poll its status; when it finishes, refresh the list
+  // so the analyzed chat's intent count updates.
+  const active = run.running || run.queued.length > 0;
+  useEffect(() => {
+    if (!active) return;
+    let cancelled = false;
+    const id = window.setInterval(async () => {
+      const stillActive = await refreshRun();
+      if (!cancelled && !stillActive) await load();
+    }, 1500);
+    return () => {
+      cancelled = true;
+      window.clearInterval(id);
+    };
+  }, [active, refreshRun, load]);
+
+  const chats = state.status === "ready" ? state.chats : [];
+
+  return (
+    <main className="flex w-full flex-1 flex-col gap-4 px-4 py-5 sm:px-6">
+      <PageHeader className="sm:grid-cols-[minmax(0,1fr)_auto] sm:items-start">
+        <PageHeaderContent>
+          <PageHeaderBackRow>
+            <PageHeaderTitle>Chats</PageHeaderTitle>
+            <div className="flex items-center gap-1 sm:hidden">
+              <Button
+                aria-label="Search"
+                onClick={openCommandMenu}
+                size="icon-lg"
+                type="button"
+                variant="outline"
+              >
+                <SearchIcon />
+                <span className="sr-only">Search</span>
+              </Button>
+              <PageHeaderSidebarTrigger />
+            </div>
+          </PageHeaderBackRow>
+          <PageHeaderDescription>
+            Recent conversations captured by the Ratel plugin. Open one to read its turns, or remove
+            chats you no longer want analyzed — chats with no extracted intents are safe to clear.
+          </PageHeaderDescription>
+        </PageHeaderContent>
+        <PageHeaderActions className="hidden items-center sm:flex">
+          <Button className="h-10" onClick={() => void quietRefresh()} size="sm" variant="outline">
+            <RefreshCw />
+            Refresh
+          </Button>
+          <ResponsiveToolbar>
+            <ResponsiveToolbarButton
+              icon={<SearchIcon />}
+              kbd="⌘K"
+              label="Search"
+              onClick={openCommandMenu}
+            />
+          </ResponsiveToolbar>
+          <PageHeaderSidebarTrigger className="hidden sm:inline-flex" />
+        </PageHeaderActions>
+      </PageHeader>
+
+      {state.status === "loading" && (
+        <p className="px-1 text-muted-foreground text-sm">Loading chats…</p>
+      )}
+
+      {state.status === "error" && (
+        <EmptyState title="Couldn't load chats" description={state.message}>
+          <Button onClick={() => void load()} size="sm" variant="outline">
+            Retry
+          </Button>
+        </EmptyState>
+      )}
+
+      {state.status === "ready" && chats.length === 0 && (
+        <EmptyState
+          title="No captured chats yet."
+          description="Once the Ratel plugin captures some chat from your agent, conversations show up here. Make sure the plugin hooks are trusted in your agent."
+        />
+      )}
+
+      {state.status === "ready" && chats.length > 0 && (
+        <>
+          <span className="px-1 text-muted-foreground text-xs">
+            {chats.length} chat{chats.length === 1 ? "" : "s"}
+          </span>
+          <ul className="grid gap-2">
+            {chats.map((chat) => (
+              <ChatRow
+                chat={chat}
+                key={chat.sessionId}
+                onKicked={refreshRun}
+                onReload={reload}
+                processing={run.running && run.sessionId === chat.sessionId}
+                queued={run.queued.includes(chat.sessionId)}
+              />
+            ))}
+          </ul>
+        </>
+      )}
+    </main>
+  );
+}
+
+function ChatRow(props: {
+  chat: ChatSummary;
+  processing: boolean;
+  queued: boolean;
+  onKicked: () => Promise<boolean>;
+  onReload: () => Promise<void>;
+}) {
+  const { chat } = props;
+  const navigate = useNavigate();
+  const { token } = useRatelApp();
+  const safeToRemove = chat.intentCount === 0;
+  return (
+    <li className="flex items-start gap-3 rounded-md border border-border bg-card p-3">
+      <MessagesSquare className="mt-0.5 size-4 shrink-0 text-muted-foreground/50" />
+      <div className="min-w-0 flex-1">
+        <button
+          className="block max-w-full truncate text-left font-medium hover:underline"
+          onClick={() => void navigate({ to: chatPath(chat.sessionId, token) } as never)}
+          type="button"
+        >
+          {chat.title}
+        </button>
+        <p className="mt-0.5 truncate text-muted-foreground text-xs">
+          {chat.host} · {chat.sessionId}
+          {chat.cwd ? ` · ${chat.cwd}` : ""}
+        </p>
+        <div className="mt-1.5 flex flex-wrap items-center gap-x-2 gap-y-1 text-muted-foreground text-xs">
+          <span>
+            {chat.turnCount} turn{chat.turnCount === 1 ? "" : "s"}
+          </span>
+          <span aria-hidden>·</span>
+          <span>
+            {chat.intentCount} intent{chat.intentCount === 1 ? "" : "s"} / {chat.gapCount} gap
+            {chat.gapCount === 1 ? "" : "s"}
+          </span>
+          <span aria-hidden>·</span>
+          <AnalyzedBadge analyzed={chat.analyzed} />
+          {chat.idle && (
+            <>
+              <span aria-hidden>·</span>
+              <span>idle</span>
+            </>
+          )}
+          {chat.updatedAt && (
+            <>
+              <span aria-hidden>·</span>
+              <span>updated {relativeTime(chat.updatedAt)}</span>
+            </>
+          )}
+        </div>
+      </div>
+      <div className="flex shrink-0 items-center gap-1.5">
+        <AnalyzeChatButton
+          onKicked={props.onKicked}
+          processing={props.processing}
+          queued={props.queued}
+          sessionId={chat.sessionId}
+        />
+        <DeleteChatButton
+          onDeleted={props.onReload}
+          safeToRemove={safeToRemove}
+          sessionId={chat.sessionId}
+          title={chat.title}
+        />
+      </div>
+    </li>
+  );
+}
+
+/**
+ * Force-analyze just this chat (bypasses the cadence/recency due-checks). The
+ * "Analyzing…" state is driven by the server's run status (`processing`), so it
+ * persists across navigation — leaving and returning to Chats still shows it.
+ */
+function AnalyzeChatButton(props: {
+  sessionId: string;
+  processing: boolean;
+  queued: boolean;
+  onKicked: () => Promise<boolean>;
+}) {
+  const { request, runAction } = useRatelApp();
+
+  const onClick = async () => {
+    await runAction("Queued for analysis…", () => runIntents(request, props.sessionId));
+    // Pick up the server's run status so the indicator (and polling) start now.
+    await props.onKicked();
+  };
+
+  if (props.processing) {
+    return (
+      <div className="flex items-center gap-2 px-2 text-muted-foreground text-xs">
+        <PrismSweep dotSize={3} size={20} speed={1.3} />
+        Analyzing…
+      </div>
+    );
+  }
+  if (props.queued) {
+    return <span className="px-2 text-muted-foreground text-xs">Queued…</span>;
+  }
+  return (
+    <Button
+      aria-label="Analyze intents for this chat"
+      onClick={() => void onClick()}
+      size="sm"
+      variant="outline"
+    >
+      <Sparkles />
+      Analyze intents
+    </Button>
+  );
+}
+
+function AnalyzedBadge(props: { analyzed: boolean }) {
+  if (props.analyzed) {
+    return (
+      <span className="inline-flex items-center gap-1.5">
+        <span className="size-1.5 rounded-full bg-emerald-500/70" />
+        Analyzed
+      </span>
+    );
+  }
+  return (
+    <span className="inline-flex items-center gap-1.5">
+      <span className="size-1.5 rounded-full bg-muted-foreground/40" />
+      Not analyzed
+    </span>
+  );
+}
+
+function DeleteChatButton(props: {
+  sessionId: string;
+  title: string;
+  safeToRemove: boolean;
+  onDeleted: () => Promise<void>;
+}) {
+  const { request, runAction, busy } = useRatelApp();
+  const [open, setOpen] = useState(false);
+  const remove = async () => {
+    const ok = await runAction("Deleted chat", () => deleteChat(request, props.sessionId));
+    if (ok) {
+      setOpen(false);
+      await props.onDeleted();
+    }
+  };
+  return (
+    <Dialog onOpenChange={setOpen} open={open}>
+      <DialogTrigger render={<Button aria-label="Delete chat" size="icon-sm" variant="ghost" />}>
+        <Trash2 />
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Delete this chat?</DialogTitle>
+          <DialogDescription>
+            Removes the captured conversation “{props.title}”. This can't be undone.
+            {props.safeToRemove ? " No intents were extracted from it — safe to remove." : ""}
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <DialogClose render={<Button size="sm" variant="outline" />}>Cancel</DialogClose>
+          <Button disabled={busy} onClick={() => void remove()} size="sm" variant="destructive">
+            Delete
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function EmptyState(props: { title: string; description: string; children?: ReactNode }) {
+  return (
+    <section className="-mx-4 grid min-h-72 flex-1 place-items-center border-border border-y bg-muted/15 px-4 py-8 text-center sm:-mx-6 sm:px-6">
+      <div className="grid max-w-md gap-3">
+        <div className="mx-auto rounded-md bg-muted p-2 text-brand-green">
+          <MessagesSquare className="size-5" />
+        </div>
+        <div>
+          <h3 className="font-medium">{props.title}</h3>
+          <p className="mt-1 text-muted-foreground text-sm">{props.description}</p>
+        </div>
+        {props.children && <div>{props.children}</div>}
+      </div>
+    </section>
+  );
+}
+
+/** "just now" / "5m ago" / "3h ago" / "2d ago" / a date for older timestamps. */
+function relativeTime(iso: string): string {
+  const then = new Date(iso).getTime();
+  if (Number.isNaN(then)) return iso;
+  const diffMs = Date.now() - then;
+  const minutes = Math.round(diffMs / 60000);
+  if (minutes < 1) return "just now";
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.round(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.round(hours / 24);
+  if (days < 7) return `${days}d ago`;
+  return new Date(then).toLocaleDateString();
+}

--- a/packages/ui/src/pages/ChatsPage.tsx
+++ b/packages/ui/src/pages/ChatsPage.tsx
@@ -142,7 +142,7 @@ export function ChatsPage() {
           </PageHeaderBackRow>
           <PageHeaderDescription>
             Recent conversations captured by the Ratel plugin. Open one to read its turns, or remove
-            chats you no longer want analyzed — chats with no extracted intents are safe to clear.
+            chats you no longer want analyzed - chats with no extracted intents are safe to clear.
           </PageHeaderDescription>
         </PageHeaderContent>
         <PageHeaderActions className="hidden items-center sm:flex">
@@ -276,7 +276,7 @@ function ChatRow(props: {
 /**
  * Force-analyze just this chat (bypasses the cadence/recency due-checks). The
  * "Analyzing…" state is driven by the server's run status (`processing`), so it
- * persists across navigation — leaving and returning to Chats still shows it.
+ * persists across navigation - leaving and returning to Chats still shows it.
  */
 function AnalyzeChatButton(props: {
   sessionId: string;
@@ -358,7 +358,7 @@ function DeleteChatButton(props: {
           <DialogTitle>Delete this chat?</DialogTitle>
           <DialogDescription>
             Removes the captured conversation “{props.title}”. This can't be undone.
-            {props.safeToRemove ? " No intents were extracted from it — safe to remove." : ""}
+            {props.safeToRemove ? " No intents were extracted from it - safe to remove." : ""}
           </DialogDescription>
         </DialogHeader>
         <DialogFooter>

--- a/packages/ui/src/pages/IntentsPage.tsx
+++ b/packages/ui/src/pages/IntentsPage.tsx
@@ -1,7 +1,19 @@
 import { useNavigate } from "@tanstack/react-router";
-import { Cog, Play, SearchIcon, Sparkles, Target, Trash2 } from "lucide-react";
-import { type ReactNode, useCallback, useEffect, useState } from "react";
-import { skillPath, useRatelApp } from "@/App";
+import {
+  Activity,
+  ChevronDown,
+  ChevronRight,
+  Cog,
+  MessagesSquare,
+  Play,
+  RefreshCw,
+  SearchIcon,
+  Sparkles,
+  Target,
+  Trash2,
+} from "lucide-react";
+import { type ReactNode, useCallback, useEffect, useRef, useState } from "react";
+import { chatPath, skillPath, useRatelApp } from "@/App";
 import { Markdown } from "@/components/markdown";
 import {
   PageHeader,
@@ -44,30 +56,46 @@ import {
   type AnalysisSettings,
   type Cadence,
   clearIntents,
+  clearOfferJob,
   deleteIntent,
+  estimateGenMs,
   fetchAnalysisSettings,
+  fetchChats,
   fetchIntents,
   type IntentRecord,
   type IntentsIndex,
+  listOfferJobs,
+  type OfferJobSummary,
   offerSkill,
+  offerSkillStatus,
+  runAllIntents,
   runIntents,
   type SessionSummary,
   type SkillDraft,
   saveAnalysisSettings,
+  skillGenModelOptions,
 } from "@/lib/intents";
+import { ObservabilityPanel } from "@/pages/ObservabilityPage";
 
 type LoadState =
   | { status: "loading" }
   | { status: "error"; message: string }
   | { status: "ready"; data: IntentsIndex };
 
-type View = "cumulative" | "by-session";
+type View = "cumulative" | "by-session" | "observability";
+
+/** sessionId → its chat title/host, for the "seen in N sessions" links. */
+type SessionTitles = Record<string, { title: string; host?: string }>;
+/** intent content → its live authoring job, so a result survives navigation. */
+type OfferJobs = Record<string, OfferJobSummary>;
 
 export function IntentsPage() {
   const { request, runAction, busy, openCommandMenu } = useRatelApp();
   const [state, setState] = useState<LoadState>({ status: "loading" });
   const [view, setView] = useState<View>("cumulative");
   const [running, setRunning] = useState(false);
+  const [sessionTitles, setSessionTitles] = useState<SessionTitles>({});
+  const [offerJobs, setOfferJobs] = useState<OfferJobs>({});
 
   const load = useCallback(async () => {
     try {
@@ -83,48 +111,81 @@ export function IntentsPage() {
     }
   }, [request]);
 
+  // Side data: chat titles (for the "seen in N sessions" links) and any in-flight
+  // or finished authoring jobs (so a result stays reachable after navigating away).
+  const loadAux = useCallback(async () => {
+    try {
+      const [{ chats }, { jobs }] = await Promise.all([
+        fetchChats(request),
+        listOfferJobs(request),
+      ]);
+      const titles: SessionTitles = {};
+      for (const c of chats) titles[c.sessionId] = { title: c.title, host: c.host };
+      setSessionTitles(titles);
+      const byIntent: OfferJobs = {};
+      for (const j of jobs) byIntent[j.intent] = j;
+      setOfferJobs(byIntent);
+    } catch {
+      // Non-fatal: the page still works without titles/job hydration.
+    }
+  }, [request]);
+
   // void-returning wrapper for child `onReload`/`onCleared` props.
   const reload = useCallback(async () => {
-    await load();
-  }, [load]);
+    await Promise.all([load(), loadAux()]);
+  }, [load, loadAux]);
 
   useEffect(() => {
     void load();
-  }, [load]);
-
-  // The run is fire-and-forget on the server; poll while it reports `running` so
-  // results stream in and the banner clears itself when the run finishes.
-  useEffect(() => {
-    if (!running) return;
-    let cancelled = false;
-    const tick = async () => {
-      const data = await load();
-      if (!cancelled && data && !data.running) setRunning(false);
-    };
-    const id = window.setInterval(() => void tick(), 2000);
-    return () => {
-      cancelled = true;
-      window.clearInterval(id);
-    };
-  }, [running, load]);
-
-  const runNow = useCallback(async () => {
-    // Show the banner immediately so there's feedback even if the backend runs
-    // synchronously (e.g. a stale dev server that hasn't picked up fire-and-forget).
-    setRunning(true);
-    const ok = await runAction("Analysis started", () => runIntents(request));
-    const data = await load();
-    // Keep the banner only while the server reports an in-flight run; the polling
-    // effect clears it when that finishes. Otherwise (error, or a synchronous
-    // backend with no `running` flag) clear it now — the results are already in.
-    if (!ok || !data?.running) setRunning(false);
-  }, [runAction, request, load]);
+    void loadAux();
+  }, [load, loadAux]);
 
   const ready = state.status === "ready" ? state.data : null;
   const intents = ready?.intents ?? [];
   const sessions = ready?.sessions ?? [];
   const cadence = ready?.cadence;
   const analysisOff = ready?.enabled === false;
+  // A run may be in flight even if this client didn't start it (per-chat analyze,
+  // the cadence scheduler, another tab). Reflect the server's flag too.
+  const serverRunning = ready?.running === true;
+  const showRunning = running || serverRunning;
+
+  // The run is fire-and-forget on the server; poll while it (or any other trigger)
+  // reports `running` so results stream in and the banner clears itself.
+  useEffect(() => {
+    if (!running && !serverRunning) return;
+    let cancelled = false;
+    const tick = async () => {
+      const data = await load();
+      if (cancelled) return;
+      // A failed poll returns null (e.g. an expired token after the server
+      // restarted). Stop the spinner so the error state surfaces with a Retry,
+      // rather than hanging on "Analyzing…" forever with no feedback.
+      if (!data?.running) setRunning(false);
+    };
+    const id = window.setInterval(() => void tick(), 2000);
+    return () => {
+      cancelled = true;
+      window.clearInterval(id);
+    };
+  }, [running, serverRunning, load]);
+
+  const runNow = useCallback(
+    async (all = false) => {
+      // Show the banner immediately so there's feedback even if the backend runs
+      // synchronously (e.g. a stale dev server that hasn't picked up fire-and-forget).
+      setRunning(true);
+      const ok = await runAction(all ? "Re-analyzing all chats" : "Analysis started", () =>
+        all ? runAllIntents(request) : runIntents(request),
+      );
+      const data = await load();
+      // Keep the banner only while the server reports an in-flight run; the polling
+      // effect clears it when that finishes. Otherwise (error, or a synchronous
+      // backend with no `running` flag) clear it now — the results are already in.
+      if (!ok || !data?.running) setRunning(false);
+    },
+    [runAction, request, load],
+  );
 
   return (
     <main className="flex w-full flex-1 flex-col gap-4 px-4 py-5 sm:px-6">
@@ -156,12 +217,24 @@ export function IntentsPage() {
           <AnalysisSettingsDialog />
           <Button
             className="h-10"
-            disabled={busy || running || analysisOff}
+            disabled={busy || showRunning || analysisOff}
+            onClick={() => void runNow(true)}
+            size="sm"
+            title="Re-analyze every chat from scratch (ignores cache and the new-activity filter)"
+            variant="outline"
+          >
+            <RefreshCw />
+            Re-analyze all
+          </Button>
+          <Button
+            className="h-10"
+            disabled={busy || showRunning || analysisOff}
             onClick={() => void runNow()}
             size="sm"
+            title="Analyze chats with new activity since their last analysis"
           >
-            {running ? <Spinner /> : <Play />}
-            {running ? "Analyzing…" : "Run now"}
+            {showRunning ? <Spinner /> : <Play />}
+            {showRunning ? "Analyzing…" : "Run now"}
           </Button>
           <ResponsiveToolbar>
             <ResponsiveToolbarButton
@@ -194,58 +267,93 @@ export function IntentsPage() {
         </div>
       )}
 
-      {running && (
+      {/* While analyzing with results already on screen, a slim top banner keeps
+          context; the empty state gets the full-bleed version (below) instead. */}
+      {showRunning && intents.length > 0 && (
         <div className="flex items-center gap-2.5 rounded-md border border-border bg-muted/30 px-3 py-2 text-muted-foreground text-sm">
           <PrismSweep size={22} dotSize={3} speed={1.3} />
           Analyzing chat through the extractor… results appear as each session finishes.
         </div>
       )}
 
-      {!running && ready?.lastError && (
+      {!showRunning && ready?.lastError && (
         <div className="rounded-md border border-amber-300/60 bg-amber-50 px-3 py-2 text-amber-900 text-sm dark:border-amber-400/40 dark:bg-amber-500/15 dark:text-amber-200">
           Last analysis didn't finish: {ready.lastError}
         </div>
       )}
 
-      {ready && intents.length === 0 && (
-        <EmptyState
-          title="No intents yet"
-          description="Once the plugin captures some chat, run an analysis to extract what you've been trying to do. Make sure the Ratel plugin hooks are trusted in your agent."
-        >
-          <Button disabled={busy} onClick={() => void runNow()} size="sm">
-            <Play />
-            Run analysis
-          </Button>
-        </EmptyState>
-      )}
-
-      {ready && intents.length > 0 && (
+      {ready && (
         <>
-          <div className="flex items-center justify-between">
-            <Tabs onValueChange={(v) => setView(v as View)} value={view}>
-              <TabsList>
-                <TabsTrigger value="cumulative">Cumulative</TabsTrigger>
-                <TabsTrigger value="by-session">By session</TabsTrigger>
-              </TabsList>
-            </Tabs>
+          <div className="flex items-center justify-between gap-2">
             <div className="flex items-center gap-2">
-              <span className="px-1 text-muted-foreground text-xs">
-                {intents.length} intent{intents.length === 1 ? "" : "s"} ·{" "}
-                {intents.filter((i) => i.coverage.status === "gap").length} gaps
-                {cadence ? ` · due for analysis every ${cadence.everyNMessages} messages` : ""}
-              </span>
-              <ClearAllButton onCleared={reload} />
+              {/* The two intent views are a segmented control; "Run history" is a
+                  separate, visually distinct thing (analysis telemetry), set apart
+                  by a divider so it doesn't read as a third view of the same data. */}
+              <Tabs
+                onValueChange={(v) => setView(v as View)}
+                value={view === "observability" ? "" : view}
+              >
+                <TabsList>
+                  <TabsTrigger value="cumulative">Cumulative</TabsTrigger>
+                  <TabsTrigger value="by-session">By session</TabsTrigger>
+                </TabsList>
+              </Tabs>
+              <span aria-hidden className="mx-1 hidden h-5 w-px bg-border sm:block" />
+              <Button
+                className={
+                  view === "observability" ? "bg-accent text-foreground" : "text-muted-foreground"
+                }
+                onClick={() => setView(view === "observability" ? "cumulative" : "observability")}
+                size="sm"
+                variant="ghost"
+              >
+                <Activity />
+                Run history
+              </Button>
             </div>
+            {view !== "observability" && intents.length > 0 && (
+              <div className="flex items-center gap-2">
+                <span className="px-1 text-muted-foreground text-xs">
+                  {intents.length} intent{intents.length === 1 ? "" : "s"} ·{" "}
+                  {intents.filter((i) => i.coverage.status === "gap").length} gaps
+                  {cadence ? ` · due for analysis every ${cadence.everyNMessages} messages` : ""}
+                </span>
+                <ClearAllButton onCleared={reload} />
+              </div>
+            )}
           </div>
 
-          {view === "cumulative" ? (
-            <IntentList intents={intents} onReload={reload} />
+          {view === "observability" ? (
+            <ObservabilityPanel />
+          ) : intents.length === 0 ? (
+            showRunning ? (
+              <AnalyzingState />
+            ) : (
+              <EmptyState
+                title="No intents yet"
+                description="Once the plugin captures some chat, run an analysis to extract what you've been trying to do. Make sure the Ratel plugin hooks are trusted in your agent."
+              >
+                <Button disabled={busy} onClick={() => void runNow()} size="sm">
+                  <Play />
+                  Run analysis
+                </Button>
+              </EmptyState>
+            )
+          ) : view === "cumulative" ? (
+            <IntentList
+              intents={intents}
+              jobs={offerJobs}
+              onReload={reload}
+              sessionTitles={sessionTitles}
+            />
           ) : (
             <BySessionView
               cadence={cadence}
               intents={intents}
+              jobs={offerJobs}
               onReload={reload}
               sessions={sessions}
+              sessionTitles={sessionTitles}
             />
           )}
         </>
@@ -254,20 +362,31 @@ export function IntentsPage() {
   );
 }
 
+const SESSIONS_PAGE = 8;
+
 function BySessionView(props: {
   intents: IntentRecord[];
   sessions: SessionSummary[];
   cadence?: Cadence;
+  sessionTitles: SessionTitles;
+  jobs: OfferJobs;
   onReload: () => Promise<void>;
 }) {
-  if (props.sessions.length === 0) {
-    return <p className="px-1 text-muted-foreground text-sm">No analyzed sessions yet.</p>;
+  const [shown, setShown] = useState(SESSIONS_PAGE);
+  // Hide sessions that produced no intents (nothing to show) and sort newest first.
+  const sessions = [...props.sessions]
+    .filter((s) => s.intentCount > 0)
+    .sort((a, b) => b.analyzedAt.localeCompare(a.analyzedAt));
+  if (sessions.length === 0) {
+    return (
+      <p className="px-1 text-muted-foreground text-sm">No analyzed sessions with intents yet.</p>
+    );
   }
-  // Newest first by analysis time.
-  const sessions = [...props.sessions].sort((a, b) => b.analyzedAt.localeCompare(a.analyzedAt));
+  const visible = sessions.slice(0, shown);
+  const remaining = sessions.length - visible.length;
   return (
     <div className="grid gap-5">
-      {sessions.map((session) => {
+      {visible.map((session) => {
         const intents = props.intents.filter((i) => i.sessions.includes(session.sessionId));
         return (
           <section className="grid gap-2" key={session.sessionId}>
@@ -284,10 +403,22 @@ function BySessionView(props: {
                 {cadenceProgress(session, props.cadence)}
               </p>
             </div>
-            <IntentList intents={intents} onReload={props.onReload} />
+            <IntentList
+              intents={intents}
+              jobs={props.jobs}
+              onReload={props.onReload}
+              sessionTitles={props.sessionTitles}
+            />
           </section>
         );
       })}
+      {remaining > 0 && (
+        <div className="flex justify-center">
+          <Button onClick={() => setShown((n) => n + SESSIONS_PAGE)} size="sm" variant="outline">
+            Show more sessions ({remaining} more)
+          </Button>
+        </div>
+      )}
     </div>
   );
 }
@@ -301,37 +432,182 @@ function cadenceProgress(session: SessionSummary, cadence?: Cadence): string {
   return ` · ${newTurns}/${cadence.everyNMessages} new since last analysis (${tail})`;
 }
 
-function IntentList(props: { intents: IntentRecord[]; onReload: () => Promise<void> }) {
+const INTENTS_PAGE = 25;
+
+function IntentList(props: {
+  intents: IntentRecord[];
+  sessionTitles: SessionTitles;
+  jobs: OfferJobs;
+  onReload: () => Promise<void>;
+}) {
+  const [shown, setShown] = useState(INTENTS_PAGE);
+  const visible = props.intents.slice(0, shown);
+  const remaining = props.intents.length - visible.length;
   return (
-    <ul className="grid gap-2">
-      {props.intents.map((intent) => (
-        <IntentRow intent={intent} key={intent.content} onReload={props.onReload} />
-      ))}
-    </ul>
+    <div className="grid gap-2">
+      <ul className="grid gap-2">
+        {visible.map((intent) => (
+          <IntentRow
+            initialJob={props.jobs[intent.content]}
+            intent={intent}
+            key={intent.content}
+            onReload={props.onReload}
+            sessionTitles={props.sessionTitles}
+          />
+        ))}
+      </ul>
+      {remaining > 0 && (
+        <div className="flex justify-center pt-1">
+          <Button onClick={() => setShown((n) => n + INTENTS_PAGE)} size="sm" variant="outline">
+            Show more ({remaining} more)
+          </Button>
+        </div>
+      )}
+    </div>
   );
 }
 
-function IntentRow(props: { intent: IntentRecord; onReload: () => Promise<void> }) {
+function IntentRow(props: {
+  intent: IntentRecord;
+  sessionTitles: SessionTitles;
+  initialJob?: OfferJobSummary;
+  onReload: () => Promise<void>;
+}) {
   const { intent } = props;
+  const seen = intent.sessions.length;
   const isGap = intent.coverage.status === "gap";
+  // The server already ranks the list; a gap that recurs across several sessions
+  // is what we want users to act on first, so flag it as a top gap.
+  const topGap = isGap && seen >= 3;
+  // Emphasize frequency when an intent shows up across many sessions.
+  const frequent = seen >= 3;
   return (
     <li className="flex items-start gap-3 rounded-md border border-border bg-card p-3">
       <Target className="mt-0.5 size-4 shrink-0 text-muted-foreground/50" />
       <div className="min-w-0 flex-1">
-        <strong className="block font-medium">{intent.content}</strong>
+        <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+          <strong className="font-medium">{intent.content}</strong>
+          {topGap && (
+            <span className="inline-flex items-center gap-1 rounded-full bg-amber-500/15 px-1.5 py-0.5 font-medium text-[10px] text-amber-700 uppercase tracking-wide dark:text-amber-300">
+              Top gap
+            </span>
+          )}
+        </div>
         <div className="mt-1.5 flex flex-wrap items-center gap-x-2 gap-y-1 text-muted-foreground text-xs">
           <CoverageBadge intent={intent} />
           <span aria-hidden>·</span>
-          <span>
-            seen in {intent.sessions.length} session{intent.sessions.length === 1 ? "" : "s"}
-          </span>
+          <SessionsPopover
+            frequent={frequent}
+            sessionIds={intent.sessions}
+            sessionTitles={props.sessionTitles}
+          />
+          {intent.evidences && intent.evidences.length > 0 && (
+            <>
+              <span aria-hidden>·</span>
+              <EvidenceDisclosure evidences={intent.evidences} />
+            </>
+          )}
         </div>
       </div>
       <div className="flex shrink-0 items-center gap-1.5">
-        {isGap && <OfferSkillDialog intent={intent.content} onCreated={props.onReload} />}
+        {/* Offer a skill for any intent — covered ones can still want a better/new skill;
+            the generator already gets existing skill IDs so it won't duplicate. */}
+        <OfferSkillCell
+          initialJob={props.initialJob}
+          intent={intent.content}
+          onCreated={props.onReload}
+        />
         <DeleteIntentButton content={intent.content} onDeleted={props.onReload} />
       </div>
     </li>
+  );
+}
+
+/** "seen in N sessions" — opens the list of those chats (capped), each a link to its page. */
+function SessionsPopover(props: {
+  sessionIds: string[];
+  sessionTitles: SessionTitles;
+  frequent: boolean;
+}) {
+  const { token } = useRatelApp();
+  const navigate = useNavigate();
+  const seen = props.sessionIds.length;
+  const CAP = 10;
+  const shown = props.sessionIds.slice(0, CAP);
+  const more = seen - shown.length;
+  return (
+    <Popover>
+      <PopoverTrigger
+        render={
+          <button
+            className={
+              props.frequent
+                ? "inline-flex items-center gap-1 font-semibold text-foreground hover:underline"
+                : "inline-flex items-center gap-1 hover:text-foreground hover:underline"
+            }
+            type="button"
+          />
+        }
+      >
+        <MessagesSquare className="size-3" />
+        seen in {seen} session{seen === 1 ? "" : "s"}
+      </PopoverTrigger>
+      <PopoverContent align="start" className="w-72 gap-1 p-1">
+        <p className="px-2 pt-1 text-muted-foreground text-xs">Open a chat</p>
+        <div className="grid">
+          {shown.map((sid) => {
+            const meta = props.sessionTitles[sid];
+            return (
+              <button
+                className="grid gap-0.5 rounded px-2 py-1.5 text-left hover:bg-accent"
+                key={sid}
+                onClick={() => void navigate({ to: chatPath(sid, token) } as never)}
+                type="button"
+              >
+                <span className="truncate text-xs">{meta?.title ?? sid}</span>
+                <span className="truncate font-mono text-[10px] text-muted-foreground">{sid}</span>
+              </button>
+            );
+          })}
+        </div>
+        {more > 0 && (
+          <p className="px-2 py-1 text-[10px] text-muted-foreground">
+            +{more} more session{more === 1 ? "" : "s"}
+          </p>
+        )}
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+/** Expandable "proof" for an intent: the evidence spans/turns that produced it. */
+function EvidenceDisclosure(props: { evidences: string[] }) {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <button
+        className="inline-flex items-center gap-1 hover:text-foreground hover:underline"
+        onClick={() => setOpen((o) => !o)}
+        type="button"
+      >
+        {open ? <ChevronDown className="size-3" /> : <ChevronRight className="size-3" />}
+        {open ? "Hide" : "Show"} evidence ({props.evidences.length})
+      </button>
+      {open && (
+        <ul className="mt-1 grid basis-full gap-1.5 border-muted-foreground/20 border-l-2 pl-3">
+          {props.evidences.map((ev, i) => (
+            <li
+              className="whitespace-pre-wrap text-muted-foreground italic"
+              // Evidence is a static, read-only list that never reorders, so the index is a safe key.
+              // biome-ignore lint/suspicious/noArrayIndexKey: static, ordered evidence list
+              key={i}
+            >
+              “{ev}”
+            </li>
+          ))}
+        </ul>
+      )}
+    </>
   );
 }
 
@@ -440,64 +716,274 @@ function CoverageBadge(props: { intent: IntentRecord }) {
   );
 }
 
-function OfferSkillDialog(props: { intent: string; onCreated: () => Promise<void> }) {
-  const { request, runAction, busy } = useRatelApp();
-  const [open, setOpen] = useState(false);
-  const [phase, setPhase] = useState<"idle" | "generating" | "error">("idle");
-  const [editing, setEditing] = useState(false);
+type OfferPhase = "idle" | "running" | "ready" | "error";
+
+const OFFER_POLL_MS = 1500;
+const PROGRESS_CAP = 92;
+
+/**
+ * In-row "Offer New Skills" cell. Default state shows the button; on click it
+ * starts a BACKGROUND authoring job and replaces the button in place with a
+ * compact progress bar paced by the chosen model. When the job finishes it opens
+ * the review dialog pre-filled with the draft.
+ *
+ * The job lives on the server, so it survives navigation: `initialJob` hydrates
+ * this cell from the server's job registry — a still-running job resumes its
+ * progress bar, and a finished one shows a "Review skill" button that reopens the
+ * draft. That's what keeps a result reachable after you leave and come back.
+ */
+function OfferSkillCell(props: {
+  intent: string;
+  initialJob?: OfferJobSummary;
+  onCreated: () => Promise<void>;
+}) {
+  const { request, runAction } = useRatelApp();
+  const [phase, setPhase] = useState<OfferPhase>("idle");
+  const [progress, setProgress] = useState(0);
   const [error, setError] = useState("");
   const [draft, setDraft] = useState<SkillDraft | null>(null);
-  const [name, setName] = useState("");
-  const [description, setDescription] = useState("");
-  const [tags, setTags] = useState("");
-  const [body, setBody] = useState("");
-  const [progress, setProgress] = useState(0);
-  const [filling, setFilling] = useState(false);
+  const [reviewOpen, setReviewOpen] = useState(false);
+  const [loadingDraft, setLoadingDraft] = useState(false);
+  // Expected authoring time (ms) for the chosen model, set from the start response.
+  const [tau, setTau] = useState(() => estimateGenMs(props.initialJob?.model));
+  // Set once a skill is created from this cell, so we don't re-hydrate it back to
+  // "Review" from the (still-present) server job after the user is done with it.
+  const consumed = useRef(false);
 
-  // Fake progress while authoring: fast start, easing toward a cap over ~40s
-  // (it never reaches 100 on its own). On completion `filling` pins it to 100.
+  // Adopt a pre-existing server job (started earlier / in another tab). Only from
+  // the idle state, so it never clobbers an interaction already in progress.
   useEffect(() => {
-    if (phase !== "generating" || filling) return;
+    const job = props.initialJob;
+    if (!job || consumed.current) return;
+    setPhase((cur) => {
+      if (cur !== "idle") return cur;
+      if (job.status === "running") {
+        setTau(estimateGenMs(job.model));
+        return "running";
+      }
+      if (job.status === "done") return "ready";
+      if (job.status === "error") {
+        setError(job.error ?? "Failed to author a skill draft");
+        return "error";
+      }
+      return cur;
+    });
+  }, [props.initialJob]);
+
+  // Easing animation while the job runs: fast start, slowing exponentially and
+  // hovering at the cap (~90–92%) until the result arrives. Paced by the model.
+  useEffect(() => {
+    if (phase !== "running") return;
     const start = performance.now();
-    const CAP = 95;
-    const TAU = 12000;
     const id = window.setInterval(() => {
       const elapsed = performance.now() - start;
-      setProgress(Math.min(CAP, CAP * (1 - Math.exp(-elapsed / TAU))));
+      setProgress(PROGRESS_CAP * (1 - Math.exp(-elapsed / tau)));
     }, 150);
     return () => window.clearInterval(id);
-  }, [phase, filling]);
+  }, [phase, tau]);
 
-  const generate = useCallback(async () => {
-    setFilling(false);
-    setProgress(0);
-    setPhase("generating");
+  // Poll the background job's status while it runs.
+  useEffect(() => {
+    if (phase !== "running") return;
+    let cancelled = false;
+    const tick = async () => {
+      try {
+        const status = await offerSkillStatus(request, props.intent);
+        if (cancelled) return;
+        if (status.model) setTau(estimateGenMs(status.model));
+        if (status.status === "done" && status.draft) {
+          setDraft(status.draft);
+          // Snap to 100% briefly, then open the review dialog.
+          setProgress(100);
+          window.setTimeout(() => {
+            if (cancelled) return;
+            setPhase("ready");
+            setReviewOpen(true);
+          }, 400);
+        } else if (status.status === "error") {
+          setError(status.error ?? "Failed to author a skill draft");
+          setPhase("error");
+        }
+      } catch (err) {
+        if (cancelled) return;
+        setError(err instanceof Error ? err.message : "Failed to check authoring status");
+        setPhase("error");
+      }
+    };
+    const id = window.setInterval(() => void tick(), OFFER_POLL_MS);
+    // Kick once immediately so a fast/cached job surfaces without a full interval.
+    void tick();
+    return () => {
+      cancelled = true;
+      window.clearInterval(id);
+    };
+  }, [phase, request, props.intent]);
+
+  const start = useCallback(async () => {
     setError("");
+    setDraft(null);
+    setProgress(0);
+    consumed.current = false;
     try {
-      const { draft } = await offerSkill(request, props.intent);
-      setDraft(draft);
-      setName(draft.name);
-      setDescription(draft.description);
-      setTags((draft.tags ?? []).join(", "));
-      setBody(draft.body);
-      setEditing(false);
-      // Ramp to 100% fast, hold a beat so it's visible, then show the preview.
-      setFilling(true);
-      setProgress(100);
-      window.setTimeout(() => {
-        setPhase("idle");
-        setFilling(false);
-      }, 450);
+      const res = await offerSkill(request, props.intent);
+      setTau(estimateGenMs(res.model));
+      // Whether we started it or it was already running (another tab), begin polling.
+      setPhase("running");
     } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to start skill authoring");
       setPhase("error");
-      setError(err instanceof Error ? err.message : "Failed to generate a skill draft");
     }
   }, [request, props.intent]);
 
-  const onOpenChange = (next: boolean) => {
-    setOpen(next);
-    if (next && !draft) void generate();
-  };
+  // Reopen a finished job's draft, fetching it first if this cell was hydrated
+  // from the server (so it has the job but not yet the draft).
+  const review = useCallback(async () => {
+    if (draft) {
+      setReviewOpen(true);
+      return;
+    }
+    setLoadingDraft(true);
+    try {
+      const status = await offerSkillStatus(request, props.intent);
+      if (status.draft) {
+        setDraft(status.draft);
+        setReviewOpen(true);
+      } else if (status.status === "error") {
+        setError(status.error ?? "Failed to author a skill draft");
+        setPhase("error");
+      } else {
+        await start();
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load the draft");
+      setPhase("error");
+    } finally {
+      setLoadingDraft(false);
+    }
+  }, [draft, request, props.intent, start]);
+
+  const create = useCallback(
+    async (edited: SkillDraft) => {
+      const name = edited.name.trim();
+      const ok = await runAction(`Created skill ${name}`, () =>
+        request("/api/skills", {
+          method: "POST",
+          body: {
+            name,
+            description: edited.description.trim(),
+            tags: edited.tags ?? [],
+            body: edited.body,
+          },
+        }),
+      );
+      if (ok) {
+        consumed.current = true;
+        // Drop the server-side job too, so a later refresh doesn't re-surface this
+        // (now-created) skill as "ready" and then fail with "already exists".
+        await clearOfferJob(request, props.intent).catch(() => undefined);
+        setReviewOpen(false);
+        setPhase("idle");
+        setDraft(null);
+        await props.onCreated();
+      }
+      return ok;
+    },
+    [request, runAction, props.intent, props.onCreated],
+  );
+
+  // Discard the draft entirely: clear the server job so the notification goes away.
+  const decline = useCallback(async () => {
+    consumed.current = true;
+    await clearOfferJob(request, props.intent).catch(() => undefined);
+    setReviewOpen(false);
+    setPhase("idle");
+    setDraft(null);
+    await props.onCreated();
+  }, [request, props.intent, props.onCreated]);
+
+  if (phase === "running") {
+    return (
+      <div className="flex w-44 items-center gap-2">
+        <PixelProgress className="flex-1" progress={progress} />
+        <span className="shrink-0 text-muted-foreground text-xs">Authoring…</span>
+      </div>
+    );
+  }
+
+  if (phase === "error") {
+    return (
+      <div className="flex items-center gap-1.5">
+        <span className="max-w-32 truncate text-destructive text-xs" title={error}>
+          {error}
+        </span>
+        <Button onClick={() => void start()} size="sm" variant="outline">
+          Retry
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      {phase === "ready" ? (
+        <Button
+          className="bg-brand-green text-white shadow-brand-green/20 shadow-sm hover:bg-brand-green/90"
+          disabled={loadingDraft}
+          onClick={() => void review()}
+          size="sm"
+        >
+          {loadingDraft ? (
+            <Spinner />
+          ) : (
+            <span className="size-1.5 rounded-full bg-white/90 motion-safe:animate-pulse" />
+          )}
+          Skill ready — review
+        </Button>
+      ) : (
+        <Button onClick={() => void start()} size="sm" variant="outline">
+          <Sparkles />
+          Offer New Skills
+        </Button>
+      )}
+      {draft && (
+        <OfferSkillReviewDialog
+          draft={draft}
+          intent={props.intent}
+          onCreate={create}
+          onDecline={decline}
+          onOpenChange={setReviewOpen}
+          open={reviewOpen}
+        />
+      )}
+    </>
+  );
+}
+
+/** Controlled review/edit dialog for a finished skill draft. */
+function OfferSkillReviewDialog(props: {
+  intent: string;
+  draft: SkillDraft;
+  open: boolean;
+  onOpenChange: (next: boolean) => void;
+  onCreate: (edited: SkillDraft) => Promise<boolean>;
+  onDecline: () => Promise<void>;
+}) {
+  const { busy } = useRatelApp();
+  const { draft } = props;
+  const [editing, setEditing] = useState(false);
+  const [name, setName] = useState(draft.name);
+  const [description, setDescription] = useState(draft.description);
+  const [tags, setTags] = useState((draft.tags ?? []).join(", "));
+  const [body, setBody] = useState(draft.body);
+
+  // Re-seed the fields whenever a fresh draft is handed in.
+  useEffect(() => {
+    setName(draft.name);
+    setDescription(draft.description);
+    setTags((draft.tags ?? []).join(", "));
+    setBody(draft.body);
+    setEditing(false);
+  }, [draft]);
 
   const tagList = tags
     .split(",")
@@ -505,26 +991,16 @@ function OfferSkillDialog(props: { intent: string; onCreated: () => Promise<void
     .filter(Boolean);
 
   const create = async () => {
-    const ok = await runAction(`Created skill ${name.trim()}`, () =>
-      request("/api/skills", {
-        method: "POST",
-        body: { name: name.trim(), description: description.trim(), tags: tagList, body },
-      }),
-    );
-    if (ok) {
-      setOpen(false);
-      await props.onCreated();
-    }
+    await props.onCreate({
+      name: name.trim(),
+      description: description.trim(),
+      tags: tagList,
+      body,
+    });
   };
 
-  const ready = phase === "idle" && draft;
-
   return (
-    <Dialog onOpenChange={onOpenChange} open={open}>
-      <DialogTrigger render={<Button size="sm" variant="outline" />}>
-        <Sparkles />
-        Offer New Skills
-      </DialogTrigger>
+    <Dialog onOpenChange={props.onOpenChange} open={props.open}>
       <DialogContent className="flex max-h-[85vh] flex-col gap-4 sm:max-w-2xl">
         <DialogHeader>
           <DialogTitle>Offer a new skill</DialogTitle>
@@ -536,30 +1012,7 @@ function OfferSkillDialog(props: { intent: string; onCreated: () => Promise<void
 
         {/* Only this middle region scrolls; header + footer stay put. */}
         <div className="min-h-0 flex-1 overflow-y-auto pr-1">
-          {phase === "generating" && (
-            <div className="grid gap-4 py-8">
-              <div className="flex items-center gap-3">
-                <PrismSweep dotSize={4} pattern="full" size={30} speed={1.4} />
-                <PixelProgress className="flex-1" progress={progress} />
-              </div>
-              <p className="text-center font-medium text-sm">Authoring the skill…</p>
-            </div>
-          )}
-
-          {phase === "error" && (
-            <div className="grid gap-3 py-2">
-              <p className="text-destructive text-sm">{error}</p>
-              <p className="text-muted-foreground text-xs">
-                Configure a skill generator in Settings (an Anthropic API key, or the local{" "}
-                <code className="font-mono">claude</code> CLI on PATH), then try again.
-              </p>
-              <Button onClick={() => void generate()} size="sm" variant="outline">
-                Retry
-              </Button>
-            </div>
-          )}
-
-          {ready && !editing && (
+          {!editing && (
             <div className="grid gap-3">
               <div>
                 <code className="rounded bg-muted px-1.5 py-0.5 font-mono text-xs">{name}</code>
@@ -583,7 +1036,7 @@ function OfferSkillDialog(props: { intent: string; onCreated: () => Promise<void
             </div>
           )}
 
-          {ready && editing && (
+          {editing && (
             <div className="grid gap-3">
               <div className="grid gap-1.5">
                 <Label htmlFor="offer-name">Name</Label>
@@ -614,25 +1067,35 @@ function OfferSkillDialog(props: { intent: string; onCreated: () => Promise<void
           )}
         </div>
 
-        <DialogFooter>
-          <DialogClose render={<Button size="sm" variant="outline" />}>Cancel</DialogClose>
-          {ready && (
+        <DialogFooter className="sm:justify-between">
+          <Button
+            className="text-destructive hover:text-destructive"
+            disabled={busy}
+            onClick={() => void props.onDecline()}
+            size="sm"
+            variant="ghost"
+          >
+            <Trash2 />
+            Decline
+          </Button>
+          <div className="flex items-center gap-2">
+            <DialogClose render={<Button size="sm" variant="outline" />}>Later</DialogClose>
             <Button onClick={() => setEditing((e) => !e)} size="sm" variant="outline">
               {editing ? "Preview" : "Edit"}
             </Button>
-          )}
-          <Button
-            disabled={busy || !ready || name.trim() === ""}
-            onClick={() => void create()}
-            size="sm"
-          >
-            Create skill
-          </Button>
+            <Button disabled={busy || name.trim() === ""} onClick={() => void create()} size="sm">
+              Create skill
+            </Button>
+          </div>
         </DialogFooter>
       </DialogContent>
     </Dialog>
   );
 }
+
+// base-ui Select can't hold an empty-string value, so the "Default" choice uses
+// this sentinel and maps back to "" (which the generator treats as its default).
+const SKILLGEN_DEFAULT = "__default__";
 
 function AnalysisSettingsDialog() {
   const { request, runAction, busy } = useRatelApp();
@@ -655,6 +1118,7 @@ function AnalysisSettingsDialog() {
         setSecretMask(res.secretMask);
         setNums({
           everyNMessages: numToStr(a.cadence?.everyNMessages),
+          recentHours: numToStr(a.cadence?.recentHours),
           minScore: numToStr(a.coverage?.minScore),
           relativeRatio: numToStr(a.coverage?.relativeRatio),
           maxSkills: numToStr(a.coverage?.maxSkills),
@@ -668,7 +1132,12 @@ function AnalysisSettingsDialog() {
   const save = async () => {
     const next: AnalysisSettings = {
       ...form,
-      cadence: { ...form.cadence, everyNMessages: numberOrUndefined(nums.everyNMessages) },
+      cadence: {
+        ...form.cadence,
+        everyNMessages: numberOrUndefined(nums.everyNMessages),
+        // 0/empty → undefined (no limit); the config rejects non-positive values.
+        recentHours: floatOrUndefined(nums.recentHours) || undefined,
+      },
       coverage: {
         minScore: floatOrUndefined(nums.minScore),
         relativeRatio: floatOrUndefined(nums.relativeRatio),
@@ -718,6 +1187,16 @@ function AnalysisSettingsDialog() {
             title="Cadence"
             hint="When analysis is due (manual Run now always works)."
           >
+            <SettingRow
+              control={
+                <Switch
+                  checked={cadence.auto ?? false}
+                  onCheckedChange={(v) => update({ cadence: { ...cadence, auto: v } })}
+                />
+              }
+              hint="Let the gateway run analysis automatically in the background on a timer. Off by default — manual Run now always works."
+              label="Automatic runs"
+            />
             <div className="grid items-end gap-3 sm:grid-cols-2">
               <Field htmlFor="cadence-n" label="Every N messages">
                 <Input
@@ -739,6 +1218,20 @@ function AnalysisSettingsDialog() {
                 label="On idle"
               />
             </div>
+            <Field htmlFor="cadence-recent" label="Only chats active in the last (hours)">
+              <Input
+                id="cadence-recent"
+                inputMode="decimal"
+                onChange={(e) => setNum("recentHours", e.target.value)}
+                placeholder="e.g. 5 — leave blank for no limit"
+                value={nums.recentHours ?? ""}
+              />
+            </Field>
+            <p className="px-1 text-muted-foreground text-xs">
+              Bulk and automatic runs only analyze chats updated within this window — keeps a run
+              from churning through every old chat. Per-chat “Analyze intents” (on the Chats page)
+              ignores it.
+            </p>
           </SettingsSection>
 
           <SettingsSection
@@ -887,7 +1380,35 @@ function AnalysisSettingsDialog() {
                   />
                 </Field>
               )}
+              <Field label="Model">
+                <Select
+                  onValueChange={(v) =>
+                    update({
+                      skillGen: { ...skillGen, model: v && v !== SKILLGEN_DEFAULT ? v : "" },
+                    })
+                  }
+                  value={skillGen.model ? skillGen.model : SKILLGEN_DEFAULT}
+                >
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {skillGenModelOptions(skillGenProvider).map((opt) => (
+                      <SelectItem
+                        key={opt.value || SKILLGEN_DEFAULT}
+                        value={opt.value || SKILLGEN_DEFAULT}
+                      >
+                        {opt.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </Field>
             </div>
+            <p className="px-1 text-muted-foreground text-xs">
+              The model used to author skills. This also sets the expected authoring time shown in
+              the “Offer New Skills” progress bar.
+            </p>
             {skillGenProvider === "claude-cli" && (
               <p className="px-1 text-muted-foreground text-xs">
                 Uses your local <code className="font-mono">claude</code> CLI — no API key needed.
@@ -946,6 +1467,23 @@ function SettingRow(props: { label: string; hint?: string; control: ReactNode })
       </div>
       {props.control}
     </div>
+  );
+}
+
+/** Full-bleed "analyzing" panel shown in place of the empty state while a run is in flight. */
+function AnalyzingState() {
+  return (
+    <section className="-mx-4 grid min-h-72 flex-1 place-items-center border-border border-y bg-muted/15 px-4 py-8 text-center sm:-mx-6 sm:px-6">
+      <div className="grid max-w-md justify-items-center gap-4">
+        <PrismSweep dotSize={4} pattern="full" size={40} speed={1.4} />
+        <div>
+          <h3 className="font-medium">Analyzing chat through the extractor…</h3>
+          <p className="mt-1 text-muted-foreground text-sm">
+            Results appear as each session finishes.
+          </p>
+        </div>
+      </div>
+    </section>
   );
 }
 

--- a/packages/ui/src/pages/IntentsPage.tsx
+++ b/packages/ui/src/pages/IntentsPage.tsx
@@ -280,14 +280,8 @@ export function IntentsPage() {
         </div>
       )}
 
-      {/* While analyzing with results already on screen, a slim top banner keeps
-          context; the empty state gets the full-bleed version (below) instead. */}
-      {showRunning && intents.length > 0 && (
-        <div className="flex items-center gap-2.5 rounded-md border border-border bg-muted/30 px-3 py-2 text-muted-foreground text-sm">
-          <PrismSweep size={22} dotSize={3} speed={1.3} />
-          Analyzing chat through the extractor… results appear as each session finishes.
-        </div>
-      )}
+      {/* No "analyzing" banner while results are on screen — the searching slot at the
+          top of the list (and the Run-now button's spinner) already signal the run. */}
 
       {!showRunning && ready?.lastError && (
         <div className="rounded-md border border-amber-300/60 bg-amber-50 px-3 py-2 text-amber-900 text-sm dark:border-amber-400/40 dark:bg-amber-500/15 dark:text-amber-200">
@@ -462,21 +456,20 @@ function IntentList(props: {
   // Keep the searching slot mounted through its collapse animation after a run ends.
   const placeholder = usePresence(streaming, PLACEHOLDER_EXIT_MS);
 
-  // While a run streams in, reveal everything so each new intent (and the slot) is
-  // visible as it lands; we never collapse back, so the list doesn't jump when it ends.
-  useEffect(() => {
-    if (streaming) setShown((n) => Math.max(n, items.length));
-  }, [streaming, items.length]);
-
+  // New intents arrive at the TOP, so they're always within the first page — no need
+  // to reveal the whole list; older intents stay paginated.
   const visible = items.slice(0, shown);
   const remaining = items.length - visible.length;
   return (
     <div className="grid gap-2">
       <ul className="grid gap-2">
+        {/* The searching slot sits at the top; each new intent grows in just below it,
+            pushing the rest down — results stream in from the top. */}
+        {placeholder.mounted && <IntentSearchingRow exiting={placeholder.exiting} />}
         {visible.map((intent) => (
           <li
             // The wrapper li grows the row into place on arrival; the inner overflow
-            // clip is what makes the height animation read as a slide into the slot.
+            // clip is what makes the height animation read as a slide down from the top.
             className={cn("grid", entering.has(intent.content) && "animate-intent-enter")}
             key={intent.content}
           >
@@ -490,7 +483,6 @@ function IntentList(props: {
             </div>
           </li>
         ))}
-        {placeholder.mounted && <IntentSearchingRow exiting={placeholder.exiting} />}
       </ul>
       {remaining > 0 && (
         <div className="flex justify-center pt-1">

--- a/packages/ui/src/pages/IntentsPage.tsx
+++ b/packages/ui/src/pages/IntentsPage.tsx
@@ -244,7 +244,7 @@ export function IntentsPage() {
             disabled={busy || showRunning || analysisOff}
             onClick={() => void runNow()}
             size="sm"
-            title="Analyze chats with new activity since their last analysis"
+            title="Analyze every chat (reuses cached results for unchanged chats)"
           >
             {showRunning ? <Spinner /> : <Play />}
             {showRunning ? "Analyzing…" : "Run now"}

--- a/packages/ui/src/pages/IntentsPage.tsx
+++ b/packages/ui/src/pages/IntentsPage.tsx
@@ -181,7 +181,7 @@ export function IntentsPage() {
       const data = await load();
       // Keep the banner only while the server reports an in-flight run; the polling
       // effect clears it when that finishes. Otherwise (error, or a synchronous
-      // backend with no `running` flag) clear it now — the results are already in.
+      // backend with no `running` flag) clear it now - the results are already in.
       if (!ok || !data?.running) setRunning(false);
     },
     [runAction, request, load],
@@ -209,7 +209,7 @@ export function IntentsPage() {
           </PageHeaderBackRow>
           <PageHeaderDescription>
             What you keep asking your agents to do, extracted from captured chat and matched against
-            the skills Ratel manages. Gaps are intents no skill covers — offer a new skill to close
+            the skills Ratel manages. Gaps are intents no skill covers - offer a new skill to close
             them.
           </PageHeaderDescription>
         </PageHeaderContent>
@@ -262,7 +262,7 @@ export function IntentsPage() {
 
       {analysisOff && (
         <div className="rounded-md border border-border bg-muted/40 px-3 py-2 text-muted-foreground text-sm">
-          Analysis is off — chat isn't being captured and runs are disabled. Turn it on in{" "}
+          Analysis is off - chat isn't being captured and runs are disabled. Turn it on in{" "}
           <strong className="font-medium">Settings → Enabled</strong>.
         </div>
       )}
@@ -510,7 +510,7 @@ function IntentRow(props: {
         </div>
       </div>
       <div className="flex shrink-0 items-center gap-1.5">
-        {/* Offer a skill for any intent — covered ones can still want a better/new skill;
+        {/* Offer a skill for any intent - covered ones can still want a better/new skill;
             the generator already gets existing skill IDs so it won't duplicate. */}
         <OfferSkillCell
           initialJob={props.initialJob}
@@ -523,7 +523,7 @@ function IntentRow(props: {
   );
 }
 
-/** "seen in N sessions" — opens the list of those chats (capped), each a link to its page. */
+/** "seen in N sessions" - opens the list of those chats (capped), each a link to its page. */
 function SessionsPopover(props: {
   sessionIds: string[];
   sessionTitles: SessionTitles;
@@ -728,7 +728,7 @@ const PROGRESS_CAP = 92;
  * the review dialog pre-filled with the draft.
  *
  * The job lives on the server, so it survives navigation: `initialJob` hydrates
- * this cell from the server's job registry — a still-running job resumes its
+ * this cell from the server's job registry - a still-running job resumes its
  * progress bar, and a finished one shows a "Review skill" button that reopens the
  * draft. That's what keeps a result reachable after you leave and come back.
  */
@@ -937,7 +937,7 @@ function OfferSkillCell(props: {
           ) : (
             <span className="size-1.5 rounded-full bg-white/90 motion-safe:animate-pulse" />
           )}
-          Skill ready — review
+          Skill ready - review
         </Button>
       ) : (
         <Button onClick={() => void start()} size="sm" variant="outline">
@@ -1005,7 +1005,7 @@ function OfferSkillReviewDialog(props: {
         <DialogHeader>
           <DialogTitle>Offer a new skill</DialogTitle>
           <DialogDescription className="line-clamp-2">
-            Drafted for “{props.intent}”. Review, optionally edit, then save — it writes a SKILL.md
+            Drafted for “{props.intent}”. Review, optionally edit, then save - it writes a SKILL.md
             into Ratel's managed folder.
           </DialogDescription>
         </DialogHeader>
@@ -1194,7 +1194,7 @@ function AnalysisSettingsDialog() {
                   onCheckedChange={(v) => update({ cadence: { ...cadence, auto: v } })}
                 />
               }
-              hint="Let the gateway run analysis automatically in the background on a timer. Off by default — manual Run now always works."
+              hint="Let the gateway run analysis automatically in the background on a timer. Off by default - manual Run now always works."
               label="Automatic runs"
             />
             <div className="grid items-end gap-3 sm:grid-cols-2">
@@ -1223,12 +1223,12 @@ function AnalysisSettingsDialog() {
                 id="cadence-recent"
                 inputMode="decimal"
                 onChange={(e) => setNum("recentHours", e.target.value)}
-                placeholder="e.g. 5 — leave blank for no limit"
+                placeholder="e.g. 5 - leave blank for no limit"
                 value={nums.recentHours ?? ""}
               />
             </Field>
             <p className="px-1 text-muted-foreground text-xs">
-              Bulk and automatic runs only analyze chats updated within this window — keeps a run
+              Bulk and automatic runs only analyze chats updated within this window - keeps a run
               from churning through every old chat. Per-chat “Analyze intents” (on the Chats page)
               ignores it.
             </p>
@@ -1298,14 +1298,14 @@ function AnalysisSettingsDialog() {
             </div>
             {extractorProvider === "http" && (
               <p className="px-1 text-muted-foreground text-xs">
-                The sidecar serves whichever model it was started with — set it in the sidecar's{" "}
+                The sidecar serves whichever model it was started with - set it in the sidecar's{" "}
                 <code className="font-mono">settings.json</code> (or{" "}
                 <code className="font-mono">CLAIM_EXTRACTOR_MODEL</code>), not here.
               </p>
             )}
             {extractorProvider === "naive" && (
               <p className="px-1 text-muted-foreground text-xs">
-                Naive mode needs no model — it records one intent per user message (good for testing
+                Naive mode needs no model - it records one intent per user message (good for testing
                 the pipeline).
               </p>
             )}
@@ -1411,7 +1411,7 @@ function AnalysisSettingsDialog() {
             </p>
             {skillGenProvider === "claude-cli" && (
               <p className="px-1 text-muted-foreground text-xs">
-                Uses your local <code className="font-mono">claude</code> CLI — no API key needed.
+                Uses your local <code className="font-mono">claude</code> CLI - no API key needed.
               </p>
             )}
           </SettingsSection>

--- a/packages/ui/src/pages/IntentsPage.tsx
+++ b/packages/ui/src/pages/IntentsPage.tsx
@@ -1,0 +1,974 @@
+import { useNavigate } from "@tanstack/react-router";
+import { Cog, Play, SearchIcon, Sparkles, Target, Trash2 } from "lucide-react";
+import { type ReactNode, useCallback, useEffect, useState } from "react";
+import { skillPath, useRatelApp } from "@/App";
+import { Markdown } from "@/components/markdown";
+import {
+  PageHeader,
+  PageHeaderActions,
+  PageHeaderBackRow,
+  PageHeaderContent,
+  PageHeaderDescription,
+  PageHeaderSidebarTrigger,
+  PageHeaderTitle,
+} from "@/components/page-header";
+import { ResponsiveToolbar, ResponsiveToolbarButton } from "@/components/responsive-toolbar";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { PixelProgress } from "@/components/ui/pixel-progress";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { PrismSweep } from "@/components/ui/prism-sweep";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Spinner } from "@/components/ui/spinner";
+import { Switch } from "@/components/ui/switch";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  type AnalysisSettings,
+  type Cadence,
+  clearIntents,
+  deleteIntent,
+  fetchAnalysisSettings,
+  fetchIntents,
+  type IntentRecord,
+  type IntentsIndex,
+  offerSkill,
+  runIntents,
+  type SessionSummary,
+  type SkillDraft,
+  saveAnalysisSettings,
+} from "@/lib/intents";
+
+type LoadState =
+  | { status: "loading" }
+  | { status: "error"; message: string }
+  | { status: "ready"; data: IntentsIndex };
+
+type View = "cumulative" | "by-session";
+
+export function IntentsPage() {
+  const { request, runAction, busy, openCommandMenu } = useRatelApp();
+  const [state, setState] = useState<LoadState>({ status: "loading" });
+  const [view, setView] = useState<View>("cumulative");
+  const [running, setRunning] = useState(false);
+
+  const load = useCallback(async () => {
+    try {
+      const data = await fetchIntents(request);
+      setState({ status: "ready", data });
+      return data;
+    } catch (err) {
+      setState({
+        status: "error",
+        message: err instanceof Error ? err.message : "Failed to load intents",
+      });
+      return null;
+    }
+  }, [request]);
+
+  // void-returning wrapper for child `onReload`/`onCleared` props.
+  const reload = useCallback(async () => {
+    await load();
+  }, [load]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  // The run is fire-and-forget on the server; poll while it reports `running` so
+  // results stream in and the banner clears itself when the run finishes.
+  useEffect(() => {
+    if (!running) return;
+    let cancelled = false;
+    const tick = async () => {
+      const data = await load();
+      if (!cancelled && data && !data.running) setRunning(false);
+    };
+    const id = window.setInterval(() => void tick(), 2000);
+    return () => {
+      cancelled = true;
+      window.clearInterval(id);
+    };
+  }, [running, load]);
+
+  const runNow = useCallback(async () => {
+    // Show the banner immediately so there's feedback even if the backend runs
+    // synchronously (e.g. a stale dev server that hasn't picked up fire-and-forget).
+    setRunning(true);
+    const ok = await runAction("Analysis started", () => runIntents(request));
+    const data = await load();
+    // Keep the banner only while the server reports an in-flight run; the polling
+    // effect clears it when that finishes. Otherwise (error, or a synchronous
+    // backend with no `running` flag) clear it now — the results are already in.
+    if (!ok || !data?.running) setRunning(false);
+  }, [runAction, request, load]);
+
+  const ready = state.status === "ready" ? state.data : null;
+  const intents = ready?.intents ?? [];
+  const sessions = ready?.sessions ?? [];
+  const cadence = ready?.cadence;
+  const analysisOff = ready?.enabled === false;
+
+  return (
+    <main className="flex w-full flex-1 flex-col gap-4 px-4 py-5 sm:px-6">
+      <PageHeader className="sm:grid-cols-[minmax(0,1fr)_auto] sm:items-start">
+        <PageHeaderContent>
+          <PageHeaderBackRow>
+            <PageHeaderTitle>Intents</PageHeaderTitle>
+            <div className="flex items-center gap-1 sm:hidden">
+              <Button
+                aria-label="Search"
+                onClick={openCommandMenu}
+                size="icon-lg"
+                type="button"
+                variant="outline"
+              >
+                <SearchIcon />
+                <span className="sr-only">Search</span>
+              </Button>
+              <PageHeaderSidebarTrigger />
+            </div>
+          </PageHeaderBackRow>
+          <PageHeaderDescription>
+            What you keep asking your agents to do, extracted from captured chat and matched against
+            the skills Ratel manages. Gaps are intents no skill covers — offer a new skill to close
+            them.
+          </PageHeaderDescription>
+        </PageHeaderContent>
+        <PageHeaderActions className="hidden items-center sm:flex">
+          <AnalysisSettingsDialog />
+          <Button
+            className="h-10"
+            disabled={busy || running || analysisOff}
+            onClick={() => void runNow()}
+            size="sm"
+          >
+            {running ? <Spinner /> : <Play />}
+            {running ? "Analyzing…" : "Run now"}
+          </Button>
+          <ResponsiveToolbar>
+            <ResponsiveToolbarButton
+              icon={<SearchIcon />}
+              kbd="⌘K"
+              label="Search"
+              onClick={openCommandMenu}
+            />
+          </ResponsiveToolbar>
+          <PageHeaderSidebarTrigger className="hidden sm:inline-flex" />
+        </PageHeaderActions>
+      </PageHeader>
+
+      {state.status === "loading" && (
+        <p className="px-1 text-muted-foreground text-sm">Loading intents…</p>
+      )}
+
+      {state.status === "error" && (
+        <EmptyState title="Couldn't load intents" description={state.message}>
+          <Button onClick={() => void load()} size="sm" variant="outline">
+            Retry
+          </Button>
+        </EmptyState>
+      )}
+
+      {analysisOff && (
+        <div className="rounded-md border border-border bg-muted/40 px-3 py-2 text-muted-foreground text-sm">
+          Analysis is off — chat isn't being captured and runs are disabled. Turn it on in{" "}
+          <strong className="font-medium">Settings → Enabled</strong>.
+        </div>
+      )}
+
+      {running && (
+        <div className="flex items-center gap-2.5 rounded-md border border-border bg-muted/30 px-3 py-2 text-muted-foreground text-sm">
+          <PrismSweep size={22} dotSize={3} speed={1.3} />
+          Analyzing chat through the extractor… results appear as each session finishes.
+        </div>
+      )}
+
+      {!running && ready?.lastError && (
+        <div className="rounded-md border border-amber-300/60 bg-amber-50 px-3 py-2 text-amber-900 text-sm dark:border-amber-400/40 dark:bg-amber-500/15 dark:text-amber-200">
+          Last analysis didn't finish: {ready.lastError}
+        </div>
+      )}
+
+      {ready && intents.length === 0 && (
+        <EmptyState
+          title="No intents yet"
+          description="Once the plugin captures some chat, run an analysis to extract what you've been trying to do. Make sure the Ratel plugin hooks are trusted in your agent."
+        >
+          <Button disabled={busy} onClick={() => void runNow()} size="sm">
+            <Play />
+            Run analysis
+          </Button>
+        </EmptyState>
+      )}
+
+      {ready && intents.length > 0 && (
+        <>
+          <div className="flex items-center justify-between">
+            <Tabs onValueChange={(v) => setView(v as View)} value={view}>
+              <TabsList>
+                <TabsTrigger value="cumulative">Cumulative</TabsTrigger>
+                <TabsTrigger value="by-session">By session</TabsTrigger>
+              </TabsList>
+            </Tabs>
+            <div className="flex items-center gap-2">
+              <span className="px-1 text-muted-foreground text-xs">
+                {intents.length} intent{intents.length === 1 ? "" : "s"} ·{" "}
+                {intents.filter((i) => i.coverage.status === "gap").length} gaps
+                {cadence ? ` · due for analysis every ${cadence.everyNMessages} messages` : ""}
+              </span>
+              <ClearAllButton onCleared={reload} />
+            </div>
+          </div>
+
+          {view === "cumulative" ? (
+            <IntentList intents={intents} onReload={reload} />
+          ) : (
+            <BySessionView
+              cadence={cadence}
+              intents={intents}
+              onReload={reload}
+              sessions={sessions}
+            />
+          )}
+        </>
+      )}
+    </main>
+  );
+}
+
+function BySessionView(props: {
+  intents: IntentRecord[];
+  sessions: SessionSummary[];
+  cadence?: Cadence;
+  onReload: () => Promise<void>;
+}) {
+  if (props.sessions.length === 0) {
+    return <p className="px-1 text-muted-foreground text-sm">No analyzed sessions yet.</p>;
+  }
+  // Newest first by analysis time.
+  const sessions = [...props.sessions].sort((a, b) => b.analyzedAt.localeCompare(a.analyzedAt));
+  return (
+    <div className="grid gap-5">
+      {sessions.map((session) => {
+        const intents = props.intents.filter((i) => i.sessions.includes(session.sessionId));
+        return (
+          <section className="grid gap-2" key={session.sessionId}>
+            <div className="px-1">
+              <h2 className="truncate font-medium text-sm">
+                {session.cwd ?? session.sessionId}{" "}
+                <span className="text-muted-foreground">
+                  ({session.intentCount} intent{session.intentCount === 1 ? "" : "s"},{" "}
+                  {session.gapCount} gaps)
+                </span>
+              </h2>
+              <p className="truncate text-muted-foreground text-xs">
+                {session.host ?? "unknown"} · {session.sessionId}
+                {cadenceProgress(session, props.cadence)}
+              </p>
+            </div>
+            <IntentList intents={intents} onReload={props.onReload} />
+          </section>
+        );
+      })}
+    </div>
+  );
+}
+
+/** " · 3/10 new messages since last analysis" when a session has accumulated turns. */
+function cadenceProgress(session: SessionSummary, cadence?: Cadence): string {
+  const newTurns = session.newTurnCount ?? 0;
+  if (!cadence || newTurns === 0) return "";
+  const remaining = Math.max(0, cadence.everyNMessages - newTurns);
+  const tail = remaining === 0 ? "due now" : `${remaining} until due`;
+  return ` · ${newTurns}/${cadence.everyNMessages} new since last analysis (${tail})`;
+}
+
+function IntentList(props: { intents: IntentRecord[]; onReload: () => Promise<void> }) {
+  return (
+    <ul className="grid gap-2">
+      {props.intents.map((intent) => (
+        <IntentRow intent={intent} key={intent.content} onReload={props.onReload} />
+      ))}
+    </ul>
+  );
+}
+
+function IntentRow(props: { intent: IntentRecord; onReload: () => Promise<void> }) {
+  const { intent } = props;
+  const isGap = intent.coverage.status === "gap";
+  return (
+    <li className="flex items-start gap-3 rounded-md border border-border bg-card p-3">
+      <Target className="mt-0.5 size-4 shrink-0 text-muted-foreground/50" />
+      <div className="min-w-0 flex-1">
+        <strong className="block font-medium">{intent.content}</strong>
+        <div className="mt-1.5 flex flex-wrap items-center gap-x-2 gap-y-1 text-muted-foreground text-xs">
+          <CoverageBadge intent={intent} />
+          <span aria-hidden>·</span>
+          <span>
+            seen in {intent.sessions.length} session{intent.sessions.length === 1 ? "" : "s"}
+          </span>
+        </div>
+      </div>
+      <div className="flex shrink-0 items-center gap-1.5">
+        {isGap && <OfferSkillDialog intent={intent.content} onCreated={props.onReload} />}
+        <DeleteIntentButton content={intent.content} onDeleted={props.onReload} />
+      </div>
+    </li>
+  );
+}
+
+function DeleteIntentButton(props: { content: string; onDeleted: () => Promise<void> }) {
+  const { request, runAction, busy } = useRatelApp();
+  const onClick = async () => {
+    const ok = await runAction("Deleted intent", () => deleteIntent(request, props.content));
+    if (ok) await props.onDeleted();
+  };
+  return (
+    <Button
+      aria-label="Delete intent"
+      disabled={busy}
+      onClick={() => void onClick()}
+      size="icon-sm"
+      variant="ghost"
+    >
+      <Trash2 />
+    </Button>
+  );
+}
+
+function ClearAllButton(props: { onCleared: () => Promise<void> }) {
+  const { request, runAction, busy } = useRatelApp();
+  const [open, setOpen] = useState(false);
+  const clear = async () => {
+    const ok = await runAction("Cleared all intents", () => clearIntents(request));
+    if (ok) {
+      setOpen(false);
+      await props.onCleared();
+    }
+  };
+  return (
+    <Dialog onOpenChange={setOpen} open={open}>
+      <DialogTrigger render={<Button size="sm" variant="outline" />}>
+        <Trash2 />
+        Clear all
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Clear all intents?</DialogTitle>
+          <DialogDescription>
+            Removes every extracted intent from the list. They're re-extracted from captured chat
+            the next time you run an analysis.
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <DialogClose render={<Button size="sm" variant="outline" />}>Cancel</DialogClose>
+          <Button disabled={busy} onClick={() => void clear()} size="sm" variant="destructive">
+            Clear all
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function CoverageBadge(props: { intent: IntentRecord }) {
+  const { token } = useRatelApp();
+  const navigate = useNavigate();
+  const { coverage } = props.intent;
+
+  if (coverage.status === "gap") {
+    return (
+      <span className="inline-flex items-center gap-1.5">
+        <span className="size-1.5 rounded-full bg-amber-500/60" />
+        Gap
+      </span>
+    );
+  }
+
+  // Quiet metadata-weight indicator; click to reveal the BM25-ranked skills as links.
+  const count = coverage.skills.length;
+  return (
+    <Popover>
+      <PopoverTrigger
+        render={
+          <button
+            className="inline-flex items-center gap-1.5 hover:text-foreground hover:underline"
+            type="button"
+          />
+        }
+      >
+        <span className="size-1.5 rounded-full bg-emerald-500/70" />
+        Covered ({count})
+      </PopoverTrigger>
+      <PopoverContent align="start" className="w-60 gap-1 p-1">
+        <p className="px-2 pt-1 text-muted-foreground text-xs">Matching skills (BM25)</p>
+        <div className="grid">
+          {coverage.skills.map((skill) => (
+            <button
+              className="flex items-center justify-between gap-2 rounded px-2 py-1.5 text-left hover:bg-accent"
+              key={skill.skillId}
+              onClick={() => void navigate({ to: skillPath(skill.skillId, token) } as never)}
+              type="button"
+            >
+              <span className="truncate font-mono text-xs">{skill.skillId}</span>
+              <span className="shrink-0 text-[10px] text-muted-foreground">
+                {skill.score.toFixed(1)}
+              </span>
+            </button>
+          ))}
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+function OfferSkillDialog(props: { intent: string; onCreated: () => Promise<void> }) {
+  const { request, runAction, busy } = useRatelApp();
+  const [open, setOpen] = useState(false);
+  const [phase, setPhase] = useState<"idle" | "generating" | "error">("idle");
+  const [editing, setEditing] = useState(false);
+  const [error, setError] = useState("");
+  const [draft, setDraft] = useState<SkillDraft | null>(null);
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
+  const [tags, setTags] = useState("");
+  const [body, setBody] = useState("");
+  const [progress, setProgress] = useState(0);
+  const [filling, setFilling] = useState(false);
+
+  // Fake progress while authoring: fast start, easing toward a cap over ~40s
+  // (it never reaches 100 on its own). On completion `filling` pins it to 100.
+  useEffect(() => {
+    if (phase !== "generating" || filling) return;
+    const start = performance.now();
+    const CAP = 95;
+    const TAU = 12000;
+    const id = window.setInterval(() => {
+      const elapsed = performance.now() - start;
+      setProgress(Math.min(CAP, CAP * (1 - Math.exp(-elapsed / TAU))));
+    }, 150);
+    return () => window.clearInterval(id);
+  }, [phase, filling]);
+
+  const generate = useCallback(async () => {
+    setFilling(false);
+    setProgress(0);
+    setPhase("generating");
+    setError("");
+    try {
+      const { draft } = await offerSkill(request, props.intent);
+      setDraft(draft);
+      setName(draft.name);
+      setDescription(draft.description);
+      setTags((draft.tags ?? []).join(", "));
+      setBody(draft.body);
+      setEditing(false);
+      // Ramp to 100% fast, hold a beat so it's visible, then show the preview.
+      setFilling(true);
+      setProgress(100);
+      window.setTimeout(() => {
+        setPhase("idle");
+        setFilling(false);
+      }, 450);
+    } catch (err) {
+      setPhase("error");
+      setError(err instanceof Error ? err.message : "Failed to generate a skill draft");
+    }
+  }, [request, props.intent]);
+
+  const onOpenChange = (next: boolean) => {
+    setOpen(next);
+    if (next && !draft) void generate();
+  };
+
+  const tagList = tags
+    .split(",")
+    .map((t) => t.trim())
+    .filter(Boolean);
+
+  const create = async () => {
+    const ok = await runAction(`Created skill ${name.trim()}`, () =>
+      request("/api/skills", {
+        method: "POST",
+        body: { name: name.trim(), description: description.trim(), tags: tagList, body },
+      }),
+    );
+    if (ok) {
+      setOpen(false);
+      await props.onCreated();
+    }
+  };
+
+  const ready = phase === "idle" && draft;
+
+  return (
+    <Dialog onOpenChange={onOpenChange} open={open}>
+      <DialogTrigger render={<Button size="sm" variant="outline" />}>
+        <Sparkles />
+        Offer New Skills
+      </DialogTrigger>
+      <DialogContent className="flex max-h-[85vh] flex-col gap-4 sm:max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>Offer a new skill</DialogTitle>
+          <DialogDescription className="line-clamp-2">
+            Drafted for “{props.intent}”. Review, optionally edit, then save — it writes a SKILL.md
+            into Ratel's managed folder.
+          </DialogDescription>
+        </DialogHeader>
+
+        {/* Only this middle region scrolls; header + footer stay put. */}
+        <div className="min-h-0 flex-1 overflow-y-auto pr-1">
+          {phase === "generating" && (
+            <div className="grid gap-4 py-8">
+              <div className="flex items-center gap-3">
+                <PrismSweep dotSize={4} pattern="full" size={30} speed={1.4} />
+                <PixelProgress className="flex-1" progress={progress} />
+              </div>
+              <p className="text-center font-medium text-sm">Authoring the skill…</p>
+            </div>
+          )}
+
+          {phase === "error" && (
+            <div className="grid gap-3 py-2">
+              <p className="text-destructive text-sm">{error}</p>
+              <p className="text-muted-foreground text-xs">
+                Configure a skill generator in Settings (an Anthropic API key, or the local{" "}
+                <code className="font-mono">claude</code> CLI on PATH), then try again.
+              </p>
+              <Button onClick={() => void generate()} size="sm" variant="outline">
+                Retry
+              </Button>
+            </div>
+          )}
+
+          {ready && !editing && (
+            <div className="grid gap-3">
+              <div>
+                <code className="rounded bg-muted px-1.5 py-0.5 font-mono text-xs">{name}</code>
+                <p className="mt-1.5 font-medium text-sm">{description}</p>
+              </div>
+              {tagList.length > 0 && (
+                <div className="flex flex-wrap gap-1">
+                  {tagList.map((t) => (
+                    <span
+                      key={t}
+                      className="rounded bg-muted px-1.5 py-0.5 text-muted-foreground text-xs"
+                    >
+                      {t}
+                    </span>
+                  ))}
+                </div>
+              )}
+              <div className="rounded-md border border-border bg-card p-3">
+                <Markdown>{body || "_(no instructions)_"}</Markdown>
+              </div>
+            </div>
+          )}
+
+          {ready && editing && (
+            <div className="grid gap-3">
+              <div className="grid gap-1.5">
+                <Label htmlFor="offer-name">Name</Label>
+                <Input id="offer-name" onChange={(e) => setName(e.target.value)} value={name} />
+              </div>
+              <div className="grid gap-1.5">
+                <Label htmlFor="offer-description">Description</Label>
+                <Textarea
+                  id="offer-description"
+                  onChange={(e) => setDescription(e.target.value)}
+                  value={description}
+                />
+              </div>
+              <div className="grid gap-1.5">
+                <Label htmlFor="offer-tags">Tags (comma-separated)</Label>
+                <Input id="offer-tags" onChange={(e) => setTags(e.target.value)} value={tags} />
+              </div>
+              <div className="grid gap-1.5">
+                <Label htmlFor="offer-body">Instructions</Label>
+                <Textarea
+                  className="min-h-48 font-mono text-xs"
+                  id="offer-body"
+                  onChange={(e) => setBody(e.target.value)}
+                  value={body}
+                />
+              </div>
+            </div>
+          )}
+        </div>
+
+        <DialogFooter>
+          <DialogClose render={<Button size="sm" variant="outline" />}>Cancel</DialogClose>
+          {ready && (
+            <Button onClick={() => setEditing((e) => !e)} size="sm" variant="outline">
+              {editing ? "Preview" : "Edit"}
+            </Button>
+          )}
+          <Button
+            disabled={busy || !ready || name.trim() === ""}
+            onClick={() => void create()}
+            size="sm"
+          >
+            Create skill
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function AnalysisSettingsDialog() {
+  const { request, runAction, busy } = useRatelApp();
+  const [open, setOpen] = useState(false);
+  const [secretMask, setSecretMask] = useState("");
+  const [form, setForm] = useState<AnalysisSettings>({});
+  // Numeric fields are kept as raw strings so partial input (e.g. "1.") types cleanly.
+  const [nums, setNums] = useState<Record<string, string>>({});
+
+  const update = (patch: AnalysisSettings) => setForm((prev) => ({ ...prev, ...patch }));
+  const setNum = (key: string, value: string) => setNums((n) => ({ ...n, [key]: value }));
+
+  const onOpenChange = async (next: boolean) => {
+    setOpen(next);
+    if (next) {
+      try {
+        const res = await fetchAnalysisSettings(request);
+        const a = res.analysis ?? {};
+        setForm(a);
+        setSecretMask(res.secretMask);
+        setNums({
+          everyNMessages: numToStr(a.cadence?.everyNMessages),
+          minScore: numToStr(a.coverage?.minScore),
+          relativeRatio: numToStr(a.coverage?.relativeRatio),
+          maxSkills: numToStr(a.coverage?.maxSkills),
+        });
+      } catch {
+        setForm({});
+      }
+    }
+  };
+
+  const save = async () => {
+    const next: AnalysisSettings = {
+      ...form,
+      cadence: { ...form.cadence, everyNMessages: numberOrUndefined(nums.everyNMessages) },
+      coverage: {
+        minScore: floatOrUndefined(nums.minScore),
+        relativeRatio: floatOrUndefined(nums.relativeRatio),
+        maxSkills: numberOrUndefined(nums.maxSkills),
+      },
+    };
+    const ok = await runAction("Saved analysis settings", () =>
+      saveAnalysisSettings(request, next),
+    );
+    if (ok) setOpen(false);
+  };
+
+  const cadence = form.cadence ?? {};
+  const extractor = form.extractor ?? {};
+  const skillGen = form.skillGen ?? {};
+  const extractorProvider = extractor.provider ?? "naive";
+  const skillGenProvider = skillGen.provider ?? "auto";
+
+  return (
+    <Dialog onOpenChange={(n) => void onOpenChange(n)} open={open}>
+      <DialogTrigger render={<Button className="h-10" size="sm" variant="outline" />}>
+        <Cog />
+        Settings
+      </DialogTrigger>
+      <DialogContent className="flex max-h-[85vh] flex-col gap-4 sm:max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>Analysis settings</DialogTitle>
+          <DialogDescription>
+            How chat is analyzed into intents, which model extracts them, how strictly they match
+            skills, and how new skills are generated. Saved to your user-scope Ratel config.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="min-h-0 flex-1 space-y-4 overflow-y-auto overflow-x-hidden pr-1">
+          <SettingRow
+            control={
+              <Switch
+                checked={form.enabled ?? true}
+                onCheckedChange={(v) => update({ enabled: v })}
+              />
+            }
+            hint="When off, Ratel stops capturing chat and running intent analysis."
+            label="Enabled"
+          />
+
+          <SettingsSection
+            title="Cadence"
+            hint="When analysis is due (manual Run now always works)."
+          >
+            <div className="grid items-end gap-3 sm:grid-cols-2">
+              <Field htmlFor="cadence-n" label="Every N messages">
+                <Input
+                  id="cadence-n"
+                  inputMode="numeric"
+                  onChange={(e) => setNum("everyNMessages", e.target.value)}
+                  placeholder="10"
+                  value={nums.everyNMessages ?? ""}
+                />
+              </Field>
+              <SettingRow
+                control={
+                  <Switch
+                    checked={cadence.onIdle ?? false}
+                    onCheckedChange={(v) => update({ cadence: { ...cadence, onIdle: v } })}
+                  />
+                }
+                hint="Also analyze when a session stops."
+                label="On idle"
+              />
+            </div>
+          </SettingsSection>
+
+          <SettingsSection
+            title="Extractor"
+            hint="The model that turns chat into claims + intents."
+          >
+            <div className="grid gap-3 sm:grid-cols-2">
+              <Field label="Provider">
+                <Select
+                  onValueChange={(v) =>
+                    update({ extractor: { ...extractor, provider: v as never } })
+                  }
+                  value={extractorProvider}
+                >
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="http">HTTP endpoint (sidecar / remote)</SelectItem>
+                    <SelectItem value="cloud">Cloud</SelectItem>
+                    <SelectItem value="naive">Naive (no model)</SelectItem>
+                  </SelectContent>
+                </Select>
+              </Field>
+              {extractorProvider !== "naive" && (
+                <Field htmlFor="ex-endpoint" label="Endpoint URL">
+                  <Input
+                    id="ex-endpoint"
+                    onChange={(e) =>
+                      update({ extractor: { ...extractor, endpoint: e.target.value } })
+                    }
+                    placeholder="http://127.0.0.1:8723"
+                    value={extractor.endpoint ?? ""}
+                  />
+                </Field>
+              )}
+              {/* Model + key only matter for a cloud endpoint that serves multiple models;
+                  the local sidecar serves whatever it was launched with and ignores them. */}
+              {extractorProvider === "cloud" && (
+                <>
+                  <Field htmlFor="ex-model" label="Model">
+                    <Input
+                      id="ex-model"
+                      onChange={(e) =>
+                        update({ extractor: { ...extractor, model: e.target.value } })
+                      }
+                      placeholder="claim-extractor-4B"
+                      value={extractor.model ?? ""}
+                    />
+                  </Field>
+                  <Field htmlFor="ex-key" label="API key">
+                    <Input
+                      id="ex-key"
+                      onChange={(e) =>
+                        update({ extractor: { ...extractor, apiKey: e.target.value } })
+                      }
+                      placeholder={secretMask ? "•••• (saved)" : "required for cloud"}
+                      type="password"
+                      value={extractor.apiKey ?? ""}
+                    />
+                  </Field>
+                </>
+              )}
+            </div>
+            {extractorProvider === "http" && (
+              <p className="px-1 text-muted-foreground text-xs">
+                The sidecar serves whichever model it was started with — set it in the sidecar's{" "}
+                <code className="font-mono">settings.json</code> (or{" "}
+                <code className="font-mono">CLAIM_EXTRACTOR_MODEL</code>), not here.
+              </p>
+            )}
+            {extractorProvider === "naive" && (
+              <p className="px-1 text-muted-foreground text-xs">
+                Naive mode needs no model — it records one intent per user message (good for testing
+                the pipeline).
+              </p>
+            )}
+          </SettingsSection>
+
+          <SettingsSection
+            title="Coverage matching"
+            hint="How strictly intents match skills (BM25). Higher min score = fewer, stronger matches; lower relative cutoff = more skills per intent."
+          >
+            <div className="grid gap-3 sm:grid-cols-3">
+              <Field htmlFor="cov-min" label="Min score">
+                <Input
+                  id="cov-min"
+                  inputMode="decimal"
+                  onChange={(e) => setNum("minScore", e.target.value)}
+                  placeholder="1.0"
+                  value={nums.minScore ?? ""}
+                />
+              </Field>
+              <Field htmlFor="cov-ratio" label="Relative cutoff (0–1)">
+                <Input
+                  id="cov-ratio"
+                  inputMode="decimal"
+                  onChange={(e) => setNum("relativeRatio", e.target.value)}
+                  placeholder="0.6"
+                  value={nums.relativeRatio ?? ""}
+                />
+              </Field>
+              <Field htmlFor="cov-max" label="Max skills">
+                <Input
+                  id="cov-max"
+                  inputMode="numeric"
+                  onChange={(e) => setNum("maxSkills", e.target.value)}
+                  placeholder="4"
+                  value={nums.maxSkills ?? ""}
+                />
+              </Field>
+            </div>
+          </SettingsSection>
+
+          <SettingsSection title="Skill generation" hint="Used by “Offer New Skills”.">
+            <div className="grid gap-3 sm:grid-cols-2">
+              <Field label="Provider">
+                <Select
+                  onValueChange={(v) => update({ skillGen: { ...skillGen, provider: v as never } })}
+                  value={skillGenProvider}
+                >
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="auto">Auto (API key if set, else CLI)</SelectItem>
+                    <SelectItem value="anthropic-api">Anthropic API</SelectItem>
+                    <SelectItem value="claude-cli">Local claude CLI</SelectItem>
+                  </SelectContent>
+                </Select>
+              </Field>
+              {skillGenProvider !== "claude-cli" && (
+                <Field htmlFor="sg-key" label="Anthropic API key">
+                  <Input
+                    id="sg-key"
+                    onChange={(e) => update({ skillGen: { ...skillGen, apiKey: e.target.value } })}
+                    placeholder={
+                      secretMask
+                        ? "•••• (saved)"
+                        : skillGenProvider === "auto"
+                          ? "optional"
+                          : "required"
+                    }
+                    type="password"
+                    value={skillGen.apiKey ?? ""}
+                  />
+                </Field>
+              )}
+            </div>
+            {skillGenProvider === "claude-cli" && (
+              <p className="px-1 text-muted-foreground text-xs">
+                Uses your local <code className="font-mono">claude</code> CLI — no API key needed.
+              </p>
+            )}
+          </SettingsSection>
+        </div>
+
+        <DialogFooter>
+          <DialogClose render={<Button size="sm" variant="outline" />}>Cancel</DialogClose>
+          <Button disabled={busy} onClick={() => void save()} size="sm">
+            Save
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function SettingsSection(props: { title: string; hint?: string; children: ReactNode }) {
+  return (
+    <fieldset className="grid gap-3 rounded-md border border-border p-3">
+      <legend className="px-1 font-medium text-sm">{props.title}</legend>
+      {props.hint && <p className="-mt-1 px-1 text-muted-foreground text-xs">{props.hint}</p>}
+      {props.children}
+    </fieldset>
+  );
+}
+
+function Field(props: { label: string; htmlFor?: string; children: ReactNode }) {
+  return (
+    <div className="grid min-w-0 gap-1.5">
+      <Label htmlFor={props.htmlFor}>{props.label}</Label>
+      {props.children}
+    </div>
+  );
+}
+
+function numToStr(value: number | undefined): string {
+  return value === undefined ? "" : String(value);
+}
+
+function floatOrUndefined(value: string): number | undefined {
+  const trimmed = value.trim();
+  if (trimmed === "") return undefined;
+  const n = Number(trimmed);
+  return Number.isFinite(n) && n >= 0 ? n : undefined;
+}
+
+function SettingRow(props: { label: string; hint?: string; control: ReactNode }) {
+  return (
+    <div className="flex items-center justify-between gap-3">
+      <div className="grid gap-0.5">
+        <span className="font-medium text-sm">{props.label}</span>
+        {props.hint && <span className="text-muted-foreground text-xs">{props.hint}</span>}
+      </div>
+      {props.control}
+    </div>
+  );
+}
+
+function EmptyState(props: { title: string; description: string; children?: ReactNode }) {
+  return (
+    <section className="-mx-4 grid min-h-72 flex-1 place-items-center border-border border-y bg-muted/15 px-4 py-8 text-center sm:-mx-6 sm:px-6">
+      <div className="grid max-w-md gap-3">
+        <div className="mx-auto rounded-md bg-muted p-2 text-brand-green">
+          <Target className="size-5" />
+        </div>
+        <div>
+          <h3 className="font-medium">{props.title}</h3>
+          <p className="mt-1 text-muted-foreground text-sm">{props.description}</p>
+        </div>
+        {props.children && <div>{props.children}</div>}
+      </div>
+    </section>
+  );
+}
+
+function numberOrUndefined(value: string): number | undefined {
+  const trimmed = value.trim();
+  if (trimmed === "") return undefined;
+  const n = Number(trimmed);
+  return Number.isInteger(n) && n > 0 ? n : undefined;
+}

--- a/packages/ui/src/pages/IntentsPage.tsx
+++ b/packages/ui/src/pages/IntentsPage.tsx
@@ -1,9 +1,12 @@
 import { useNavigate } from "@tanstack/react-router";
 import {
   Activity,
+  CheckCircle2,
   ChevronDown,
   ChevronRight,
   Cog,
+  Eye,
+  EyeOff,
   MessagesSquare,
   Play,
   RefreshCw,
@@ -11,8 +14,9 @@ import {
   Sparkles,
   Target,
   Trash2,
+  XCircle,
 } from "lucide-react";
-import { type ReactNode, useCallback, useEffect, useRef, useState } from "react";
+import { type ChangeEvent, type ReactNode, useCallback, useEffect, useRef, useState } from "react";
 import { chatPath, skillPath, useRatelApp } from "@/App";
 import { Markdown } from "@/components/markdown";
 import {
@@ -58,6 +62,7 @@ import {
   clearIntents,
   clearOfferJob,
   deleteIntent,
+  type ExtractorHealth,
   estimateGenMs,
   fetchAnalysisSettings,
   fetchChats,
@@ -74,6 +79,7 @@ import {
   type SkillDraft,
   saveAnalysisSettings,
   skillGenModelOptions,
+  testExtractor,
 } from "@/lib/intents";
 import { ObservabilityPanel } from "@/pages/ObservabilityPage";
 
@@ -1105,17 +1111,76 @@ function AnalysisSettingsDialog() {
   // Numeric fields are kept as raw strings so partial input (e.g. "1.") types cleanly.
   const [nums, setNums] = useState<Record<string, string>>({});
 
+  // Connection-test state for the extractor endpoint (the "Test connection" button).
+  const [testing, setTesting] = useState(false);
+  const [testResult, setTestResult] = useState<ExtractorHealth | null>(null);
+
+  // Secrets are never sent to the browser — the server returns a mask sentinel.
+  // We blank those fields (so the native reveal can't expose the sentinel) and
+  // remember which were saved, re-injecting the sentinel on submit for a field the
+  // user left untouched so a no-op save preserves the stored secret.
+  const [savedSecrets, setSavedSecrets] = useState({ extractor: false, skillGen: false });
+  const [secretTouched, setSecretTouched] = useState({ extractor: false, skillGen: false });
+
   const update = (patch: AnalysisSettings) => setForm((prev) => ({ ...prev, ...patch }));
   const setNum = (key: string, value: string) => setNums((n) => ({ ...n, [key]: value }));
 
+  // Editing the extractor invalidates any prior test result (it may now be stale).
+  const updateExtractor = (patch: Partial<NonNullable<AnalysisSettings["extractor"]>>) => {
+    setTestResult(null);
+    setForm((prev) => ({ ...prev, extractor: { ...prev.extractor, ...patch } }));
+  };
+
+  // Re-inject the mask sentinel for a saved secret the user didn't touch, so a
+  // no-op save/test preserves the stored value (the server swaps the sentinel back
+  // for the real secret). A touched-but-blank field is left blank → clears it.
+  const withPreservedSecrets = (f: AnalysisSettings): AnalysisSettings => {
+    const out: AnalysisSettings = { ...f };
+    if (savedSecrets.extractor && !secretTouched.extractor && !f.extractor?.apiKey) {
+      out.extractor = { ...f.extractor, apiKey: secretMask };
+    }
+    if (savedSecrets.skillGen && !secretTouched.skillGen && !f.skillGen?.apiKey) {
+      out.skillGen = { ...f.skillGen, apiKey: secretMask };
+    }
+    return out;
+  };
+
+  const runTest = async () => {
+    setTesting(true);
+    setTestResult(null);
+    try {
+      setTestResult(await testExtractor(request, withPreservedSecrets(form).extractor));
+    } catch (err) {
+      setTestResult({ ok: false, detail: err instanceof Error ? err.message : "Test failed" });
+    } finally {
+      setTesting(false);
+    }
+  };
+
   const onOpenChange = async (next: boolean) => {
     setOpen(next);
+    setTestResult(null);
+    setSecretTouched({ extractor: false, skillGen: false });
     if (next) {
       try {
         const res = await fetchAnalysisSettings(request);
         const a = res.analysis ?? {};
-        setForm(a);
+        // A saved secret arrives as the mask sentinel; blank the field but remember
+        // it's saved (shown via a "saved" placeholder), so the reveal button can't
+        // expose the sentinel and a no-op save still preserves the real value.
+        const exSaved = Boolean(a.extractor) && a.extractor?.apiKey === res.secretMask;
+        const sgSaved = Boolean(a.skillGen) && a.skillGen?.apiKey === res.secretMask;
+        setForm({
+          ...a,
+          ...(a.extractor && {
+            extractor: { ...a.extractor, apiKey: exSaved ? "" : a.extractor.apiKey },
+          }),
+          ...(a.skillGen && {
+            skillGen: { ...a.skillGen, apiKey: sgSaved ? "" : a.skillGen.apiKey },
+          }),
+        });
         setSecretMask(res.secretMask);
+        setSavedSecrets({ extractor: exSaved, skillGen: sgSaved });
         setNums({
           everyNMessages: numToStr(a.cadence?.everyNMessages),
           recentHours: numToStr(a.cadence?.recentHours),
@@ -1125,12 +1190,13 @@ function AnalysisSettingsDialog() {
         });
       } catch {
         setForm({});
+        setSavedSecrets({ extractor: false, skillGen: false });
       }
     }
   };
 
   const save = async () => {
-    const next: AnalysisSettings = {
+    const next: AnalysisSettings = withPreservedSecrets({
       ...form,
       cadence: {
         ...form.cadence,
@@ -1143,17 +1209,34 @@ function AnalysisSettingsDialog() {
         relativeRatio: floatOrUndefined(nums.relativeRatio),
         maxSkills: numberOrUndefined(nums.maxSkills),
       },
-    };
+    });
     const ok = await runAction("Saved analysis settings", () =>
       saveAnalysisSettings(request, next),
     );
     if (ok) setOpen(false);
   };
 
+  // Editing a secret field marks it touched (so we don't re-inject the sentinel)
+  // and clears any stale test result.
+  const setExtractorKey = (value: string) => {
+    setSecretTouched((s) => ({ ...s, extractor: true }));
+    updateExtractor({ apiKey: value });
+  };
+  const setSkillGenKey = (value: string) => {
+    setSecretTouched((s) => ({ ...s, skillGen: true }));
+    update({ skillGen: { ...form.skillGen, apiKey: value } });
+  };
+
   const cadence = form.cadence ?? {};
   const extractor = form.extractor ?? {};
   const skillGen = form.skillGen ?? {};
   const extractorProvider = extractor.provider ?? "naive";
+  // The dropdown offers just "http" (any HTTP endpoint) and "naive"; a legacy
+  // "cloud" config still behaves like http, so it maps to the http option here.
+  const providerValue = extractorProvider === "naive" ? "naive" : "http";
+  // Default to bearer (matches the legacy apiKey→Bearer behavior); switch to basic
+  // for the hosted endpoint. A blank credential = no auth (a local sidecar needs none).
+  const authScheme = extractor.authScheme ?? (extractor.username ? "basic" : "bearer");
   const skillGenProvider = skillGen.provider ?? "auto";
 
   return (
@@ -1236,22 +1319,19 @@ function AnalysisSettingsDialog() {
 
           <SettingsSection
             title="Extractor"
-            hint="The model that turns chat into claims + intents."
+            hint="Turns chat into claims + intents. A local sidecar and a hosted endpoint speak the same contract, so switching is just the URL (and auth)."
           >
             <div className="grid gap-3 sm:grid-cols-2">
               <Field label="Provider">
                 <Select
-                  onValueChange={(v) =>
-                    update({ extractor: { ...extractor, provider: v as never } })
-                  }
-                  value={extractorProvider}
+                  onValueChange={(v) => updateExtractor({ provider: v as never })}
+                  value={providerValue}
                 >
                   <SelectTrigger>
                     <SelectValue />
                   </SelectTrigger>
                   <SelectContent>
-                    <SelectItem value="http">HTTP endpoint (sidecar / remote)</SelectItem>
-                    <SelectItem value="cloud">Cloud</SelectItem>
+                    <SelectItem value="http">HTTP endpoint</SelectItem>
                     <SelectItem value="naive">Naive (no model)</SelectItem>
                   </SelectContent>
                 </Select>
@@ -1260,47 +1340,91 @@ function AnalysisSettingsDialog() {
                 <Field htmlFor="ex-endpoint" label="Endpoint URL">
                   <Input
                     id="ex-endpoint"
-                    onChange={(e) =>
-                      update({ extractor: { ...extractor, endpoint: e.target.value } })
-                    }
+                    onChange={(e) => updateExtractor({ endpoint: e.target.value })}
                     placeholder="http://127.0.0.1:8723"
                     value={extractor.endpoint ?? ""}
                   />
                 </Field>
               )}
-              {/* Model + key only matter for a cloud endpoint that serves multiple models;
-                  the local sidecar serves whatever it was launched with and ignores them. */}
-              {extractorProvider === "cloud" && (
-                <>
-                  <Field htmlFor="ex-model" label="Model">
-                    <Input
-                      id="ex-model"
-                      onChange={(e) =>
-                        update({ extractor: { ...extractor, model: e.target.value } })
-                      }
-                      placeholder="claim-extractor-4B"
-                      value={extractor.model ?? ""}
-                    />
-                  </Field>
-                  <Field htmlFor="ex-key" label="API key">
-                    <Input
-                      id="ex-key"
-                      onChange={(e) =>
-                        update({ extractor: { ...extractor, apiKey: e.target.value } })
-                      }
-                      placeholder={secretMask ? "•••• (saved)" : "required for cloud"}
-                      type="password"
-                      value={extractor.apiKey ?? ""}
-                    />
-                  </Field>
-                </>
-              )}
             </div>
-            {extractorProvider === "http" && (
+
+            {extractorProvider !== "naive" && (
+              <>
+                <Field label="Authentication">
+                  <Select
+                    onValueChange={(v) => updateExtractor({ authScheme: v as "bearer" | "basic" })}
+                    value={authScheme}
+                  >
+                    <SelectTrigger>
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="basic">Basic auth</SelectItem>
+                      <SelectItem value="bearer">Bearer token</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </Field>
+                {authScheme === "basic" && (
+                  <Field htmlFor="ex-user" label="Username">
+                    <Input
+                      autoComplete="off"
+                      id="ex-user"
+                      onChange={(e) => updateExtractor({ username: e.target.value })}
+                      placeholder="e.g. ratel"
+                      value={extractor.username ?? ""}
+                    />
+                  </Field>
+                )}
+                <Field htmlFor="ex-key" label={authScheme === "basic" ? "Password" : "API token"}>
+                  <PasswordInput
+                    id="ex-key"
+                    onChange={(e) => setExtractorKey(e.target.value)}
+                    placeholder={
+                      savedSecrets.extractor
+                        ? "•••• saved (type to replace)"
+                        : "Leave blank for a local sidecar (no auth)"
+                    }
+                    value={extractor.apiKey ?? ""}
+                  />
+                </Field>
+                <div className="flex flex-wrap items-center gap-3">
+                  <Button
+                    disabled={testing || !extractor.endpoint}
+                    onClick={() => void runTest()}
+                    size="sm"
+                    type="button"
+                    variant="outline"
+                  >
+                    {testing ? <Spinner /> : null}
+                    Test connection
+                  </Button>
+                  {testResult ? (
+                    <span
+                      className={`inline-flex items-center gap-1.5 text-xs ${
+                        testResult.ok
+                          ? "text-emerald-600 dark:text-emerald-400"
+                          : "text-destructive"
+                      }`}
+                    >
+                      {testResult.ok ? (
+                        <CheckCircle2 className="size-4" />
+                      ) : (
+                        <XCircle className="size-4" />
+                      )}
+                      {testResult.ok ? "Connected" : "Failed"}
+                      {testResult.detail ? (
+                        <span className="text-muted-foreground">- {testResult.detail}</span>
+                      ) : null}
+                    </span>
+                  ) : null}
+                </div>
+              </>
+            )}
+            {extractorProvider !== "naive" && (
               <p className="px-1 text-muted-foreground text-xs">
-                The sidecar serves whichever model it was started with - set it in the sidecar's{" "}
-                <code className="font-mono">settings.json</code> (or{" "}
-                <code className="font-mono">CLAIM_EXTRACTOR_MODEL</code>), not here.
+                Local sidecar or hosted endpoint - same contract, just the URL. A local sidecar
+                needs no auth (leave the credential blank); a hosted endpoint needs Basic or Bearer
+                auth. Each endpoint serves its own model, so there's nothing to pick here.
               </p>
             )}
             {extractorProvider === "naive" && (
@@ -1365,17 +1489,16 @@ function AnalysisSettingsDialog() {
               </Field>
               {skillGenProvider !== "claude-cli" && (
                 <Field htmlFor="sg-key" label="Anthropic API key">
-                  <Input
+                  <PasswordInput
                     id="sg-key"
-                    onChange={(e) => update({ skillGen: { ...skillGen, apiKey: e.target.value } })}
+                    onChange={(e) => setSkillGenKey(e.target.value)}
                     placeholder={
-                      secretMask
-                        ? "•••• (saved)"
+                      savedSecrets.skillGen
+                        ? "•••• saved (type to replace)"
                         : skillGenProvider === "auto"
                           ? "optional"
                           : "required"
                     }
-                    type="password"
                     value={skillGen.apiKey ?? ""}
                   />
                 </Field>
@@ -1443,6 +1566,39 @@ function Field(props: { label: string; htmlFor?: string; children: ReactNode }) 
     <div className="grid min-w-0 gap-1.5">
       <Label htmlFor={props.htmlFor}>{props.label}</Label>
       {props.children}
+    </div>
+  );
+}
+
+/** A password input with a show/hide toggle. Reveals only what the user typed —
+ *  saved secrets arrive blanked, so the toggle can never expose a stored value. */
+function PasswordInput(props: {
+  id?: string;
+  value: string;
+  onChange: (e: ChangeEvent<HTMLInputElement>) => void;
+  placeholder?: string;
+}) {
+  const [show, setShow] = useState(false);
+  return (
+    <div className="relative">
+      <Input
+        autoComplete="off"
+        className="pr-10"
+        id={props.id}
+        onChange={props.onChange}
+        placeholder={props.placeholder}
+        type={show ? "text" : "password"}
+        value={props.value}
+      />
+      <button
+        aria-label={show ? "Hide" : "Show"}
+        className="absolute inset-y-0 right-0 flex items-center px-3 text-muted-foreground transition-colors hover:text-foreground"
+        onClick={() => setShow((s) => !s)}
+        tabIndex={-1}
+        type="button"
+      >
+        {show ? <EyeOff className="size-4" /> : <Eye className="size-4" />}
+      </button>
     </div>
   );
 }

--- a/packages/ui/src/pages/IntentsPage.tsx
+++ b/packages/ui/src/pages/IntentsPage.tsx
@@ -18,6 +18,12 @@ import {
 } from "lucide-react";
 import { type ChangeEvent, type ReactNode, useCallback, useEffect, useRef, useState } from "react";
 import { chatPath, skillPath, useRatelApp } from "@/App";
+import {
+  IntentSearchingRow,
+  PLACEHOLDER_EXIT_MS,
+  usePresence,
+  useStreamingOrder,
+} from "@/components/intent-stream";
 import { Markdown } from "@/components/markdown";
 import {
   PageHeader,
@@ -81,6 +87,7 @@ import {
   skillGenModelOptions,
   testExtractor,
 } from "@/lib/intents";
+import { cn } from "@/lib/utils";
 import { ObservabilityPanel } from "@/pages/ObservabilityPage";
 
 type LoadState =
@@ -351,6 +358,7 @@ export function IntentsPage() {
               jobs={offerJobs}
               onReload={reload}
               sessionTitles={sessionTitles}
+              streaming={showRunning}
             />
           ) : (
             <BySessionView
@@ -445,22 +453,44 @@ function IntentList(props: {
   sessionTitles: SessionTitles;
   jobs: OfferJobs;
   onReload: () => Promise<void>;
+  /** A run is streaming results into this list: animate new rows in and show the slot. */
+  streaming?: boolean;
 }) {
+  const streaming = props.streaming ?? false;
+  const { items, entering } = useStreamingOrder(props.intents, streaming);
   const [shown, setShown] = useState(INTENTS_PAGE);
-  const visible = props.intents.slice(0, shown);
-  const remaining = props.intents.length - visible.length;
+  // Keep the searching slot mounted through its collapse animation after a run ends.
+  const placeholder = usePresence(streaming, PLACEHOLDER_EXIT_MS);
+
+  // While a run streams in, reveal everything so each new intent (and the slot) is
+  // visible as it lands; we never collapse back, so the list doesn't jump when it ends.
+  useEffect(() => {
+    if (streaming) setShown((n) => Math.max(n, items.length));
+  }, [streaming, items.length]);
+
+  const visible = items.slice(0, shown);
+  const remaining = items.length - visible.length;
   return (
     <div className="grid gap-2">
       <ul className="grid gap-2">
         {visible.map((intent) => (
-          <IntentRow
-            initialJob={props.jobs[intent.content]}
-            intent={intent}
+          <li
+            // The wrapper li grows the row into place on arrival; the inner overflow
+            // clip is what makes the height animation read as a slide into the slot.
+            className={cn("grid", entering.has(intent.content) && "animate-intent-enter")}
             key={intent.content}
-            onReload={props.onReload}
-            sessionTitles={props.sessionTitles}
-          />
+          >
+            <div className="overflow-hidden">
+              <IntentRow
+                initialJob={props.jobs[intent.content]}
+                intent={intent}
+                onReload={props.onReload}
+                sessionTitles={props.sessionTitles}
+              />
+            </div>
+          </li>
         ))}
+        {placeholder.mounted && <IntentSearchingRow exiting={placeholder.exiting} />}
       </ul>
       {remaining > 0 && (
         <div className="flex justify-center pt-1">
@@ -488,7 +518,7 @@ function IntentRow(props: {
   // Emphasize frequency when an intent shows up across many sessions.
   const frequent = seen >= 3;
   return (
-    <li className="flex items-start gap-3 rounded-md border border-border bg-card p-3">
+    <div className="flex items-start gap-3 rounded-md border border-border bg-card p-3">
       <Target className="mt-0.5 size-4 shrink-0 text-muted-foreground/50" />
       <div className="min-w-0 flex-1">
         <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
@@ -525,7 +555,7 @@ function IntentRow(props: {
         />
         <DeleteIntentButton content={intent.content} onDeleted={props.onReload} />
       </div>
-    </li>
+    </div>
   );
 }
 

--- a/packages/ui/src/pages/ObservabilityPage.tsx
+++ b/packages/ui/src/pages/ObservabilityPage.tsx
@@ -1,0 +1,510 @@
+import { Activity, ChevronDown, ChevronRight } from "lucide-react";
+import { type ReactNode, useCallback, useEffect, useState } from "react";
+import useMeasure from "react-use-measure";
+import { useRatelApp } from "@/App";
+import { Button } from "@/components/ui/button";
+import { fetchObservability, type ObservabilityResponse, type RunLogEntry } from "@/lib/intents";
+
+type LoadState =
+  | { status: "loading" }
+  | { status: "error"; message: string }
+  | { status: "ready"; data: ObservabilityResponse };
+
+/**
+ * Analysis-run telemetry, rendered as a tab inside the Intents page (no page
+ * header of its own — the Intents page provides it).
+ */
+export function ObservabilityPanel() {
+  const { request } = useRatelApp();
+  const [state, setState] = useState<LoadState>({ status: "loading" });
+
+  const load = useCallback(async () => {
+    setState({ status: "loading" });
+    try {
+      const data = await fetchObservability(request);
+      setState({ status: "ready", data });
+    } catch (err) {
+      setState({
+        status: "error",
+        message: err instanceof Error ? err.message : "Failed to load observability data",
+      });
+    }
+  }, [request]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const data = state.status === "ready" ? state.data : null;
+
+  return (
+    <div className="flex flex-col gap-4">
+      <p className="px-1 text-muted-foreground text-sm">
+        A history of every analysis run — when Ratel read your captured chats and extracted intents,
+        how long it took, and what it found. Use it to confirm analysis is running and spot
+        failures.
+      </p>
+
+      <Glossary />
+
+      {state.status === "loading" && (
+        <p className="px-1 text-muted-foreground text-sm">Loading observability data…</p>
+      )}
+
+      {state.status === "error" && (
+        <EmptyState title="Couldn't load observability data" description={state.message}>
+          <Button onClick={() => void load()} size="sm" variant="outline">
+            Retry
+          </Button>
+        </EmptyState>
+      )}
+
+      {data && data.runs.length === 0 && (
+        <EmptyState
+          title="No analysis runs recorded yet."
+          description="Click “Run now” above to analyze your captured chats; each run's timing and per-session results show up here."
+        />
+      )}
+
+      {data && data.runs.length > 0 && (
+        <>
+          <SummaryHeader runs={data.runs} summary={data.summary} />
+          <RunsChart runs={data.runs} />
+          <RunsList runs={data.runs} />
+        </>
+      )}
+    </div>
+  );
+}
+
+function SummaryHeader(props: { runs: RunLogEntry[]; summary: ObservabilityResponse["summary"] }) {
+  const { runs, summary } = props;
+
+  // Stats the server summary doesn't already give us, derived from the run log.
+  const totalIntents = runs.reduce((sum, run) => sum + run.totalIntents, 0);
+  let totalSessions = 0;
+  let cachedSessions = 0;
+  for (const run of runs) {
+    totalSessions += run.sessions.length;
+    cachedSessions += run.sessions.filter((session) => session.cacheHit).length;
+  }
+  const cacheHitRate =
+    totalSessions > 0 ? `${Math.round((cachedSessions / totalSessions) * 100)}%` : "—";
+
+  return (
+    <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-6">
+      <SummaryCard
+        hint="How many times analysis has run"
+        label="Total runs"
+        value={String(summary.totalRuns)}
+      />
+      <SummaryCard
+        hint="When analysis last ran"
+        label="Last run"
+        value={summary.lastRunAt ? relativeTime(summary.lastRunAt) : "—"}
+      />
+      <SummaryCard
+        hint="Typical time one run takes"
+        label="Avg duration"
+        value={formatDuration(summary.avgDurationMs)}
+      />
+      <SummaryCard
+        hint="Intents extracted across all runs"
+        label="Intents found"
+        value={String(totalIntents)}
+      />
+      <SummaryCard
+        hint="Sessions reused instead of re-run"
+        label="Cache hit rate"
+        value={cacheHitRate}
+      />
+      <SummaryCard
+        hint="Intents with no matching skill, per run"
+        label="Avg gaps / run"
+        value={summary.avgGapsPerRun.toFixed(1)}
+      />
+    </div>
+  );
+}
+
+function SummaryCard(props: { label: string; value: string; hint?: string }) {
+  return (
+    <div className="rounded-md border border-border bg-card p-3">
+      <p className="text-muted-foreground text-xs">{props.label}</p>
+      <p className="mt-0.5 font-medium text-lg">{props.value}</p>
+      {props.hint && <p className="mt-0.5 text-[11px] text-muted-foreground/70">{props.hint}</p>}
+    </div>
+  );
+}
+
+/** Collapsible plain-language key for the terms on this page. */
+function Glossary() {
+  return (
+    <details className="rounded-md border border-border bg-muted/20 px-3 py-2 text-sm">
+      <summary className="cursor-pointer font-medium text-muted-foreground">
+        How to read this page
+      </summary>
+      <dl className="mt-2 grid gap-2 sm:grid-cols-2">
+        <GlossaryItem term="Run">
+          One pass of the analyzer over your captured chats. Triggered by “Run now” or, if enabled,
+          automatically on a timer.
+        </GlossaryItem>
+        <GlossaryItem term="Trigger">
+          What started the run — <span className="font-mono text-xs">manual</span> (you clicked Run
+          now), <span className="font-mono text-xs">cadence</span> (the automatic timer), or{" "}
+          <span className="font-mono text-xs">idle</span> (a session went quiet).
+        </GlossaryItem>
+        <GlossaryItem term="Intent">
+          Something you repeatedly try to get an agent to do, extracted from the conversation.
+        </GlossaryItem>
+        <GlossaryItem term="Gap">
+          An intent that no managed skill covers yet — a candidate for “Offer New Skills” on the
+          Intents page.
+        </GlossaryItem>
+        <GlossaryItem term="Session">
+          One captured chat that a run looked at. A run can process several sessions.
+        </GlossaryItem>
+        <GlossaryItem term="Cached">
+          The conversation hadn’t changed since last time, so the result was reused instead of
+          re-running the model — faster and cheaper.
+        </GlossaryItem>
+      </dl>
+    </details>
+  );
+}
+
+function GlossaryItem(props: { term: string; children: ReactNode }) {
+  return (
+    <div>
+      <dt className="font-medium text-foreground text-xs">{props.term}</dt>
+      <dd className="text-muted-foreground text-xs">{props.children}</dd>
+    </div>
+  );
+}
+
+// Fixed chart height; width is measured at runtime so the viewBox maps 1:1 to
+// pixels (no aspect-ratio stretching → round markers, undistorted lines).
+const CHART_H = 180;
+const CHART_PAD = { top: 16, right: 16, bottom: 22, left: 30 };
+const GRID_LINES = 3;
+
+interface ChartPoint {
+  key: string;
+  at: string;
+  totalIntents: number;
+  totalGaps: number;
+  x: number;
+  intentY: number;
+  gapY: number;
+}
+
+function RunsChart(props: { runs: RunLogEntry[] }) {
+  const [ref, bounds] = useMeasure();
+  const width = Math.max(320, Math.round(bounds.width));
+  const plotW = width - CHART_PAD.left - CHART_PAD.right;
+  const plotH = CHART_H - CHART_PAD.top - CHART_PAD.bottom;
+
+  // Oldest-to-newest, capped to the last 30 runs. A dependency-free inline-SVG
+  // line chart — recharts is intentionally avoided (it broke the dev bundle).
+  const recent = [...props.runs].slice(0, 30).reverse();
+  const max = Math.max(1, ...recent.map((run) => Math.max(run.totalIntents, run.totalGaps)));
+
+  const points: ChartPoint[] = recent.map((run, index) => {
+    // One point centers in the plot; otherwise spread evenly left→right.
+    const x =
+      recent.length === 1
+        ? CHART_PAD.left + plotW / 2
+        : CHART_PAD.left + (plotW * index) / (recent.length - 1);
+    const yFor = (value: number) => CHART_PAD.top + plotH - (value / max) * plotH;
+    return {
+      key: run.runId,
+      at: run.at,
+      totalIntents: run.totalIntents,
+      totalGaps: run.totalGaps,
+      x,
+      intentY: yFor(run.totalIntents),
+      gapY: yFor(run.totalGaps),
+    };
+  });
+
+  const intentPath = toPath(points, (p) => p.intentY);
+  const gapPath = toPath(points, (p) => p.gapY);
+  const baselineY = CHART_PAD.top + plotH;
+
+  return (
+    <section className="rounded-md border border-border bg-card p-3">
+      <div className="mb-2 flex items-center justify-between px-1">
+        <h2 className="font-medium text-sm">Intents &amp; gaps over time</h2>
+        <div className="flex items-center gap-3 text-muted-foreground text-xs">
+          <LegendSwatch color="var(--chart-1)" label="Intents" />
+          <LegendSwatch color="var(--chart-2)" label="Gaps" />
+        </div>
+      </div>
+      <div className="w-full" ref={ref}>
+        {bounds.width > 0 && (
+          <svg
+            aria-label="Intents and gaps per run over time"
+            height={CHART_H}
+            role="img"
+            viewBox={`0 0 ${width} ${CHART_H}`}
+            width={width}
+          >
+            {/* Horizontal gridlines. */}
+            {Array.from({ length: GRID_LINES }, (_, i) => {
+              const y = CHART_PAD.top + (plotH * i) / (GRID_LINES - 1);
+              return (
+                <line
+                  className="stroke-border"
+                  key={`grid-${y}`}
+                  opacity={i === GRID_LINES - 1 ? 0.9 : 0.4}
+                  strokeWidth={1}
+                  x1={CHART_PAD.left}
+                  x2={width - CHART_PAD.right}
+                  y1={y}
+                  y2={y}
+                />
+              );
+            })}
+
+            {/* Y-axis labels (max + 0). */}
+            <text
+              className="fill-muted-foreground"
+              fontSize={10}
+              textAnchor="end"
+              x={CHART_PAD.left - 6}
+              y={CHART_PAD.top + 3}
+            >
+              {max}
+            </text>
+            <text
+              className="fill-muted-foreground"
+              fontSize={10}
+              textAnchor="end"
+              x={CHART_PAD.left - 6}
+              y={baselineY + 3}
+            >
+              0
+            </text>
+
+            {/* Series lines. */}
+            <path
+              d={gapPath}
+              fill="none"
+              stroke="var(--chart-2)"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+            />
+            <path
+              d={intentPath}
+              fill="none"
+              stroke="var(--chart-1)"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+            />
+
+            {/* Markers with tooltips. */}
+            {points.map((p) => (
+              <g key={p.key}>
+                <circle cx={p.x} cy={p.gapY} fill="var(--chart-2)" r={3}>
+                  <title>{markerTitle(p)}</title>
+                </circle>
+                <circle cx={p.x} cy={p.intentY} fill="var(--chart-1)" r={3}>
+                  <title>{markerTitle(p)}</title>
+                </circle>
+              </g>
+            ))}
+          </svg>
+        )}
+      </div>
+    </section>
+  );
+}
+
+/** Build an SVG polyline `d` string; falls back to a tiny dot for a single point. */
+function toPath(points: ChartPoint[], y: (p: ChartPoint) => number): string {
+  if (points.length === 0) return "";
+  if (points.length === 1) {
+    const p = points[0];
+    return `M ${p.x} ${y(p)} L ${p.x} ${y(p)}`;
+  }
+  return points.map((p, i) => `${i === 0 ? "M" : "L"} ${p.x} ${y(p)}`).join(" ");
+}
+
+function markerTitle(p: ChartPoint): string {
+  const intents = `${p.totalIntents} intent${p.totalIntents === 1 ? "" : "s"}`;
+  const gaps = `${p.totalGaps} gap${p.totalGaps === 1 ? "" : "s"}`;
+  return `${shortDateTime(p.at)} · ${intents} / ${gaps}`;
+}
+
+function LegendSwatch(props: { color: string; label: string }) {
+  return (
+    <span className="inline-flex items-center gap-1">
+      <span className="size-2 rounded-sm" style={{ backgroundColor: props.color }} />
+      {props.label}
+    </span>
+  );
+}
+
+function RunsList(props: { runs: RunLogEntry[] }) {
+  return (
+    <div className="grid gap-2">
+      <span className="px-1 text-muted-foreground text-xs">
+        {props.runs.length} run{props.runs.length === 1 ? "" : "s"}
+      </span>
+      {props.runs.map((run) => (
+        <RunRow key={run.runId} run={run} />
+      ))}
+    </div>
+  );
+}
+
+function RunRow(props: { run: RunLogEntry }) {
+  const { run } = props;
+  const [open, setOpen] = useState(false);
+  const hasErrors = run.sessions.some((session) => !session.ok);
+  return (
+    <div className="rounded-md border border-border bg-card">
+      <button
+        className="flex w-full items-start gap-3 p-3 text-left"
+        onClick={() => setOpen((value) => !value)}
+        type="button"
+      >
+        {open ? (
+          <ChevronDown className="mt-0.5 size-4 shrink-0 text-muted-foreground/60" />
+        ) : (
+          <ChevronRight className="mt-0.5 size-4 shrink-0 text-muted-foreground/60" />
+        )}
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+            <strong className="font-medium text-sm">{relativeTime(run.at)}</strong>
+            <span className="text-muted-foreground text-xs">{run.trigger}</span>
+            {run.model && <Chip>{run.model}</Chip>}
+            {hasErrors && (
+              <Chip tone="error">{run.sessions.filter((session) => !session.ok).length} error</Chip>
+            )}
+          </div>
+          <div className="mt-1 flex flex-wrap items-center gap-x-2 gap-y-1 text-muted-foreground text-xs">
+            <span>{formatDuration(run.durationMs)}</span>
+            <span aria-hidden>·</span>
+            <span>
+              {run.totalIntents} intent{run.totalIntents === 1 ? "" : "s"} / {run.totalGaps} gap
+              {run.totalGaps === 1 ? "" : "s"}
+            </span>
+            <span aria-hidden>·</span>
+            <span>
+              {run.sessions.length} session{run.sessions.length === 1 ? "" : "s"}
+            </span>
+          </div>
+        </div>
+      </button>
+      {open && run.sessions.length > 0 && (
+        <div className="grid gap-1.5 border-border border-t p-3">
+          {run.sessions.map((session) => (
+            <div
+              className={
+                session.ok
+                  ? "rounded border border-border bg-muted/20 p-2"
+                  : "rounded border border-destructive/40 bg-destructive/5 p-2"
+              }
+              key={session.sessionId}
+            >
+              <div className="flex flex-wrap items-center gap-2">
+                <span className="truncate font-mono text-xs">{session.sessionId}</span>
+                {session.host && (
+                  <span className="text-muted-foreground text-xs">{session.host}</span>
+                )}
+                {session.ok ? <Chip tone="success">ok</Chip> : <Chip tone="error">error</Chip>}
+                {session.cacheHit && <Chip>cached</Chip>}
+              </div>
+              <div className="mt-1 flex flex-wrap items-center gap-x-2 gap-y-1 text-muted-foreground text-xs">
+                <span>
+                  {session.intents} intent{session.intents === 1 ? "" : "s"} / {session.gaps} gap
+                  {session.gaps === 1 ? "" : "s"}
+                </span>
+                <span aria-hidden>·</span>
+                <span>
+                  {session.turns} turn{session.turns === 1 ? "" : "s"}
+                </span>
+                <span aria-hidden>·</span>
+                <span>{formatDuration(session.latencyMs)}</span>
+              </div>
+              {!session.ok && session.error && (
+                <p className="mt-1 text-destructive text-xs">{session.error}</p>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function Chip(props: { children: ReactNode; tone?: "success" | "error" }) {
+  const tone = props.tone;
+  return (
+    <span
+      className={
+        tone === "success"
+          ? "rounded-full border border-emerald-300/70 bg-emerald-50 px-2 py-0.5 text-[10px] text-emerald-900 dark:border-emerald-400/40 dark:bg-emerald-500/15 dark:text-emerald-200"
+          : tone === "error"
+            ? "rounded-full border border-destructive/40 bg-destructive/10 px-2 py-0.5 text-[10px] text-destructive"
+            : "rounded-full border border-border bg-muted px-2 py-0.5 text-[10px] text-muted-foreground"
+      }
+    >
+      {props.children}
+    </span>
+  );
+}
+
+function EmptyState(props: { title: string; description: string; children?: ReactNode }) {
+  return (
+    <section className="-mx-4 grid min-h-72 flex-1 place-items-center border-border border-y bg-muted/15 px-4 py-8 text-center sm:-mx-6 sm:px-6">
+      <div className="grid max-w-md gap-3">
+        <div className="mx-auto rounded-md bg-muted p-2 text-brand-green">
+          <Activity className="size-5" />
+        </div>
+        <div>
+          <h3 className="font-medium">{props.title}</h3>
+          <p className="mt-1 text-muted-foreground text-sm">{props.description}</p>
+        </div>
+        {props.children && <div>{props.children}</div>}
+      </div>
+    </section>
+  );
+}
+
+function formatDuration(ms: number): string {
+  if (!Number.isFinite(ms) || ms <= 0) return "—";
+  if (ms < 1000) return `${Math.round(ms)}ms`;
+  const seconds = ms / 1000;
+  if (seconds < 60) return `${seconds.toFixed(seconds < 10 ? 1 : 0)}s`;
+  const minutes = Math.floor(seconds / 60);
+  const rest = Math.round(seconds % 60);
+  return `${minutes}m ${rest}s`;
+}
+
+/** "just now" / "5m ago" / "3h ago" / "2d ago" / a date for older timestamps. */
+function relativeTime(iso: string): string {
+  const then = new Date(iso).getTime();
+  if (Number.isNaN(then)) return iso;
+  const diffMs = Date.now() - then;
+  const minutes = Math.round(diffMs / 60000);
+  if (minutes < 1) return "just now";
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.round(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.round(hours / 24);
+  if (days < 7) return `${days}d ago`;
+  return new Date(then).toLocaleDateString();
+}
+
+/** "3 Mar 14:02" — compact day/month + time, for chart marker tooltips. */
+function shortDateTime(iso: string): string {
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return iso;
+  const day = date.toLocaleDateString([], { day: "numeric", month: "short" });
+  const time = date.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+  return `${day} ${time}`;
+}

--- a/packages/ui/src/pages/ObservabilityPage.tsx
+++ b/packages/ui/src/pages/ObservabilityPage.tsx
@@ -12,7 +12,7 @@ type LoadState =
 
 /**
  * Analysis-run telemetry, rendered as a tab inside the Intents page (no page
- * header of its own — the Intents page provides it).
+ * header of its own - the Intents page provides it).
  */
 export function ObservabilityPanel() {
   const { request } = useRatelApp();
@@ -40,7 +40,7 @@ export function ObservabilityPanel() {
   return (
     <div className="flex flex-col gap-4">
       <p className="px-1 text-muted-foreground text-sm">
-        A history of every analysis run — when Ratel read your captured chats and extracted intents,
+        A history of every analysis run - when Ratel read your captured chats and extracted intents,
         how long it took, and what it found. Use it to confirm analysis is running and spot
         failures.
       </p>
@@ -89,7 +89,7 @@ function SummaryHeader(props: { runs: RunLogEntry[]; summary: ObservabilityRespo
     cachedSessions += run.sessions.filter((session) => session.cacheHit).length;
   }
   const cacheHitRate =
-    totalSessions > 0 ? `${Math.round((cachedSessions / totalSessions) * 100)}%` : "—";
+    totalSessions > 0 ? `${Math.round((cachedSessions / totalSessions) * 100)}%` : "-";
 
   return (
     <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-6">
@@ -101,7 +101,7 @@ function SummaryHeader(props: { runs: RunLogEntry[]; summary: ObservabilityRespo
       <SummaryCard
         hint="When analysis last ran"
         label="Last run"
-        value={summary.lastRunAt ? relativeTime(summary.lastRunAt) : "—"}
+        value={summary.lastRunAt ? relativeTime(summary.lastRunAt) : "-"}
       />
       <SummaryCard
         hint="Typical time one run takes"
@@ -150,7 +150,7 @@ function Glossary() {
           automatically on a timer.
         </GlossaryItem>
         <GlossaryItem term="Trigger">
-          What started the run — <span className="font-mono text-xs">manual</span> (you clicked Run
+          What started the run - <span className="font-mono text-xs">manual</span> (you clicked Run
           now), <span className="font-mono text-xs">cadence</span> (the automatic timer), or{" "}
           <span className="font-mono text-xs">idle</span> (a session went quiet).
         </GlossaryItem>
@@ -158,7 +158,7 @@ function Glossary() {
           Something you repeatedly try to get an agent to do, extracted from the conversation.
         </GlossaryItem>
         <GlossaryItem term="Gap">
-          An intent that no managed skill covers yet — a candidate for “Offer New Skills” on the
+          An intent that no managed skill covers yet - a candidate for “Offer New Skills” on the
           Intents page.
         </GlossaryItem>
         <GlossaryItem term="Session">
@@ -166,7 +166,7 @@ function Glossary() {
         </GlossaryItem>
         <GlossaryItem term="Cached">
           The conversation hadn’t changed since last time, so the result was reused instead of
-          re-running the model — faster and cheaper.
+          re-running the model - faster and cheaper.
         </GlossaryItem>
       </dl>
     </details>
@@ -205,7 +205,7 @@ function RunsChart(props: { runs: RunLogEntry[] }) {
   const plotH = CHART_H - CHART_PAD.top - CHART_PAD.bottom;
 
   // Oldest-to-newest, capped to the last 30 runs. A dependency-free inline-SVG
-  // line chart — recharts is intentionally avoided (it broke the dev bundle).
+  // line chart - recharts is intentionally avoided (it broke the dev bundle).
   const recent = [...props.runs].slice(0, 30).reverse();
   const max = Math.max(1, ...recent.map((run) => Math.max(run.totalIntents, run.totalGaps)));
 
@@ -476,7 +476,7 @@ function EmptyState(props: { title: string; description: string; children?: Reac
 }
 
 function formatDuration(ms: number): string {
-  if (!Number.isFinite(ms) || ms <= 0) return "—";
+  if (!Number.isFinite(ms) || ms <= 0) return "-";
   if (ms < 1000) return `${Math.round(ms)}ms`;
   const seconds = ms / 1000;
   if (seconds < 60) return `${seconds.toFixed(seconds < 10 ? 1 : 0)}s`;
@@ -500,7 +500,7 @@ function relativeTime(iso: string): string {
   return new Date(then).toLocaleDateString();
 }
 
-/** "3 Mar 14:02" — compact day/month + time, for chart marker tooltips. */
+/** "3 Mar 14:02" - compact day/month + time, for chart marker tooltips. */
 function shortDateTime(iso: string): string {
   const date = new Date(iso);
   if (Number.isNaN(date.getTime())) return iso;

--- a/packages/ui/src/pages/ObservabilityPage.tsx
+++ b/packages/ui/src/pages/ObservabilityPage.tsx
@@ -183,58 +183,49 @@ function GlossaryItem(props: { term: string; children: ReactNode }) {
 }
 
 // Fixed chart height; width is measured at runtime so the viewBox maps 1:1 to
-// pixels (no aspect-ratio stretching → round markers, undistorted lines).
-const CHART_H = 180;
-const CHART_PAD = { top: 16, right: 16, bottom: 22, left: 30 };
-const GRID_LINES = 3;
+// pixels (no aspect-ratio stretching → crisp, undistorted bars).
+const CHART_H = 200;
+const CHART_PAD = { top: 14, right: 12, bottom: 14, left: 28 };
+// Cap the bar count so the chart stays readable; the rest is in the list below.
+const MAX_BARS = 24;
 
-interface ChartPoint {
-  key: string;
-  at: string;
-  totalIntents: number;
-  totalGaps: number;
-  x: number;
-  intentY: number;
-  gapY: number;
-}
-
+/**
+ * Per-run grouped bars (intents vs gaps), oldest→newest. A bar chart reads more
+ * honestly than a line for discrete runs - a run that found nothing is a clear
+ * empty slot rather than a dip in a connected line. Dependency-free inline SVG;
+ * recharts is intentionally avoided (it broke the dev bundle).
+ */
 function RunsChart(props: { runs: RunLogEntry[] }) {
   const [ref, bounds] = useMeasure();
   const width = Math.max(320, Math.round(bounds.width));
   const plotW = width - CHART_PAD.left - CHART_PAD.right;
   const plotH = CHART_H - CHART_PAD.top - CHART_PAD.bottom;
-
-  // Oldest-to-newest, capped to the last 30 runs. A dependency-free inline-SVG
-  // line chart - recharts is intentionally avoided (it broke the dev bundle).
-  const recent = [...props.runs].slice(0, 30).reverse();
-  const max = Math.max(1, ...recent.map((run) => Math.max(run.totalIntents, run.totalGaps)));
-
-  const points: ChartPoint[] = recent.map((run, index) => {
-    // One point centers in the plot; otherwise spread evenly left→right.
-    const x =
-      recent.length === 1
-        ? CHART_PAD.left + plotW / 2
-        : CHART_PAD.left + (plotW * index) / (recent.length - 1);
-    const yFor = (value: number) => CHART_PAD.top + plotH - (value / max) * plotH;
-    return {
-      key: run.runId,
-      at: run.at,
-      totalIntents: run.totalIntents,
-      totalGaps: run.totalGaps,
-      x,
-      intentY: yFor(run.totalIntents),
-      gapY: yFor(run.totalGaps),
-    };
-  });
-
-  const intentPath = toPath(points, (p) => p.intentY);
-  const gapPath = toPath(points, (p) => p.gapY);
   const baselineY = CHART_PAD.top + plotH;
 
+  const recent = [...props.runs].slice(0, MAX_BARS).reverse();
+  const max = Math.max(1, ...recent.map((run) => Math.max(run.totalIntents, run.totalGaps)));
+  const ticks = niceTicks(max);
+  const yFor = (value: number) => baselineY - (value / max) * plotH;
+
+  // One slot per run; two centered bars (intents, gaps) within each slot, widths
+  // capped so a single run doesn't render as two enormous blocks.
+  const slotW = recent.length > 0 ? plotW / recent.length : plotW;
+  const barGap = 2;
+  const barW = Math.max(3, Math.min(26, (slotW - barGap) / 2 - 3));
+  const groupW = barW * 2 + barGap;
+
   return (
-    <section className="rounded-md border border-border bg-card p-3">
-      <div className="mb-2 flex items-center justify-between px-1">
-        <h2 className="font-medium text-sm">Intents &amp; gaps over time</h2>
+    <section className="rounded-md border border-border bg-card p-3 sm:p-4">
+      <div className="mb-3 flex flex-wrap items-center justify-between gap-2 px-1">
+        <div>
+          <h2 className="font-medium text-sm">Intents &amp; gaps per run</h2>
+          <p className="mt-0.5 text-muted-foreground text-xs">
+            {recent.length === props.runs.length
+              ? `All ${recent.length} run${recent.length === 1 ? "" : "s"}`
+              : `Last ${recent.length} of ${props.runs.length} runs`}{" "}
+            · oldest to newest
+          </p>
+        </div>
         <div className="flex items-center gap-3 text-muted-foreground text-xs">
           <LegendSwatch color="var(--chart-1)" label="Intents" />
           <LegendSwatch color="var(--chart-2)" label="Gaps" />
@@ -243,99 +234,92 @@ function RunsChart(props: { runs: RunLogEntry[] }) {
       <div className="w-full" ref={ref}>
         {bounds.width > 0 && (
           <svg
-            aria-label="Intents and gaps per run over time"
+            aria-label="Intents and gaps per run"
             height={CHART_H}
             role="img"
             viewBox={`0 0 ${width} ${CHART_H}`}
             width={width}
           >
-            {/* Horizontal gridlines. */}
-            {Array.from({ length: GRID_LINES }, (_, i) => {
-              const y = CHART_PAD.top + (plotH * i) / (GRID_LINES - 1);
+            {/* Gridlines + y-axis labels. */}
+            {ticks.map((tick) => {
+              const y = yFor(tick);
               return (
-                <line
-                  className="stroke-border"
-                  key={`grid-${y}`}
-                  opacity={i === GRID_LINES - 1 ? 0.9 : 0.4}
-                  strokeWidth={1}
-                  x1={CHART_PAD.left}
-                  x2={width - CHART_PAD.right}
-                  y1={y}
-                  y2={y}
-                />
+                <g key={tick}>
+                  <line
+                    className="stroke-border"
+                    opacity={tick === 0 ? 0.9 : 0.35}
+                    strokeWidth={1}
+                    x1={CHART_PAD.left}
+                    x2={width - CHART_PAD.right}
+                    y1={y}
+                    y2={y}
+                  />
+                  <text
+                    className="fill-muted-foreground"
+                    fontSize={10}
+                    textAnchor="end"
+                    x={CHART_PAD.left - 6}
+                    y={y + 3}
+                  >
+                    {tick}
+                  </text>
+                </g>
               );
             })}
 
-            {/* Y-axis labels (max + 0). */}
-            <text
-              className="fill-muted-foreground"
-              fontSize={10}
-              textAnchor="end"
-              x={CHART_PAD.left - 6}
-              y={CHART_PAD.top + 3}
-            >
-              {max}
-            </text>
-            <text
-              className="fill-muted-foreground"
-              fontSize={10}
-              textAnchor="end"
-              x={CHART_PAD.left - 6}
-              y={baselineY + 3}
-            >
-              0
-            </text>
-
-            {/* Series lines. */}
-            <path
-              d={gapPath}
-              fill="none"
-              stroke="var(--chart-2)"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth={2}
-            />
-            <path
-              d={intentPath}
-              fill="none"
-              stroke="var(--chart-1)"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth={2}
-            />
-
-            {/* Markers with tooltips. */}
-            {points.map((p) => (
-              <g key={p.key}>
-                <circle cx={p.x} cy={p.gapY} fill="var(--chart-2)" r={3}>
-                  <title>{markerTitle(p)}</title>
-                </circle>
-                <circle cx={p.x} cy={p.intentY} fill="var(--chart-1)" r={3}>
-                  <title>{markerTitle(p)}</title>
-                </circle>
-              </g>
-            ))}
+            {/* Grouped bars per run. */}
+            {recent.map((run, index) => {
+              const slotX = CHART_PAD.left + slotW * index + (slotW - groupW) / 2;
+              const intentY = yFor(run.totalIntents);
+              const gapY = yFor(run.totalGaps);
+              const radius = Math.min(3, barW / 2);
+              return (
+                <g key={run.runId}>
+                  <rect
+                    fill="var(--chart-1)"
+                    height={Math.max(0, baselineY - intentY)}
+                    rx={radius}
+                    width={barW}
+                    x={slotX}
+                    y={intentY}
+                  >
+                    <title>{barTitle(run, "intents")}</title>
+                  </rect>
+                  <rect
+                    fill="var(--chart-2)"
+                    height={Math.max(0, baselineY - gapY)}
+                    rx={radius}
+                    width={barW}
+                    x={slotX + barW + barGap}
+                    y={gapY}
+                  >
+                    <title>{barTitle(run, "gaps")}</title>
+                  </rect>
+                </g>
+              );
+            })}
           </svg>
         )}
       </div>
+      {recent.length > 1 && (
+        <div className="mt-1 flex justify-between px-1 text-[10px] text-muted-foreground/70">
+          <span>{shortDateTime(recent[0].at)}</span>
+          <span>{shortDateTime(recent[recent.length - 1].at)}</span>
+        </div>
+      )}
     </section>
   );
 }
 
-/** Build an SVG polyline `d` string; falls back to a tiny dot for a single point. */
-function toPath(points: ChartPoint[], y: (p: ChartPoint) => number): string {
-  if (points.length === 0) return "";
-  if (points.length === 1) {
-    const p = points[0];
-    return `M ${p.x} ${y(p)} L ${p.x} ${y(p)}`;
-  }
-  return points.map((p, i) => `${i === 0 ? "M" : "L"} ${p.x} ${y(p)}`).join(" ");
+/** Up to three integer y-axis ticks (0, midpoint, max), de-duplicated. */
+function niceTicks(max: number): number[] {
+  return [...new Set([0, Math.round(max / 2), max])].sort((a, b) => a - b);
 }
 
-function markerTitle(p: ChartPoint): string {
-  const intents = `${p.totalIntents} intent${p.totalIntents === 1 ? "" : "s"}`;
-  const gaps = `${p.totalGaps} gap${p.totalGaps === 1 ? "" : "s"}`;
-  return `${shortDateTime(p.at)} · ${intents} / ${gaps}`;
+function barTitle(run: RunLogEntry, kind: "intents" | "gaps"): string {
+  const value = kind === "intents" ? run.totalIntents : run.totalGaps;
+  const noun = kind === "intents" ? "intent" : "gap";
+  return `${shortDateTime(run.at)} · ${value} ${noun}${value === 1 ? "" : "s"}`;
 }
 
 function LegendSwatch(props: { color: string; label: string }) {

--- a/packages/ui/src/pages/SkillsPage.tsx
+++ b/packages/ui/src/pages/SkillsPage.tsx
@@ -209,7 +209,7 @@ export function SkillsPage() {
           skills={managed}
           renderAction={(skill) =>
             skill.source === "ratel" ? (
-              <span className="px-1 text-muted-foreground text-xs">Created in Ratel</span>
+              <DeleteSkillButton id={skill.id} name={skill.name} onDeleted={load} />
             ) : (
               <Button
                 disabled={busy}
@@ -343,6 +343,46 @@ function EmptyState(props: { title: string; description: string; children?: Reac
         {props.children && <div>{props.children}</div>}
       </div>
     </section>
+  );
+}
+
+function DeleteSkillButton(props: {
+  id: string;
+  name: string;
+  onDeleted: () => void | Promise<void>;
+}) {
+  const { request, runAction, busy } = useRatelApp();
+  const [open, setOpen] = useState(false);
+
+  const del = async () => {
+    const ok = await runAction(`Deleted ${props.name}`, () =>
+      request(`/api/skills/${encodeURIComponent(props.id)}`, { method: "DELETE" }),
+    );
+    if (ok) {
+      setOpen(false);
+      await props.onDeleted();
+    }
+  };
+
+  return (
+    <Dialog onOpenChange={setOpen} open={open}>
+      <DialogTrigger render={<Button size="sm" variant="outline" />}>Delete</DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Delete “{props.name}”?</DialogTitle>
+          <DialogDescription>
+            Permanently removes this Ratel-created skill from{" "}
+            <code>~/.ratel/skills/{props.id}</code>. This can't be undone.
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <DialogClose render={<Button size="sm" variant="outline" />}>Cancel</DialogClose>
+          <Button disabled={busy} onClick={() => void del()} size="sm" variant="destructive">
+            Delete
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
   );
 }
 

--- a/packages/ui/src/routeTree.gen.ts
+++ b/packages/ui/src/routeTree.gen.ts
@@ -5,6 +5,8 @@
 import { Route as rootRoute } from "./routes/__root";
 import { Route as AgentSetupRouteImport } from "./routes/agent-setup";
 import { Route as AgentSetupKindRouteImport } from "./routes/agent-setup.$kind";
+import { Route as ChatsRouteImport } from "./routes/chats";
+import { Route as ChatsIdRouteImport } from "./routes/chats.$id";
 import { Route as IndexRouteImport } from "./routes/index";
 import { Route as IntentsRouteImport } from "./routes/intents";
 import { Route as SkillsRouteImport } from "./routes/skills";
@@ -27,6 +29,18 @@ const AgentSetupRoute = AgentSetupRouteImport.update({
 const AgentSetupKindRoute = AgentSetupKindRouteImport.update({
   id: "/agent-setup/$kind",
   path: "/agent-setup/$kind",
+  getParentRoute: () => rootRoute,
+} as any);
+
+const ChatsRoute = ChatsRouteImport.update({
+  id: "/chats",
+  path: "/chats",
+  getParentRoute: () => rootRoute,
+} as any);
+
+const ChatsIdRoute = ChatsIdRouteImport.update({
+  id: "/chats/$id",
+  path: "/chats/$id",
   getParentRoute: () => rootRoute,
 } as any);
 
@@ -83,6 +97,20 @@ declare module "@tanstack/react-router" {
       preLoaderRoute: typeof AgentSetupKindRouteImport;
       parentRoute: typeof rootRoute;
     };
+    "/chats": {
+      id: "/chats";
+      path: "/chats";
+      fullPath: "/chats";
+      preLoaderRoute: typeof ChatsRouteImport;
+      parentRoute: typeof rootRoute;
+    };
+    "/chats/$id": {
+      id: "/chats/$id";
+      path: "/chats/$id";
+      fullPath: "/chats/$id";
+      preLoaderRoute: typeof ChatsIdRouteImport;
+      parentRoute: typeof rootRoute;
+    };
     "/intents": {
       id: "/intents";
       path: "/intents";
@@ -125,6 +153,8 @@ export const routeTree = rootRoute
   ._addFileChildren({
     AgentSetupRoute,
     AgentSetupKindRoute,
+    ChatsRoute,
+    ChatsIdRoute,
     IndexRoute,
     IntentsRoute,
     SkillsRoute,

--- a/packages/ui/src/routeTree.gen.ts
+++ b/packages/ui/src/routeTree.gen.ts
@@ -6,6 +6,7 @@ import { Route as rootRoute } from "./routes/__root";
 import { Route as AgentSetupRouteImport } from "./routes/agent-setup";
 import { Route as AgentSetupKindRouteImport } from "./routes/agent-setup.$kind";
 import { Route as IndexRouteImport } from "./routes/index";
+import { Route as IntentsRouteImport } from "./routes/intents";
 import { Route as SkillsRouteImport } from "./routes/skills";
 import { Route as SkillsIdRouteImport } from "./routes/skills.$id";
 import { Route as ToolsScopeNameRouteImport } from "./routes/tools/$scope/$name";
@@ -26,6 +27,12 @@ const AgentSetupRoute = AgentSetupRouteImport.update({
 const AgentSetupKindRoute = AgentSetupKindRouteImport.update({
   id: "/agent-setup/$kind",
   path: "/agent-setup/$kind",
+  getParentRoute: () => rootRoute,
+} as any);
+
+const IntentsRoute = IntentsRouteImport.update({
+  id: "/intents",
+  path: "/intents",
   getParentRoute: () => rootRoute,
 } as any);
 
@@ -76,6 +83,13 @@ declare module "@tanstack/react-router" {
       preLoaderRoute: typeof AgentSetupKindRouteImport;
       parentRoute: typeof rootRoute;
     };
+    "/intents": {
+      id: "/intents";
+      path: "/intents";
+      fullPath: "/intents";
+      preLoaderRoute: typeof IntentsRouteImport;
+      parentRoute: typeof rootRoute;
+    };
     "/skills": {
       id: "/skills";
       path: "/skills";
@@ -112,6 +126,7 @@ export const routeTree = rootRoute
     AgentSetupRoute,
     AgentSetupKindRoute,
     IndexRoute,
+    IntentsRoute,
     SkillsRoute,
     SkillsIdRoute,
     ToolsNewRoute,

--- a/packages/ui/src/routes/chats.$id.tsx
+++ b/packages/ui/src/routes/chats.$id.tsx
@@ -1,0 +1,22 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { ChatDetailPage } from "@/pages/ChatDetailPage";
+
+type AppSearch = {
+  t?: string;
+};
+
+export const Route = createFileRoute("/chats/$id")({
+  validateSearch,
+  component: ChatDetailRoute,
+});
+
+function ChatDetailRoute() {
+  const { id } = Route.useParams();
+  return <ChatDetailPage sessionId={id} />;
+}
+
+function validateSearch(search: Record<string, unknown>): AppSearch {
+  return {
+    t: typeof search.t === "string" ? search.t : undefined,
+  };
+}

--- a/packages/ui/src/routes/chats.tsx
+++ b/packages/ui/src/routes/chats.tsx
@@ -1,0 +1,17 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { ChatsPage } from "@/pages/ChatsPage";
+
+type AppSearch = {
+  t?: string;
+};
+
+export const Route = createFileRoute("/chats")({
+  validateSearch,
+  component: ChatsPage,
+});
+
+function validateSearch(search: Record<string, unknown>): AppSearch {
+  return {
+    t: typeof search.t === "string" ? search.t : undefined,
+  };
+}

--- a/packages/ui/src/routes/intents.tsx
+++ b/packages/ui/src/routes/intents.tsx
@@ -1,0 +1,17 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { IntentsPage } from "@/pages/IntentsPage";
+
+type AppSearch = {
+  t?: string;
+};
+
+export const Route = createFileRoute("/intents")({
+  validateSearch,
+  component: IntentsPage,
+});
+
+function validateSearch(search: Record<string, unknown>): AppSearch {
+  return {
+    t: typeof search.t === "string" ? search.t : undefined,
+  };
+}


### PR DESCRIPTION
## Chat → intent-extraction pipeline

Captures your agent chats, extracts the **intents** (what you keep asking agents to do) and **claims** from them, and matches each intent against Ratel-managed skills so **gaps** (intents no skill covers) surface as candidates for new skills.

### How it works
- **Capture (copy, not stream):** a plugin hook (`capture-chat.mjs`) writes redacted, size-capped chat turns to `~/.ratel/chat/<host>/<sessionId>.jsonl` on `UserPromptSubmit` / `Stop`. Ratel never reads the agent's own transcript store at analysis time.
- **Extraction:** the runner sends a session's turns to an extractor over the **orbitals claim-extractor contract**, then BM25-matches intents against managed skills. Results are content-addressed cached by `(turns + model)`; "Re-analyze all" bypasses the cache; "Clear intents" drops it.
- **Extractor deployments are interchangeable** — a local Apple-Silicon sidecar or the hosted Principled endpoint speak the same contract, so switching is just the endpoint URL (+ auth: none / Bearer / Basic).

### UI (Intents / Chats)
- **Intents tab:** coverage view, per-chat + bulk analysis, "Offer New Skills", and an analysis-settings dialog (provider/endpoint/auth, cadence, coverage thresholds, skill-gen).
- **Test connection** button probes the extractor's `/health` server-side (secret never reaches the browser).
- **Chats:** list + full-width, bottom-pinned chat transcript view.
- **Run history:** per-run summary + grouped bar chart (intents vs gaps) + drill-down.
- Secrets are masked on read; a saved secret shows empty + a "saved" placeholder with a show/hide toggle, and a no-op save preserves it.

### Notable fixes in the latest commit
- Unified the sidecar + client on `POST /orbitals/claim-extractor/extract` (kept `/v1/extract` as a back-compat alias).
- Basic-auth support; failing extracts surface the server's error body (so a hosted **500 from an unknown model name** is diagnosable). Removed the foot-gun Model field from the UI.
- Improved skill-generation prompt (XML-delimited context + explicit quality bar / fixed SKILL.md structure).