### PR TITLE
Unify agent import flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ All notable changes to this package are documented here. The format is based on 
 ## [0.4.0] - 2026-06-30
 
 ### Changed
-- **`ratel-mcp mcp link` and `ratel-mcp mcp import` now install the Claude Code statusline automatically** once they finish wiring up Claude Code, instead of requiring a separate `ratel-mcp statusline install` step. A pre-existing non-Ratel statusline is left untouched (reported as a note, not an error).
+- **Agent setup commands now live at the top level as `ratel-mcp import` and `ratel-mcp link`.** Import now spans both MCP entries and native skills, so neither command is nested under the MCP-only command group.
+- **`ratel-mcp link` and `ratel-mcp import` now install the Claude Code statusline automatically** once they finish wiring up Claude Code, instead of requiring a separate `ratel-mcp statusline install` step. A pre-existing non-Ratel statusline is left untouched (reported as a note, not an error).
 - **Skill activation now links native Claude Code / Codex skill folders into Ratel instead of moving them.** Deactivation removes Ratel's managed link and reverses Ratel-owned metadata edits while leaving the native skill folder in its agent's directory.
 
 ## [0.3.1] - 2026-06-18

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this package are documented here. The format is based on 
 
 ### Fixed
 - Skill-only Claude Code imports now reach the statusline step, and one invalid selected skill no longer aborts other successful skill imports.
+- Dry-run imports no longer execute the Link preflight or write agent configs and backups.
 
 ## [0.3.1] - 2026-06-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,12 @@ All notable changes to this package are documented here. The format is based on 
 
 ### Changed
 - **Agent setup commands now live at the top level as `ratel-mcp import` and `ratel-mcp link`.** Import now spans both MCP entries and native skills, so neither command is nested under the MCP-only command group.
-- **`ratel-mcp link` and `ratel-mcp import` now install the Claude Code statusline automatically** once they finish wiring up Claude Code, instead of requiring a separate `ratel-mcp statusline install` step. A pre-existing non-Ratel statusline is left untouched (reported as a note, not an error).
+- **CLI and UI now consume the same explicit import workflow.** An unlinked source agent first offers link, continue without linking, or cancel; the confirmed import owns Ratel writes, repeatable source MCP cleanup, and native skill invalidation; Claude Code then offers the standalone statusline flow.
+- **Linking now owns only the Ratel gateway installation.** It no longer removes native entries or installs the statusline as a side effect.
 - **Skill activation now links native Claude Code / Codex skill folders into Ratel instead of moving them.** Deactivation removes Ratel's managed link and reverses Ratel-owned metadata edits while leaving the native skill folder in its agent's directory.
+
+### Fixed
+- Skill-only Claude Code imports now reach the statusline step, and one invalid selected skill no longer aborts other successful skill imports.
 
 ## [0.3.1] - 2026-06-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,14 +5,7 @@ All notable changes to this package are documented here. The format is based on 
 ## [0.4.0] - 2026-06-30
 
 ### Changed
-- **Agent setup commands now live at the top level as `ratel-mcp import` and `ratel-mcp link`.** Import now spans both MCP entries and native skills, so neither command is nested under the MCP-only command group.
-- **CLI and UI now consume the same explicit import workflow.** An unlinked source agent first offers link, continue without linking, or cancel; the confirmed import owns Ratel writes, repeatable source MCP cleanup, and native skill invalidation; Claude Code then offers the standalone statusline flow.
-- **Linking now owns only the Ratel gateway installation.** It no longer removes native entries or installs the statusline as a side effect.
-- **Skill activation now links native Claude Code / Codex skill folders into Ratel instead of moving them.** Deactivation removes Ratel's managed link and reverses Ratel-owned metadata edits while leaving the native skill folder in its agent's directory.
-
-### Fixed
-- Skill-only Claude Code imports now reach the statusline step, and one invalid selected skill no longer aborts other successful skill imports.
-- Dry-run imports no longer execute the Link preflight or write agent configs and backups.
+- **`ratel-mcp mcp link` and `ratel-mcp mcp import` now install the Claude Code statusline automatically** once they finish wiring up Claude Code, instead of requiring a separate `ratel-mcp statusline install` step. A pre-existing non-Ratel statusline is left untouched (reported as a note, not an error).
 
 ## [0.3.1] - 2026-06-18
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,9 @@ ratel-mcp import --agent claude-code
 ratel-mcp import --agent codex
 ```
 
-Select the upstreams to migrate, approve the Ratel Local configuration, then approve replacing their native entries with one Ratel Local entry. The wizard preserves scopes and backs up every changed file.
+The CLI and UI use the same import sequence. If the source agent is not linked, the first step offers to link and continue, continue without linking, or cancel. The confirmed import writes selected entries to Ratel, removes those MCP entries from the source agent, and marks selected native skills invoke-only. Skipping the link is useful when importing for another linked agent, but the imported MCPs and skills are no longer directly usable from the unlinked source agent. The wizard preserves scopes and backs up every changed file.
+
+Claude Code then offers a separate, skippable Ratel statusline step. Linking itself only installs the Ratel gateway entry; install or reinstall the statusline manually with `ratel-mcp statusline install`.
 
 If your upstreams are already in Ratel Local configuration, `link` adds Ratel Local to the agent without importing or removing native entries:
 

--- a/README.md
+++ b/README.md
@@ -54,19 +54,19 @@ Run the command for your agent from the project where you use those servers:
 
 ```bash
 # Claude Code
-ratel-mcp mcp import --agent claude-code
+ratel-mcp import --agent claude-code
 
 # Codex
-ratel-mcp mcp import --agent codex
+ratel-mcp import --agent codex
 ```
 
 Select the upstreams to migrate, approve the Ratel Local configuration, then approve replacing their native entries with one Ratel Local entry. The wizard preserves scopes and backs up every changed file.
 
-If your upstreams are already in Ratel Local configuration, `mcp link` adds Ratel Local to the agent without importing or removing native entries:
+If your upstreams are already in Ratel Local configuration, `link` adds Ratel Local to the agent without importing or removing native entries:
 
 ```bash
-ratel-mcp mcp link --agent claude-code
-ratel-mcp mcp link --agent codex
+ratel-mcp link --agent claude-code
+ratel-mcp link --agent codex
 ```
 
 Native entries remain directly exposed, so their schemas still enter the agent's context without capability search.

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ ratel-mcp import --agent claude-code
 ratel-mcp import --agent codex
 ```
 
-The CLI and UI use the same import sequence. If the source agent is not linked, the first step offers to link and continue, continue without linking, or cancel. The confirmed import writes selected entries to Ratel, removes those MCP entries from the source agent, and marks selected native skills invoke-only. Skipping the link is useful when importing for another linked agent, but the imported MCPs and skills are no longer directly usable from the unlinked source agent. The wizard preserves scopes and backs up every changed file.
+The CLI and UI use the same import sequence. If the source agent is not linked, the first step offers to link and continue, continue without linking, or cancel. The confirmed import writes selected entries to Ratel, removes those MCP entries from the source agent, and marks selected native skills invoke-only. Skipping the link is useful when importing for another linked agent, but the imported MCPs and skills are no longer directly usable from the unlinked source agent. The wizard preserves MCP scopes and backs up every changed MCP or agent config file. Skill management is reversible: use **Stop managing** in the UI or `ratel-mcp skill deactivate` to remove Ratel's link and restore its metadata changes.
 
 Claude Code then offers a separate, skippable Ratel statusline step. Linking itself only installs the Ratel gateway entry; install or reinstall the statusline manually with `ratel-mcp statusline install`.
 

--- a/apps/ratel-mcp/plugin/skills/ratel-mcp/SKILL.md
+++ b/apps/ratel-mcp/plugin/skills/ratel-mcp/SKILL.md
@@ -58,8 +58,11 @@ the existing config shape, and validate the JSON afterwards.
 Top-level commands:
 
 - `ratel-mcp serve` starts the MCP gateway over stdio.
+- `ratel-mcp import` migrates agent MCP entries and native skills into Ratel.
+- `ratel-mcp link` points an agent at the Ratel gateway without removing native MCP entries.
 - `ratel-mcp mcp` manages upstream MCP server entries.
 - `ratel-mcp backup` manages backup snapshots.
+- `ratel-mcp skill` manages Claude Code and Codex skills through Ratel.
 - `ratel-mcp ui` launches the local browser UI.
 - `ratel-mcp statusline` renders or manages the Claude Code Ratel statusline.
 - `ratel-mcp --version` or `ratel-mcp version` prints the CLI version.
@@ -72,9 +75,17 @@ Top-level commands:
 - `list` lists configured upstreams across Ratel scopes.
 - `get` shows one entry's resolved details.
 - `edit` edits fields on an existing entry; it is interactive when no edit flags are supplied.
-- `import` migrates agent MCP configs into Ratel and can rewrite the agent to use the Ratel gateway.
-- `link` rewrites an agent's config to point at Ratel for entries already in Ratel scopes.
 - `auth` runs OAuth for HTTP/SSE upstreams or checks stored auth state.
+
+`ratel-mcp skill` verbs:
+
+- `activate` links native Claude Code and Codex skills into Ratel as invoke-only without moving their folders.
+- `deactivate` removes Ratel-managed links and restores Ratel-owned metadata edits.
+- `list` shows the skills Ratel currently manages.
+- `suggest` ranks skills for a prompt.
+- `preload-hook` is the `UserPromptSubmit` hook entrypoint.
+- `install-hook` registers the preload hook in `settings.json`.
+- `uninstall-hook` removes the preload hook from `settings.json`.
 
 `ratel-mcp statusline` verbs:
 
@@ -136,6 +147,14 @@ ratel-mcp import --agent codex
 ratel-mcp import --agent claude-code
 ```
 
+If the selected agent is not linked, interactive import first offers to link
+and continue, continue without linking, or cancel. Import then resolves
+selected MCP entries against the matching Ratel scopes: the conflict strategy
+decides whether to add the incoming definition, replace the Ratel definition,
+or keep the existing Ratel definition. Entries covered by the resulting plan
+are removed from the source agent, and selected native skills are managed as
+invoke-only.
+
 Preview or automate an import:
 
 ```bash
@@ -143,16 +162,24 @@ ratel-mcp import --agent codex --dry-run
 ratel-mcp import --agent codex --yes --conflict-strategy add-missing-only
 ```
 
-Link a host to Ratel after entries already exist in Ratel config:
+Supported conflict strategies are `add-missing-only`, `replace-selected`, and
+`replace-from-agent`. `--dry-run` performs no writes. `--yes` accepts the
+non-interactive defaults; do not combine `replace-selected` with `--yes` or
+`--dry-run` because per-conflict choices require interaction.
+
+Link a host to the Ratel gateway without importing or removing native MCP
+entries:
 
 ```bash
 ratel-mcp link --agent codex
 ratel-mcp link --agent claude-code
 ```
 
-`ratel-mcp link` and `ratel-mcp import` install the Claude Code
-statusline automatically once they finish wiring up Claude Code (skipped if a
-non-Ratel statusline is already configured). Manage it directly with:
+`ratel-mcp link` changes only the gateway configuration; it never installs the
+Claude Code statusline. After a successful Claude Code import, import offers a
+separate, skippable statusline step when the Ratel statusline is not already
+installed. With `--yes`, import installs a missing statusline automatically but
+leaves an existing non-Ratel statusline unchanged. Manage it directly with:
 
 ```bash
 ratel-mcp statusline install
@@ -161,7 +188,7 @@ ratel-mcp statusline uninstall
 ```
 
 Claude Code plugins cannot currently set top-level `statusLine` defaults
-directly; use the CLI (directly, or automatically via `link`/`import`) or the
+directly; use the standalone statusline CLI, the optional import step, or the
 Claude Code agent page in `ratel-mcp ui`. The statusline reports Ratel as on
 when Claude Code starts Ratel via a linked MCP entry or an enabled
 `ratel-mcp@...` plugin.

--- a/apps/ratel-mcp/plugin/skills/ratel-mcp/SKILL.md
+++ b/apps/ratel-mcp/plugin/skills/ratel-mcp/SKILL.md
@@ -132,25 +132,25 @@ ratel-mcp mcp add --scope local docs https://example.com/mcp --header "Authoriza
 Import existing host MCP servers into Ratel:
 
 ```bash
-ratel-mcp mcp import --agent codex
-ratel-mcp mcp import --agent claude-code
+ratel-mcp import --agent codex
+ratel-mcp import --agent claude-code
 ```
 
 Preview or automate an import:
 
 ```bash
-ratel-mcp mcp import --agent codex --dry-run
-ratel-mcp mcp import --agent codex --yes --conflict-strategy add-missing-only
+ratel-mcp import --agent codex --dry-run
+ratel-mcp import --agent codex --yes --conflict-strategy add-missing-only
 ```
 
 Link a host to Ratel after entries already exist in Ratel config:
 
 ```bash
-ratel-mcp mcp link --agent codex
-ratel-mcp mcp link --agent claude-code
+ratel-mcp link --agent codex
+ratel-mcp link --agent claude-code
 ```
 
-`ratel-mcp mcp link` and `ratel-mcp mcp import` install the Claude Code
+`ratel-mcp link` and `ratel-mcp import` install the Claude Code
 statusline automatically once they finish wiring up Claude Code (skipped if a
 non-Ratel statusline is already configured). Manage it directly with:
 

--- a/apps/ratel-mcp/src/cli/args.test.ts
+++ b/apps/ratel-mcp/src/cli/args.test.ts
@@ -42,18 +42,20 @@ describe("parseArgs — group/verb routing", () => {
     expect(parseArgs(["statusline", "uninstall"]).verb).toBe("uninstall");
   });
 
-  it.each([
-    "add",
-    "remove",
-    "list",
-    "get",
-    "edit",
-    "import",
-    "link",
-  ] as const)("recognizes mcp %s", (verb) => {
+  it.each(["add", "remove", "list", "get", "edit"] as const)("recognizes mcp %s", (verb) => {
     const r = parseArgs(["mcp", verb]);
     expect(r.group).toBe("mcp");
     expect(r.verb).toBe(verb);
+  });
+
+  it.each(["import", "link"] as const)("recognizes top-level %s", (command) => {
+    const r = parseArgs([command]);
+    expect(r.group).toBe(command);
+    expect(r.verb).toBeUndefined();
+  });
+
+  it.each(["import", "link"] as const)("does not expose %s as an mcp verb", (verb) => {
+    expect(() => parseArgs(["mcp", verb])).toThrow(new RegExp(`unknown mcp verb: ${verb}`));
   });
 
   it("recognizes the top-level serve group", () => {
@@ -146,7 +148,7 @@ describe("parseArgs — flags and config paths", () => {
   });
 
   it("treats a bare --key followed by another flag as a boolean", () => {
-    const r = parseArgs(["mcp", "import", "--yes", "--dry-run"]);
+    const r = parseArgs(["import", "--yes", "--dry-run"]);
     expect(r.flags).toEqual({ yes: true, "dry-run": true });
   });
 

--- a/apps/ratel-mcp/src/cli/args.ts
+++ b/apps/ratel-mcp/src/cli/args.ts
@@ -1,6 +1,16 @@
-export type Group = "mcp" | "backup" | "skill" | "statusline" | "serve" | "ui" | "help" | "version";
+export type Group =
+  | "mcp"
+  | "backup"
+  | "skill"
+  | "import"
+  | "link"
+  | "statusline"
+  | "serve"
+  | "ui"
+  | "help"
+  | "version";
 
-export type McpVerb = "add" | "remove" | "list" | "get" | "edit" | "import" | "link" | "auth";
+export type McpVerb = "add" | "remove" | "list" | "get" | "edit" | "auth";
 
 export type BackupVerb = "list";
 
@@ -15,16 +25,7 @@ export type SkillVerb =
   | "install-hook"
   | "uninstall-hook";
 
-const MCP_VERBS: ReadonlySet<string> = new Set([
-  "add",
-  "remove",
-  "list",
-  "get",
-  "edit",
-  "import",
-  "link",
-  "auth",
-]);
+const MCP_VERBS: ReadonlySet<string> = new Set(["add", "remove", "list", "get", "edit", "auth"]);
 
 const BACKUP_VERBS: ReadonlySet<string> = new Set(["list"]);
 
@@ -134,6 +135,9 @@ export function parseArgs(argv: string[]): ParsedArgs {
       verb = candidate;
       i = 2;
     }
+  } else if (first === "import" || first === "link") {
+    group = first;
+    i = 1;
   } else if (first === "statusline") {
     group = "statusline";
     i = 1;

--- a/apps/ratel-mcp/src/cli/cli.test.ts
+++ b/apps/ratel-mcp/src/cli/cli.test.ts
@@ -217,12 +217,14 @@ describe("runCli — serve", () => {
 });
 
 describe("runCli — help and routing", () => {
-  it("--help logs a top-level usage that names the mcp and backup groups", async () => {
+  it("--help advertises import and link as top-level commands", async () => {
     const logs: string[] = [];
     await runCli(["--help"], { logger: (m) => logs.push(m) });
     const out = logs.join("\n");
     expect(out).toMatch(/mcp/);
     expect(out).toMatch(/backup/);
+    expect(out).toMatch(/^\s*import\s/m);
+    expect(out).toMatch(/^\s*link\s/m);
   });
 
   it("--version logs the injected package version", async () => {
@@ -236,7 +238,8 @@ describe("runCli — help and routing", () => {
     await runCli(["mcp"], { logger: (m) => logs.push(m) });
     const out = logs.join("\n");
     expect(out).toMatch(/add/);
-    expect(out).toMatch(/import/);
+    expect(out).not.toMatch(/^\s*import\s/m);
+    expect(out).not.toMatch(/^\s*link\s/m);
   });
 
   it("`ratel-mcp backup` (no verb) logs the backup group usage", async () => {

--- a/apps/ratel-mcp/src/cli/cli.test.ts
+++ b/apps/ratel-mcp/src/cli/cli.test.ts
@@ -227,6 +227,22 @@ describe("runCli — help and routing", () => {
     expect(out).toMatch(/^\s*link\s/m);
   });
 
+  it("prints command-specific help for import and link without running either workflow", async () => {
+    for (const command of ["import", "link"] as const) {
+      const fs = new MemFs();
+      const logs: string[] = [];
+
+      await runCli([command, "--help", "--yes"], {
+        env: { homeDir: HOME, projectRoot: ROOT },
+        fs,
+        logger: (message) => logs.push(message),
+      });
+
+      expect(logs.join("\n")).toContain(`usage: ratel-mcp ${command}`);
+      expect(fs.files.size).toBe(0);
+    }
+  });
+
   it("--version logs the injected package version", async () => {
     const logs: string[] = [];
     await runCli(["--version"], { cliVersion: "1.2.3", logger: (m) => logs.push(m) });

--- a/apps/ratel-mcp/src/cli/cli.ts
+++ b/apps/ratel-mcp/src/cli/cli.ts
@@ -14,8 +14,8 @@ import {
 } from "@ratel-ai/mcp-core";
 import { ArgError, type ParsedArgs, parseArgs } from "./args.js";
 import { BACKUP_USAGE, runBackup } from "./handlers/backup.js";
-import { runImport } from "./handlers/import.js";
-import { runLink } from "./handlers/link.js";
+import { IMPORT_USAGE, runImport } from "./handlers/import.js";
+import { LINK_USAGE, runLink } from "./handlers/link.js";
 import { MCP_USAGE, runMcp } from "./handlers/mcp.js";
 import { runServe } from "./handlers/serve.js";
 import { runSkill, SKILL_USAGE } from "./handlers/skill.js";
@@ -93,6 +93,16 @@ export async function runCli(argv: string[], options: RunCliOptions = {}): Promi
 
   if (parsed.group === "skill" && parsed.verb === undefined) {
     log(SKILL_USAGE);
+    return {};
+  }
+
+  if (parsed.group === "import" && parsed.flags.help === true) {
+    log(IMPORT_USAGE);
+    return {};
+  }
+
+  if (parsed.group === "link" && parsed.flags.help === true) {
+    log(LINK_USAGE);
     return {};
   }
 

--- a/apps/ratel-mcp/src/cli/cli.ts
+++ b/apps/ratel-mcp/src/cli/cli.ts
@@ -5,12 +5,17 @@ import {
   type BackupFs,
   findProjectRoot,
   type HierarchyEnv,
+  type ImportConflictStrategy,
+  isSupportedAgentHostKind,
   type JsonFs,
   nodeFs,
+  type SupportedAgentHostKind,
   type TransportFactory,
 } from "@ratel-ai/mcp-core";
 import { ArgError, type ParsedArgs, parseArgs } from "./args.js";
 import { BACKUP_USAGE, runBackup } from "./handlers/backup.js";
+import { runImport } from "./handlers/import.js";
+import { runLink } from "./handlers/link.js";
 import { MCP_USAGE, runMcp } from "./handlers/mcp.js";
 import { runServe } from "./handlers/serve.js";
 import { runSkill, SKILL_USAGE } from "./handlers/skill.js";
@@ -44,7 +49,9 @@ const TOP_USAGE = `usage: ratel-mcp <command> [args...]
 Commands:
   serve    start the gateway over stdio (use --config <path>; repeat for multi-file merge,
            or --auto-config to load user/project/local Ratel configs)
-  mcp      manage MCP servers (add, remove, list, get, edit, import, link, auth)
+  import   migrate agent MCP configs and native skills into Ratel
+  link     point an agent at Ratel while preserving native MCP entries
+  mcp      manage MCP servers (add, remove, list, get, edit, auth)
   backup   manage backup snapshots (list)
   skill    manage Claude Code/Codex skills through Ratel (activate, deactivate, list)
   statusline render or install the Claude Code Ratel statusline
@@ -107,6 +114,24 @@ export async function runCli(argv: string[], options: RunCliOptions = {}): Promi
     return runUi(parsed, ctx, log);
   }
 
+  if (parsed.group === "import") {
+    await runImport(ctx, {
+      yes: parsed.flags.yes === true,
+      dryRun: parsed.flags["dry-run"] === true,
+      conflictStrategy: resolveImportConflictStrategy(parsed.flags["conflict-strategy"]),
+      agentKind: resolveAgentKind(parsed.flags.agent),
+    });
+    return {};
+  }
+
+  if (parsed.group === "link") {
+    await runLink(ctx, {
+      yes: parsed.flags.yes === true,
+      agentKind: resolveAgentKind(parsed.flags.agent),
+    });
+    return {};
+  }
+
   if (parsed.group === "mcp") {
     await runMcp(ctx);
     return {};
@@ -128,6 +153,36 @@ export async function runCli(argv: string[], options: RunCliOptions = {}): Promi
   }
 
   throw new ArgError(`unhandled command: ${parsed.group} ${parsed.verb}`);
+}
+
+function resolveAgentKind(value: unknown): SupportedAgentHostKind | undefined {
+  if (value === undefined || value === false || value === "auto") return undefined;
+  if (typeof value !== "string") {
+    throw new ArgError("--agent must be one of auto|claude-code|codex");
+  }
+  if (!isSupportedAgentHostKind(value)) {
+    throw new ArgError(`--agent must be one of auto|claude-code|codex, got "${value}"`);
+  }
+  return value;
+}
+
+function resolveImportConflictStrategy(value: unknown): ImportConflictStrategy | undefined {
+  if (value === undefined || value === false) return undefined;
+  if (typeof value !== "string") {
+    throw new ArgError(
+      "--conflict-strategy must be one of add-missing-only|replace-selected|replace-from-agent",
+    );
+  }
+  if (
+    value !== "add-missing-only" &&
+    value !== "replace-selected" &&
+    value !== "replace-from-agent"
+  ) {
+    throw new ArgError(
+      `--conflict-strategy must be one of add-missing-only|replace-selected|replace-from-agent, got "${value}"`,
+    );
+  }
+  return value;
 }
 
 function defaultEnv(): HierarchyEnv {

--- a/apps/ratel-mcp/src/cli/handlers/import.test.ts
+++ b/apps/ratel-mcp/src/cli/handlers/import.test.ts
@@ -65,7 +65,7 @@ function ctxOf(
   return {
     logs,
     ctx: {
-      argv: { group: "mcp", verb: "import", configPaths: [], rest: [], extras: [], flags: {} },
+      argv: { group: "import", configPaths: [], rest: [], extras: [], flags: {} },
       env: { homeDir: HOME, projectRoot: withProjectRoot ? ROOT : undefined },
       fs,
       log: (m) => logs.push(m),

--- a/apps/ratel-mcp/src/cli/handlers/import.test.ts
+++ b/apps/ratel-mcp/src/cli/handlers/import.test.ts
@@ -1,6 +1,10 @@
+import { lstat, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import type { BackupFs, JsonFs, ResolvedBin } from "@ratel-ai/mcp-core";
 import { describe, expect, it } from "vitest";
 import { CANCEL_SYMBOL, type PromptAdapter, silentPromptAdapter } from "../prompts.js";
+import type { SkillManagePaths } from "../skills/manage.js";
 import { runImport } from "./import.js";
 import type { HandlerCtx } from "./types.js";
 
@@ -68,6 +72,42 @@ function ctxOf(
       prompts,
     },
   };
+}
+
+async function makeSkillPaths(): Promise<SkillManagePaths & { root: string }> {
+  const root = await mkdtemp(join(tmpdir(), "ratel-import-skills-"));
+  return {
+    root,
+    nativeDir: join(root, ".claude", "skills"),
+    codexDir: join(root, ".codex", "skills"),
+    managedDir: join(root, ".ratel", "skills"),
+    manifestPath: join(root, ".ratel", "skill-manifest.json"),
+  };
+}
+
+async function writeCliClaudeSkill(paths: SkillManagePaths, name: string): Promise<string> {
+  const dir = join(paths.nativeDir, name);
+  await mkdir(dir, { recursive: true });
+  const text = `---\nname: ${name}\ndescription: d\n---\n# body`;
+  await writeFile(join(dir, "SKILL.md"), text, "utf8");
+  return text;
+}
+
+async function writeCliCodexSkill(paths: SkillManagePaths, name: string): Promise<string> {
+  const dir = join(paths.codexDir, name);
+  await mkdir(dir, { recursive: true });
+  const text = `---\nname: ${name}\ndescription: d\n---\n# body`;
+  await writeFile(join(dir, "SKILL.md"), text, "utf8");
+  return text;
+}
+
+async function pathExists(path: string): Promise<boolean> {
+  try {
+    await lstat(path);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 function autoConfirm(): PromptAdapter {
@@ -367,6 +407,117 @@ command = "codex"
     expect(fs.files.has(RATEL_USER)).toBe(false);
     expect(logs.join("\n")).toMatch(/would write/);
     expect(logs.join("\n")).toMatch(/\/home\/u\/\.ratel\/config\.json/);
+  });
+
+  it("--dry-run previews native skills for the requested agent without touching files", async () => {
+    const fs = new MemFs();
+    const skillPaths = await makeSkillPaths();
+    try {
+      const before = await writeCliClaudeSkill(skillPaths, "api-design");
+      const { ctx, logs } = ctxOf(fs, autoConfirm(), false);
+
+      await runImport(ctx, {
+        bin: BIN,
+        yes: true,
+        dryRun: true,
+        agentKind: "claude-code",
+        skillPaths,
+      });
+
+      expect(logs.join("\n")).toMatch(/would manage skill api-design \(claude\) as invoke-only/);
+      expect(await readFile(join(skillPaths.nativeDir, "api-design", "SKILL.md"), "utf8")).toBe(
+        before,
+      );
+      expect(await pathExists(join(skillPaths.managedDir, "api-design"))).toBe(false);
+      expect(await pathExists(skillPaths.manifestPath)).toBe(false);
+    } finally {
+      await rm(skillPaths.root, { recursive: true, force: true });
+    }
+  });
+
+  it("imports MCP entries and native skills in one requested-agent flow", async () => {
+    const fs = new MemFs();
+    fs.files.set(
+      HOME_CLAUDE,
+      JSON.stringify({
+        mcpServers: { fs: { type: "stdio", command: "echo" } },
+      }),
+    );
+    const skillPaths = await makeSkillPaths();
+    try {
+      await writeCliClaudeSkill(skillPaths, "api-design");
+      const prompts: PromptAdapter = {
+        ...autoConfirm(),
+        async multiselect(opts) {
+          if (opts.message.includes("skills")) {
+            return opts.options
+              .filter((option) => String(option.value).endsWith(":api-design"))
+              .map((option) => option.value) as unknown as never;
+          }
+          return opts.options.map((option) => option.value) as unknown as never;
+        },
+      };
+      const { ctx } = ctxOf(fs, prompts, false);
+
+      await runImport(ctx, {
+        bin: BIN,
+        agentKind: "claude-code",
+        skillPaths,
+        probe: async () => undefined,
+      });
+
+      const ratelUser = JSON.parse(fs.files.get(RATEL_USER) as string);
+      expect(ratelUser.mcpServers.fs).toEqual({ type: "stdio", command: "echo" });
+      const claude = JSON.parse(fs.files.get(HOME_CLAUDE) as string);
+      expect(claude.mcpServers["ratel-mcp"]).toEqual({
+        type: "stdio",
+        command: "ratel-mcp",
+        args: ["serve", "--config", RATEL_USER],
+      });
+      expect((await lstat(join(skillPaths.managedDir, "api-design"))).isSymbolicLink()).toBe(true);
+      expect(
+        await readFile(join(skillPaths.nativeDir, "api-design", "SKILL.md"), "utf8"),
+      ).toContain("disable-model-invocation: true");
+      const manifest = JSON.parse(await readFile(skillPaths.manifestPath, "utf8"));
+      expect(manifest.managed[0]).toMatchObject({
+        id: "api-design",
+        mode: "linked",
+        source: "claude",
+      });
+    } finally {
+      await rm(skillPaths.root, { recursive: true, force: true });
+    }
+  });
+
+  it("can manage Codex skills through requested-agent import without an MCP config", async () => {
+    const fs = new MemFs();
+    const skillPaths = await makeSkillPaths();
+    try {
+      await writeCliCodexSkill(skillPaths, "review-flow");
+      const { ctx, logs } = ctxOf(fs, autoConfirm(), false);
+
+      await runImport(ctx, {
+        bin: BIN,
+        yes: true,
+        agentKind: "codex",
+        skillPaths,
+      });
+
+      expect(fs.files.size).toBe(0);
+      expect((await lstat(join(skillPaths.managedDir, "review-flow"))).isSymbolicLink()).toBe(true);
+      expect(
+        await readFile(join(skillPaths.codexDir, "review-flow", "agents", "openai.yaml"), "utf8"),
+      ).toContain("allow_implicit_invocation: false");
+      const manifest = JSON.parse(await readFile(skillPaths.manifestPath, "utf8"));
+      expect(manifest.managed[0]).toMatchObject({
+        id: "review-flow",
+        mode: "linked",
+        source: "codex",
+      });
+      expect(logs.join("\n")).toMatch(/managing 1 skill as invoke-only/);
+    } finally {
+      await rm(skillPaths.root, { recursive: true, force: true });
+    }
   });
 
   it("--yes skips the confirm prompt entirely", async () => {

--- a/apps/ratel-mcp/src/cli/handlers/import.test.ts
+++ b/apps/ratel-mcp/src/cli/handlers/import.test.ts
@@ -13,6 +13,7 @@ const ROOT = "/r";
 const BIN: ResolvedBin = { command: "ratel-mcp", args: [], source: "path" };
 
 const HOME_CLAUDE = "/home/u/.claude.json";
+const CLAUDE_SETTINGS = "/home/u/.claude/settings.json";
 const HOME_CODEX = "/home/u/.codex/config.toml";
 const PROJECT_MCP = "/r/.mcp.json";
 const RATEL_USER = "/home/u/.ratel/config.json";
@@ -190,6 +191,17 @@ function decliningStageB(): PromptAdapter {
     async confirm() {
       stage += 1;
       return stage === 1; // accept Ratel config changes, decline Claude Code config changes
+    },
+  };
+}
+
+function decliningStageBAndAcceptingSkills(): PromptAdapter {
+  let stage = 0;
+  return {
+    ...autoConfirm(),
+    async confirm() {
+      stage += 1;
+      return stage !== 2; // accept Ratel + skill changes, decline Claude Code config changes
     },
   };
 }
@@ -484,6 +496,60 @@ command = "codex"
         mode: "linked",
         source: "claude",
       });
+    } finally {
+      await rm(skillPaths.root, { recursive: true, force: true });
+    }
+  });
+
+  it("still manages selected skills after declining Claude Code config changes", async () => {
+    const fs = new MemFs();
+    fs.files.set(
+      HOME_CLAUDE,
+      JSON.stringify({
+        mcpServers: { fs: { type: "stdio", command: "echo" } },
+      }),
+    );
+    const skillPaths = await makeSkillPaths();
+    try {
+      await writeCliClaudeSkill(skillPaths, "api-design");
+      const { ctx } = ctxOf(fs, decliningStageBAndAcceptingSkills(), false);
+
+      await runImport(ctx, {
+        bin: BIN,
+        agentKind: "claude-code",
+        skillPaths,
+        probe: async () => undefined,
+      });
+
+      expect(
+        JSON.parse(fs.files.get(HOME_CLAUDE) as string).mcpServers["ratel-mcp"],
+      ).toBeUndefined();
+      expect((await lstat(join(skillPaths.managedDir, "api-design"))).isSymbolicLink()).toBe(true);
+      expect(
+        await readFile(join(skillPaths.nativeDir, "api-design", "SKILL.md"), "utf8"),
+      ).toContain("disable-model-invocation: true");
+    } finally {
+      await rm(skillPaths.root, { recursive: true, force: true });
+    }
+  });
+
+  it("installs the Claude statusline after a skill-only import", async () => {
+    const fs = new MemFs();
+    const skillPaths = await makeSkillPaths();
+    try {
+      await writeCliClaudeSkill(skillPaths, "api-design");
+      const { ctx } = ctxOf(fs, autoConfirm(), false);
+
+      await runImport(ctx, {
+        bin: BIN,
+        yes: true,
+        agentKind: "claude-code",
+        skillPaths,
+      });
+
+      expect(JSON.parse(fs.files.get(CLAUDE_SETTINGS) as string).statusLine.command).toContain(
+        "ratel-mcp statusline",
+      );
     } finally {
       await rm(skillPaths.root, { recursive: true, force: true });
     }

--- a/apps/ratel-mcp/src/cli/handlers/import.test.ts
+++ b/apps/ratel-mcp/src/cli/handlers/import.test.ts
@@ -551,6 +551,37 @@ command = "codex"
     }
   });
 
+  it("offers the standalone statusline step after import and lets the user skip it", async () => {
+    const fs = new MemFs();
+    const skillPaths = await makeSkillPaths();
+    let statuslinePrompted = false;
+    try {
+      await writeCliClaudeSkill(skillPaths, "api-design");
+      const prompts: PromptAdapter = {
+        ...autoConfirm(),
+        async confirm(opts) {
+          if (opts.message.includes("statusline")) {
+            statuslinePrompted = true;
+            return false;
+          }
+          return true;
+        },
+      };
+      const { ctx } = ctxOf(fs, prompts, false);
+
+      await runImport(ctx, {
+        bin: BIN,
+        agentKind: "claude-code",
+        skillPaths,
+      });
+
+      expect(statuslinePrompted).toBe(true);
+      expect(fs.files.has(CLAUDE_SETTINGS)).toBe(false);
+    } finally {
+      await rm(skillPaths.root, { recursive: true, force: true });
+    }
+  });
+
   it("keeps valid skill imports and warns when another selected skill is skipped", async () => {
     const fs = new MemFs();
     const skillPaths = await makeSkillPaths();

--- a/apps/ratel-mcp/src/cli/handlers/import.test.ts
+++ b/apps/ratel-mcp/src/cli/handlers/import.test.ts
@@ -172,6 +172,7 @@ function conflictStrategyPrompts(
         if (title === "Ratel import conflicts") conflictMessages.push(message);
       },
       async select(opts) {
+        if (opts.message.includes("Link Ratel")) return "link";
         selectOptions.splice(
           0,
           selectOptions.length,
@@ -190,24 +191,12 @@ function conflictStrategyPrompts(
   };
 }
 
-function decliningStageB(): PromptAdapter {
-  let stage = 0;
+function skippingLinkAndConfirmingImport(): PromptAdapter {
   return {
     ...autoConfirm(),
-    async confirm() {
-      stage += 1;
-      return stage === 1; // accept Ratel config changes, decline Claude Code config changes
-    },
-  };
-}
-
-function decliningStageBAndAcceptingSkills(): PromptAdapter {
-  let stage = 0;
-  return {
-    ...autoConfirm(),
-    async confirm() {
-      stage += 1;
-      return stage !== 2; // accept Ratel + skill changes, decline Claude Code config changes
+    async select(opts) {
+      if (opts.message.includes("Link Ratel")) return "skip";
+      return opts.initialValue ?? opts.options[0].value;
     },
   };
 }
@@ -507,7 +496,7 @@ command = "codex"
     }
   });
 
-  it("still manages selected skills after declining Claude Code config changes", async () => {
+  it("still imports MCPs and skills after explicitly skipping the Link preflight", async () => {
     const fs = new MemFs();
     fs.files.set(
       HOME_CLAUDE,
@@ -518,7 +507,7 @@ command = "codex"
     const skillPaths = await makeSkillPaths();
     try {
       await writeCliClaudeSkill(skillPaths, "api-design");
-      const { ctx } = ctxOf(fs, decliningStageBAndAcceptingSkills(), false);
+      const { ctx } = ctxOf(fs, skippingLinkAndConfirmingImport(), false);
 
       await runImport(ctx, {
         bin: BIN,
@@ -530,6 +519,7 @@ command = "codex"
       expect(
         JSON.parse(fs.files.get(HOME_CLAUDE) as string).mcpServers["ratel-mcp"],
       ).toBeUndefined();
+      expect(JSON.parse(fs.files.get(HOME_CLAUDE) as string).mcpServers.fs).toBeUndefined();
       expect((await lstat(join(skillPaths.managedDir, "api-design"))).isSymbolicLink()).toBe(true);
       expect(
         await readFile(join(skillPaths.nativeDir, "api-design", "SKILL.md"), "utf8"),
@@ -718,7 +708,8 @@ command = "codex"
     let selectCalled = false;
     const prompts: PromptAdapter = {
       ...autoConfirm(),
-      async select() {
+      async select(opts) {
+        if (opts.message.includes("Link Ratel")) return "link";
         selectCalled = true;
         return "add-missing-only";
       },
@@ -755,7 +746,8 @@ command = "codex"
     let multiselectCalled = false;
     const prompts: PromptAdapter = {
       ...autoConfirm(),
-      async select() {
+      async select(opts) {
+        if (opts.message.includes("Link Ratel")) return "link";
         selectCalled = true;
         return "add-missing-only";
       },
@@ -819,7 +811,7 @@ command = "codex"
     ).rejects.toThrow(/replace-selected cannot be combined with --yes or --dry-run/);
   });
 
-  it("canceling at the conflict prompt exits before writes or backups", async () => {
+  it("canceling at the conflict prompt preserves the completed Link commit without importing", async () => {
     const fs = new MemFs();
     fs.files.set(
       HOME_CLAUDE,
@@ -839,11 +831,13 @@ command = "codex"
 
     const ratelUser = JSON.parse(fs.files.get(RATEL_USER) as string);
     expect(ratelUser.mcpServers.fs).toEqual({ type: "stdio", command: "existing" });
-    expect(JSON.parse(fs.files.get(HOME_CLAUDE) as string).mcpServers.fs).toBeDefined();
+    const claude = JSON.parse(fs.files.get(HOME_CLAUDE) as string);
+    expect(claude.mcpServers.fs).toBeDefined();
+    expect(claude.mcpServers["ratel-mcp"]).toBeDefined();
     const backupKeys = Array.from(fs.files.keys()).filter((k) =>
       k.startsWith("/home/u/.ratel/backups/"),
     );
-    expect(backupKeys).toEqual([]);
+    expect(backupKeys.length).toBeGreaterThan(0);
   });
 
   it("logs a backup location if executor fails mid-flight", async () => {
@@ -851,7 +845,14 @@ command = "codex"
     fs.files.set(
       HOME_CLAUDE,
       JSON.stringify({
-        mcpServers: { fs: { type: "stdio", command: "echo" } },
+        mcpServers: {
+          fs: { type: "stdio", command: "echo" },
+          "ratel-mcp": {
+            type: "stdio",
+            command: "ratel-mcp",
+            args: ["serve", "--config", RATEL_USER],
+          },
+        },
       }),
     );
     fs.failNextWriteAt = HOME_CLAUDE;
@@ -859,35 +860,6 @@ command = "codex"
     await expect(runImport(ctx, { bin: BIN, yes: true })).rejects.toThrow();
     expect(logs.join("\n")).toMatch(/partial backup may exist under ~\/\.ratel\/backups\//);
     expect(logs.join("\n")).not.toMatch(/ratel-mcp backup undo/);
-  });
-
-  it("declining Claude Code config changes leaves Ratel configs in place and Claude untouched, with a link hint", async () => {
-    const fs = new MemFs();
-    fs.files.set(
-      HOME_CLAUDE,
-      JSON.stringify({
-        mcpServers: {
-          fs: { type: "stdio", command: "echo" },
-          other: { type: "stdio", command: "echo-other" },
-        },
-      }),
-    );
-    const { ctx, logs } = ctxOf(fs, decliningStageB(), false);
-    await runImport(ctx, { bin: BIN });
-
-    // Ratel config changes applied: Ratel global has the entries.
-    expect(fs.files.has(RATEL_USER)).toBe(true);
-    const ratelUser = JSON.parse(fs.files.get(RATEL_USER) as string);
-    expect(ratelUser.mcpServers.fs).toBeDefined();
-    expect(ratelUser.mcpServers.other).toBeDefined();
-
-    // Claude Code config changes declined: Claude is untouched.
-    const claude = JSON.parse(fs.files.get(HOME_CLAUDE) as string);
-    expect(claude.mcpServers["ratel-mcp"]).toBeUndefined();
-    expect(claude.mcpServers.fs).toBeDefined();
-
-    // Hint mentions link or re-running import.
-    expect(logs.join("\n")).toMatch(/link|import/i);
   });
 
   it("multiselect deselects an entry: only selected ones land in Ratel, deselected ones stay in Claude", async () => {
@@ -913,24 +885,6 @@ command = "codex"
     expect(claude.mcpServers["ratel-mcp"]).toBeDefined();
     expect(claude.mcpServers.other).toEqual({ type: "stdio", command: "echo-other" });
     expect(claude.mcpServers.fs).toBeUndefined();
-  });
-
-  it("after declining Claude Code config changes, re-running offers them again", async () => {
-    const fs = new MemFs();
-    fs.files.set(
-      HOME_CLAUDE,
-      JSON.stringify({
-        mcpServers: { fs: { type: "stdio", command: "echo" } },
-      }),
-    );
-    const { ctx } = ctxOf(fs, decliningStageB(), false);
-    await runImport(ctx, { bin: BIN });
-    expect(JSON.parse(fs.files.get(HOME_CLAUDE) as string).mcpServers["ratel-mcp"]).toBeUndefined();
-
-    // Re-run: this time accept both change groups.
-    const { ctx: ctx2 } = ctxOf(fs, autoConfirm(), false);
-    await runImport(ctx2, { bin: BIN });
-    expect(JSON.parse(fs.files.get(HOME_CLAUDE) as string).mcpServers["ratel-mcp"]).toBeDefined();
   });
 
   it("captures and prompts for an optional description on each selected entry without one", async () => {

--- a/apps/ratel-mcp/src/cli/handlers/import.test.ts
+++ b/apps/ratel-mcp/src/cli/handlers/import.test.ts
@@ -400,6 +400,34 @@ command = "codex"
     expect(fs.files.has(RATEL_USER)).toBe(false);
   });
 
+  it("reports that a completed link is retained when the import is later cancelled", async () => {
+    const fs = new MemFs();
+    fs.files.set(
+      HOME_CLAUDE,
+      JSON.stringify({
+        mcpServers: { fs: { type: "stdio", command: "echo" } },
+      }),
+    );
+    const cancellations: string[] = [];
+    const prompts: PromptAdapter = {
+      ...autoConfirm(),
+      cancel(message) {
+        cancellations.push(message);
+      },
+      async confirm() {
+        return false;
+      },
+    };
+    const { ctx } = ctxOf(fs, prompts, false);
+
+    await runImport(ctx, { bin: BIN });
+
+    expect(cancellations).toEqual(["import cancelled · link retained"]);
+    const claude = JSON.parse(fs.files.get(HOME_CLAUDE) as string);
+    expect(claude.mcpServers["ratel-mcp"]).toBeDefined();
+    expect(claude.mcpServers.fs).toBeDefined();
+  });
+
   it("--dry-run skips execution and logs what would be written", async () => {
     const fs = new MemFs();
     const originalClaudeConfig = JSON.stringify({

--- a/apps/ratel-mcp/src/cli/handlers/import.test.ts
+++ b/apps/ratel-mcp/src/cli/handlers/import.test.ts
@@ -402,16 +402,19 @@ command = "codex"
 
   it("--dry-run skips execution and logs what would be written", async () => {
     const fs = new MemFs();
-    fs.files.set(
-      HOME_CLAUDE,
-      JSON.stringify({
-        mcpServers: { fs: { type: "stdio", command: "echo" } },
-      }),
-    );
+    const originalClaudeConfig = JSON.stringify({
+      mcpServers: { fs: { type: "stdio", command: "echo" } },
+    });
+    fs.files.set(HOME_CLAUDE, originalClaudeConfig);
     const { ctx, logs } = ctxOf(fs, autoConfirm(), false);
     await runImport(ctx, { bin: BIN, yes: true, dryRun: true });
 
     expect(fs.files.has(RATEL_USER)).toBe(false);
+    expect(fs.files.get(HOME_CLAUDE)).toBe(originalClaudeConfig);
+    expect(Array.from(fs.files.keys()).some((path) => path.includes("/.ratel/backups/"))).toBe(
+      false,
+    );
+    expect(logs.join("\n")).toMatch(/would link Claude Code to Ratel before importing/);
     expect(logs.join("\n")).toMatch(/would write/);
     expect(logs.join("\n")).toMatch(/\/home\/u\/\.ratel\/config\.json/);
   });

--- a/apps/ratel-mcp/src/cli/handlers/import.test.ts
+++ b/apps/ratel-mcp/src/cli/handlers/import.test.ts
@@ -94,6 +94,12 @@ async function writeCliClaudeSkill(paths: SkillManagePaths, name: string): Promi
   return text;
 }
 
+async function writeMalformedClaudeSkill(paths: SkillManagePaths, name: string): Promise<void> {
+  const dir = join(paths.nativeDir, name);
+  await mkdir(dir, { recursive: true });
+  await writeFile(join(dir, "SKILL.md"), "# missing frontmatter", "utf8");
+}
+
 async function writeCliCodexSkill(paths: SkillManagePaths, name: string): Promise<string> {
   const dir = join(paths.codexDir, name);
   await mkdir(dir, { recursive: true });
@@ -550,6 +556,32 @@ command = "codex"
       expect(JSON.parse(fs.files.get(CLAUDE_SETTINGS) as string).statusLine.command).toContain(
         "ratel-mcp statusline",
       );
+    } finally {
+      await rm(skillPaths.root, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps valid skill imports and warns when another selected skill is skipped", async () => {
+    const fs = new MemFs();
+    const skillPaths = await makeSkillPaths();
+    try {
+      await writeCliClaudeSkill(skillPaths, "valid-policy");
+      await writeMalformedClaudeSkill(skillPaths, "broken-policy");
+      const { ctx, logs } = ctxOf(fs, autoConfirm(), false);
+
+      await runImport(ctx, {
+        bin: BIN,
+        yes: true,
+        agentKind: "claude-code",
+        skillPaths,
+      });
+
+      expect((await lstat(join(skillPaths.managedDir, "valid-policy"))).isSymbolicLink()).toBe(
+        true,
+      );
+      expect(await pathExists(join(skillPaths.managedDir, "broken-policy"))).toBe(false);
+      expect(logs.join("\n")).toMatch(/managing 1 skill as invoke-only/);
+      expect(logs.join("\n")).toMatch(/could not manage selected skill.*broken-policy/i);
     } finally {
       await rm(skillPaths.root, { recursive: true, force: true });
     }

--- a/apps/ratel-mcp/src/cli/handlers/import.ts
+++ b/apps/ratel-mcp/src/cli/handlers/import.ts
@@ -274,8 +274,10 @@ export async function runImport(
   }
   if (workflow?.step === "statusline") {
     bin ??= opts.bin ?? (await resolveBin(ctx, opts));
-    await runStatuslineInstallStep(ctx, { bin, yes: opts.yes });
-    workflow = advanceAgentImportWorkflow(workflow, { type: "statusline-completed" });
+    const statuslineResult = await runStatuslineInstallStep(ctx, { bin, yes: opts.yes });
+    workflow = advanceAgentImportWorkflow(workflow, {
+      type: statuslineResult === "skipped" ? "statusline-skipped" : "statusline-installed",
+    });
   }
 
   if (latestManifest) {

--- a/apps/ratel-mcp/src/cli/handlers/import.ts
+++ b/apps/ratel-mcp/src/cli/handlers/import.ts
@@ -1,12 +1,16 @@
 import type { BackupManifest, RatelConfig, ServerEntry } from "@ratel-ai/mcp-core";
 import {
   type AgentHostState,
+  type AgentImportWorkflowState,
   type AgentScope,
   AutomaticAgentHostAdapter,
+  advanceAgentImportWorkflow,
+  beginAgentImportWorkflow,
   buildAgentImportPlan,
   conflictKey,
   executePlan,
   type FileChange,
+  getClaudeCodeStatuslineState,
   type ImportConflict,
   type ImportConflictStrategy,
   type ImportPlan,
@@ -17,6 +21,7 @@ import {
   ratelConfigPath,
   readJson,
   type SupportedAgentHostKind,
+  unlinkedAgentImportWarning,
 } from "@ratel-ai/mcp-core";
 import { ArgError } from "../args.js";
 import { resolveCliRatelBin } from "../ratel-bin.js";
@@ -26,6 +31,7 @@ import {
   type SkillManagePaths,
   type SkillSource,
 } from "../skills/manage.js";
+import { runLink } from "./link.js";
 import { maybeAutoInstallStatusline } from "./statusline.js";
 import type { HandlerCtx } from "./types.js";
 
@@ -112,6 +118,39 @@ export async function runImport(
     );
     ctx.prompts.outro("done");
     return null;
+  }
+
+  const workflowHostKind = resolveWorkflowHostKind(opts.agentKind, agentState);
+  let workflow = workflowHostKind
+    ? await beginCliImportWorkflow(ctx, workflowHostKind, agentState)
+    : null;
+  if (workflow?.step === "link") {
+    const decision = opts.yes
+      ? "link"
+      : await selectUnlinkedAgentAction(ctx, detection.displayName);
+    if (decision === "cancel") {
+      ctx.prompts.cancel("import cancelled (no writes)");
+      return null;
+    }
+    if (decision === "link") {
+      await runLink(ctx, {
+        yes: true,
+        bin: opts.bin,
+        envVar: opts.envVar,
+        whichResult: opts.whichResult,
+        workspaceRoot: opts.workspaceRoot,
+        agentKind: workflowHostKind ?? undefined,
+        exists: opts.exists,
+        installStatusline: false,
+      });
+      if (agentState) {
+        agentState = await agentHost.read({ env: ctx.env, fs: ctx.fs });
+        candidates = collectCandidates(agentState);
+      }
+      workflow = advanceAgentImportWorkflow(workflow, { type: "link-completed" });
+    } else {
+      workflow = advanceAgentImportWorkflow(workflow, { type: "link-skipped" });
+    }
   }
 
   if (agentState) {
@@ -206,86 +245,100 @@ export async function runImport(
     return null;
   }
 
-  let stageAManifest: BackupManifest | null = null;
-  if (plan.ratelChanges.length > 0) {
-    ctx.prompts.note(renderDiff(plan.ratelChanges), "Ratel config changes");
-    if (!opts.yes) {
-      const ok = await ctx.prompts.confirm({
-        message: `Apply ${plan.ratelChanges.length} Ratel config change(s)?`,
-        initialValue: true,
-      });
-      if (ctx.prompts.isCancel(ok) || ok === false) {
-        ctx.prompts.cancel("import cancelled (no writes)");
-        return null;
-      }
+  ctx.prompts.note(renderImportCommit(plan, selectedSkills), "Import commit");
+  if (!opts.yes) {
+    const ok = await ctx.prompts.confirm({
+      message: "Commit these import changes?",
+      initialValue: true,
+    });
+    if (ctx.prompts.isCancel(ok) || ok === false) {
+      ctx.prompts.cancel("import cancelled (no writes)");
+      return null;
     }
-    stageAManifest = await tryExecute(ctx, plan.ratelChanges, "import");
   }
 
-  let latestManifest = stageAManifest;
-  let agentChangesApplied = false;
-  let agentChangesSkipped = false;
-
-  if (agentState && plan.agentChanges.length > 0 && bin) {
-    ctx.prompts.note(
-      renderAgentStage(plan, agentState.host.displayName),
-      `${agentState.host.displayName} config changes`,
-    );
-    if (!opts.yes) {
-      const ok = await ctx.prompts.confirm({
-        message: `Replace ${plan.agentChanges.length} ${agentState.host.displayName} entr${
-          plan.agentChanges.length === 1 ? "y" : "ies"
-        } with the ratel-mcp entry?`,
-        initialValue: true,
-      });
-      if (ctx.prompts.isCancel(ok) || ok === false) {
-        ctx.log(
-          `${agentState.host.displayName} config changes skipped. Run \`ratel-mcp link\` (or re-run \`ratel-mcp import\`) to point ${agentState.host.displayName} at Ratel later.`,
-        );
-        agentChangesSkipped = true;
-      }
-    }
-    if (!agentChangesSkipped) {
-      latestManifest = await tryExecute(ctx, plan.agentChanges, "import");
-      agentChangesApplied = true;
-    }
+  let latestManifest: BackupManifest | null = null;
+  if (plan.ratelChanges.length > 0) {
+    latestManifest = await tryExecute(ctx, plan.ratelChanges, "import");
+  }
+  if (plan.agentChanges.length > 0) {
+    latestManifest = await tryExecute(ctx, plan.agentChanges, "import");
   }
 
   let skillImportResult: SkillImportResult = { managed: 0, skipped: [] };
   if (selectedSkills.length > 0) {
-    ctx.prompts.note(renderSkillStage(selectedSkills), "Skill changes");
-    if (!opts.yes) {
-      const ok = await ctx.prompts.confirm({
-        message: `Manage ${selectedSkills.length} native skill${
-          selectedSkills.length === 1 ? "" : "s"
-        } through Ratel as invoke-only?`,
-        initialValue: true,
-      });
-      if (ctx.prompts.isCancel(ok) || ok === false) {
-        ctx.prompts.cancel("import cancelled (skill changes skipped)");
-        return latestManifest;
-      }
-    }
     skillImportResult = await activateSelectedSkills(ctx, skillPaths, selectedSkills, opts);
   }
 
-  const statuslineHostKind = agentState?.host.kind ?? opts.agentKind;
-  const shouldInstallStatusline =
-    statuslineHostKind === "claude-code" &&
-    (selectedSkills.length > 0 || agentChangesApplied || plan.agentChanges.length === 0) &&
-    !agentChangesSkipped;
-  if (shouldInstallStatusline) {
+  if (workflow?.step === "import") {
+    workflow = advanceAgentImportWorkflow(workflow, { type: "import-completed" });
+  }
+  if (workflow?.step === "statusline") {
     bin ??= opts.bin ?? (await resolveBin(ctx, opts));
-    await maybeAutoInstallStatusline(ctx, statuslineHostKind, bin);
+    await maybeAutoInstallStatusline(ctx, workflow.hostKind, bin);
+    workflow = advanceAgentImportWorkflow(workflow, { type: "statusline-completed" });
   }
 
   if (latestManifest) {
     ctx.prompts.note(`Backup created. Run \`ratel-mcp backup list\` to inspect backups.`, "Done");
   }
-  ctx.prompts.outro(
-    renderCompletion(agentState, plan, skillImportResult.managed, agentChangesSkipped),
-  );
+  ctx.prompts.outro(renderCompletion(agentState, plan, skillImportResult.managed));
   return latestManifest;
+}
+
+async function beginCliImportWorkflow(
+  ctx: HandlerCtx,
+  hostKind: SupportedAgentHostKind,
+  agentState: AgentHostState | null,
+): Promise<AgentImportWorkflowState> {
+  const linked = agentState ? isAgentStateLinked(agentState) : true;
+  const statuslineInstalled =
+    hostKind === "claude-code"
+      ? (await getClaudeCodeStatuslineState(ctx)).status === "installed"
+      : false;
+  return beginAgentImportWorkflow({ hostKind, linked, statuslineInstalled });
+}
+
+function resolveWorkflowHostKind(
+  requested: SupportedAgentHostKind | undefined,
+  state: AgentHostState | null,
+): SupportedAgentHostKind | null {
+  if (requested) return requested;
+  return state?.host.kind === "claude-code" || state?.host.kind === "codex"
+    ? state.host.kind
+    : null;
+}
+
+function isAgentStateLinked(state: AgentHostState): boolean {
+  return state.scopes.some((scope) =>
+    Object.entries(scope.mcpServers).some(([name, entry]) => isRatelGatewayEntry(name, entry)),
+  );
+}
+
+async function selectUnlinkedAgentAction(
+  ctx: HandlerCtx,
+  agentDisplayName: string,
+): Promise<"link" | "skip" | "cancel"> {
+  ctx.prompts.note(unlinkedAgentImportWarning(agentDisplayName), "Agent not linked");
+  const answer = await ctx.prompts.select<"link" | "skip" | "cancel">({
+    message: "Link Ratel before importing?",
+    options: [
+      {
+        value: "link" as const,
+        label: "Link Ratel and continue",
+        hint: "Recommended; keeps imported MCPs and skills usable in this agent.",
+      },
+      {
+        value: "skip" as const,
+        label: "Continue without linking",
+        hint: "Import for use through another linked agent.",
+      },
+      { value: "cancel" as const, label: "Cancel import" },
+    ],
+    initialValue: "link",
+  });
+  if (ctx.prompts.isCancel(answer)) return "cancel";
+  return answer as "link" | "skip" | "cancel";
 }
 
 async function resolveConflictStrategy(
@@ -765,21 +818,16 @@ function renderDiff(changes: readonly FileChange[]): string {
     .join("\n");
 }
 
-function renderAgentStage(plan: ImportPlan, hostName = "agent"): string {
-  const lines: string[] = [];
-  lines.push(renderDiff(plan.agentChanges));
-  lines.push("");
-  lines.push(
-    `${hostName} MCP entries now managed by Ratel will be replaced by a single ratel-mcp entry. Other ${hostName} MCP entries are preserved.`,
-  );
-  if (plan.summary.skipped.length > 0) {
-    lines.push("");
-    lines.push("Not copied into Ratel:");
-    for (const s of plan.summary.skipped) {
-      lines.push(`  - ${s.name} (${s.scope})`);
-    }
+function renderImportCommit(plan: ImportPlan, skills: readonly SkillCandidate[]): string {
+  const sections: string[] = [];
+  if (plan.ratelChanges.length > 0) {
+    sections.push(`Ratel config\n${renderDiff(plan.ratelChanges)}`);
   }
-  return lines.join("\n");
+  if (plan.agentChanges.length > 0) {
+    sections.push(`Source agent cleanup\n${renderDiff(plan.agentChanges)}`);
+  }
+  if (skills.length > 0) sections.push(`Skills\n${renderSkillStage(skills)}`);
+  return sections.join("\n\n");
 }
 
 function renderSkillStage(skills: readonly SkillCandidate[]): string {
@@ -792,13 +840,10 @@ function renderCompletion(
   agentState: AgentHostState | null,
   plan: ImportPlan,
   managedSkillCount: number,
-  agentChangesSkipped = false,
 ): string {
   const parts: string[] = ["import complete"];
-  if (agentState && agentChangesSkipped) {
-    parts.push(`${agentState.host.displayName} config changes skipped`);
-  } else if (agentState && plan.agentChanges.length > 0) {
-    parts.push(`restart ${agentState.host.displayName} to pick up the new MCP entry`);
+  if (agentState && plan.agentChanges.length > 0) {
+    parts.push(`${agentState.host.displayName} source entries removed`);
   } else if (agentState && plan.ratelChanges.length > 0) {
     parts.push(`no ${agentState.host.displayName} changes needed`);
   }

--- a/apps/ratel-mcp/src/cli/handlers/import.ts
+++ b/apps/ratel-mcp/src/cli/handlers/import.ts
@@ -82,6 +82,17 @@ type ConflictResolutionResult =
   | { kind: "resolved"; resolution: ConflictResolution }
   | { kind: "cancelled" };
 
+export const IMPORT_USAGE = `usage: ratel-mcp import [flags]
+
+Flags:
+  --agent auto|claude-code|codex
+                              choose the source agent (default: auto)
+  --conflict-strategy add-missing-only|replace-selected|replace-from-agent
+                              choose how matching Ratel definitions are handled
+  --dry-run                   preview changes without writing files
+  --yes                       accept non-interactive defaults
+  --help                      show this help`;
+
 export async function runImport(
   ctx: HandlerCtx,
   opts: ImportFlowOptions = {},

--- a/apps/ratel-mcp/src/cli/handlers/import.ts
+++ b/apps/ratel-mcp/src/cli/handlers/import.ts
@@ -32,7 +32,7 @@ import {
   type SkillSource,
 } from "../skills/manage.js";
 import { runLink } from "./link.js";
-import { maybeAutoInstallStatusline } from "./statusline.js";
+import { runStatuslineInstallStep } from "./statusline.js";
 import type { HandlerCtx } from "./types.js";
 
 export type ProbeFn = (name: string, entry: ServerEntry) => Promise<string | undefined>;
@@ -141,7 +141,6 @@ export async function runImport(
         workspaceRoot: opts.workspaceRoot,
         agentKind: workflowHostKind ?? undefined,
         exists: opts.exists,
-        installStatusline: false,
       });
       if (agentState) {
         agentState = await agentHost.read({ env: ctx.env, fs: ctx.fs });
@@ -275,7 +274,7 @@ export async function runImport(
   }
   if (workflow?.step === "statusline") {
     bin ??= opts.bin ?? (await resolveBin(ctx, opts));
-    await maybeAutoInstallStatusline(ctx, workflow.hostKind, bin);
+    await runStatuslineInstallStep(ctx, { bin, yes: opts.yes });
     workflow = advanceAgentImportWorkflow(workflow, { type: "statusline-completed" });
   }
 

--- a/apps/ratel-mcp/src/cli/handlers/import.ts
+++ b/apps/ratel-mcp/src/cli/handlers/import.ts
@@ -421,7 +421,7 @@ async function previewSkillCandidates(
     now: opts.now,
   });
   return {
-    candidates: result.moved.map((entry) => ({
+    candidates: result.managed.map((entry) => ({
       id: entry.id,
       source: entry.source ?? "claude",
     })),
@@ -472,7 +472,7 @@ async function activateSelectedSkills(
       logger: ctx.log,
       now: opts.now,
     });
-    moved += result.moved.length;
+    moved += result.managed.length;
     skipped.push(...result.skipped);
   }
   if (skipped.length > 0) {

--- a/apps/ratel-mcp/src/cli/handlers/import.ts
+++ b/apps/ratel-mcp/src/cli/handlers/import.ts
@@ -133,18 +133,22 @@ export async function runImport(
       return null;
     }
     if (decision === "link") {
-      await runLink(ctx, {
-        yes: true,
-        bin: opts.bin,
-        envVar: opts.envVar,
-        whichResult: opts.whichResult,
-        workspaceRoot: opts.workspaceRoot,
-        agentKind: workflowHostKind ?? undefined,
-        exists: opts.exists,
-      });
-      if (agentState) {
-        agentState = await agentHost.read({ env: ctx.env, fs: ctx.fs });
-        candidates = collectCandidates(agentState);
+      if (opts.dryRun) {
+        ctx.log(`would link ${detection.displayName} to Ratel before importing`);
+      } else {
+        await runLink(ctx, {
+          yes: true,
+          bin: opts.bin,
+          envVar: opts.envVar,
+          whichResult: opts.whichResult,
+          workspaceRoot: opts.workspaceRoot,
+          agentKind: workflowHostKind ?? undefined,
+          exists: opts.exists,
+        });
+        if (agentState) {
+          agentState = await agentHost.read({ env: ctx.env, fs: ctx.fs });
+          candidates = collectCandidates(agentState);
+        }
       }
       workflow = advanceAgentImportWorkflow(workflow, { type: "link-completed" });
     } else {

--- a/apps/ratel-mcp/src/cli/handlers/import.ts
+++ b/apps/ratel-mcp/src/cli/handlers/import.ts
@@ -20,6 +20,12 @@ import {
 } from "@ratel-ai/mcp-core";
 import { ArgError } from "../args.js";
 import { resolveCliRatelBin } from "../ratel-bin.js";
+import {
+  activateSkills,
+  defaultSkillManagePaths,
+  type SkillManagePaths,
+  type SkillSource,
+} from "../skills/manage.js";
 import { maybeAutoInstallStatusline } from "./statusline.js";
 import type { HandlerCtx } from "./types.js";
 
@@ -36,6 +42,8 @@ export interface ImportFlowOptions {
   agentKind?: SupportedAgentHostKind;
   exists?: (path: string) => Promise<boolean>;
   probe?: ProbeFn;
+  skillPaths?: SkillManagePaths;
+  now?: () => Date;
 }
 
 interface Candidate {
@@ -49,6 +57,16 @@ interface ConflictResolution {
   replaceConflicts?: Set<string>;
 }
 
+interface SkillCandidate {
+  id: string;
+  source: SkillSource;
+}
+
+interface SkillPreview {
+  candidates: SkillCandidate[];
+  skipped: Array<{ id: string; reason: string }>;
+}
+
 type ConflictResolutionResult =
   | { kind: "resolved"; resolution: ConflictResolution }
   | { kind: "cancelled" };
@@ -57,82 +75,117 @@ export async function runImport(
   ctx: HandlerCtx,
   opts: ImportFlowOptions = {},
 ): Promise<BackupManifest | null> {
-  ctx.prompts.intro("Ratel · import agent MCP servers");
+  ctx.prompts.intro("Ratel · import agent MCP servers and skills");
 
   const agentHost = opts.agentKind
     ? new NamedAgentHostAdapter(opts.agentKind)
     : new AutomaticAgentHostAdapter();
   const detection = await agentHost.detect({ env: ctx.env, fs: ctx.fs });
-  if (!detection.present) {
-    ctx.prompts.note("No supported agent MCP servers found at any scope. Nothing to import.");
-    ctx.prompts.outro("done");
-    return null;
+  let agentState: AgentHostState | null = null;
+  let candidates: Candidate[] = [];
+  if (detection.present) {
+    agentState = await agentHost.read({ env: ctx.env, fs: ctx.fs });
+    candidates = collectCandidates(agentState);
   }
-  const agentState = await agentHost.read({ env: ctx.env, fs: ctx.fs });
 
-  const candidates = collectCandidates(agentState);
-  if (candidates.length === 0) {
+  const skillPaths = opts.skillPaths ?? defaultSkillManagePaths(ctx.env.homeDir);
+  const skillPreview = await previewSkillCandidates(skillPaths, {
+    source: resolveSkillSource(opts.agentKind, agentState),
+    now: opts.now,
+  });
+
+  if (!detection.present && skillPreview.candidates.length === 0) {
     ctx.prompts.note(
-      `No ${agentState.host.displayName} MCP servers found at any scope. Nothing to import.`,
+      "No supported agent MCP servers or native skills found at any scope. Nothing to import.",
     );
     ctx.prompts.outro("done");
     return null;
   }
-  ctx.prompts.note(renderDetectedAgentSources(agentState), "Detected agent");
+  if (agentState && candidates.length === 0 && skillPreview.candidates.length === 0) {
+    ctx.prompts.note(
+      `No ${agentState.host.displayName} MCP servers or native skills found at any scope. Nothing to import.`,
+    );
+    ctx.prompts.outro("done");
+    return null;
+  }
 
-  const ratelUserPath = ratelConfigPath("user", ctx.env);
-  const ratelProjectPath = ctx.env.projectRoot ? ratelConfigPath("project", ctx.env) : undefined;
-  const ratelLocalPath = ctx.env.projectRoot ? ratelConfigPath("local", ctx.env) : undefined;
+  if (agentState) {
+    ctx.prompts.note(renderDetectedAgentSources(agentState), "Detected agent");
+  }
+  if (skillPreview.candidates.length > 0 || skillPreview.skipped.length > 0) {
+    ctx.prompts.note(renderDetectedSkills(skillPreview, skillPaths), "Detected skills");
+  }
 
-  const bin = opts.bin ?? (await resolveBin(ctx, opts));
-
-  const ratelUser = await readJson<RatelConfig>(ctx.fs, ratelUserPath);
-  const ratelProject = ratelProjectPath
-    ? await readJson<RatelConfig>(ctx.fs, ratelProjectPath)
-    : null;
-  const ratelLocal = ratelLocalPath ? await readJson<RatelConfig>(ctx.fs, ratelLocalPath) : null;
-
-  const selection = await selectCandidates(ctx, candidates, opts);
+  const selection = candidates.length > 0 ? await selectCandidates(ctx, candidates, opts) : [];
   if (selection === null) {
     ctx.prompts.cancel("import cancelled");
     return null;
   }
-
-  await captureDescriptions(ctx, selection, agentState, opts);
-
-  const planInputs = {
-    agentHost,
-    agentState,
-    ratelUser,
-    ratelProject,
-    ratelLocal,
-    bin,
-    ratelUserPath,
-    ratelProjectPath,
-    ratelLocalPath,
-    projectRoot: ctx.env.projectRoot,
-  };
-  const planOptions = { selection: new Set(selection.map((c) => c.name)) };
-  const initialPlan = await buildAgentImportPlan(planInputs, planOptions);
-  const conflictResolution = await resolveConflictStrategy(
-    ctx,
-    initialPlan,
-    opts,
-    agentState.host.displayName,
-  );
-  if (conflictResolution.kind === "cancelled") {
-    ctx.prompts.cancel("import cancelled (no writes)");
+  const selectedSkills = await selectSkillCandidates(ctx, skillPreview.candidates, opts);
+  if (selectedSkills === null) {
+    ctx.prompts.cancel("import cancelled");
     return null;
   }
 
-  const plan = await buildAgentImportPlan(planInputs, {
-    ...planOptions,
-    ...conflictResolution.resolution,
-  });
+  let plan: ImportPlan = emptyImportPlan();
+  let bin: ResolvedBin | null = null;
 
-  ctx.prompts.note(renderSummary(plan, agentState.host.displayName), "Summary");
+  if (agentState && selection.length > 0) {
+    await captureDescriptions(ctx, selection, agentState, opts);
 
-  if (plan.ratelChanges.length === 0 && plan.agentChanges.length === 0) {
+    const ratelUserPath = ratelConfigPath("user", ctx.env);
+    const ratelProjectPath = ctx.env.projectRoot ? ratelConfigPath("project", ctx.env) : undefined;
+    const ratelLocalPath = ctx.env.projectRoot ? ratelConfigPath("local", ctx.env) : undefined;
+
+    bin = opts.bin ?? (await resolveBin(ctx, opts));
+
+    const ratelUser = await readJson<RatelConfig>(ctx.fs, ratelUserPath);
+    const ratelProject = ratelProjectPath
+      ? await readJson<RatelConfig>(ctx.fs, ratelProjectPath)
+      : null;
+    const ratelLocal = ratelLocalPath ? await readJson<RatelConfig>(ctx.fs, ratelLocalPath) : null;
+
+    const planInputs = {
+      agentHost,
+      agentState,
+      ratelUser,
+      ratelProject,
+      ratelLocal,
+      bin,
+      ratelUserPath,
+      ratelProjectPath,
+      ratelLocalPath,
+      projectRoot: ctx.env.projectRoot,
+    };
+    const planOptions = { selection: new Set(selection.map((c) => c.name)) };
+    const initialPlan = await buildAgentImportPlan(planInputs, planOptions);
+    const conflictResolution = await resolveConflictStrategy(
+      ctx,
+      initialPlan,
+      opts,
+      agentState.host.displayName,
+    );
+    if (conflictResolution.kind === "cancelled") {
+      ctx.prompts.cancel("import cancelled (no writes)");
+      return null;
+    }
+
+    plan = await buildAgentImportPlan(planInputs, {
+      ...planOptions,
+      ...conflictResolution.resolution,
+    });
+  }
+
+  ctx.prompts.note(
+    renderSummary(plan, agentState?.host.displayName ?? "agent", selectedSkills),
+    "Summary",
+  );
+
+  if (
+    plan.ratelChanges.length === 0 &&
+    plan.agentChanges.length === 0 &&
+    selectedSkills.length === 0
+  ) {
     ctx.prompts.outro("nothing to do");
     return null;
   }
@@ -140,6 +193,9 @@ export async function runImport(
   if (opts.dryRun) {
     for (const c of [...plan.ratelChanges, ...plan.agentChanges]) {
       if (c.kind === "write") ctx.log(`would write ${c.path}`);
+    }
+    for (const skill of selectedSkills) {
+      ctx.log(`would manage skill ${skill.id} (${skill.source}) as invoke-only`);
     }
     ctx.prompts.outro("dry-run complete");
     return null;
@@ -161,41 +217,60 @@ export async function runImport(
     stageAManifest = await tryExecute(ctx, plan.ratelChanges, "import");
   }
 
-  if (plan.agentChanges.length === 0) {
+  let latestManifest = stageAManifest;
+
+  if (agentState && plan.agentChanges.length === 0 && bin) {
     await maybeAutoInstallStatusline(ctx, agentState.host.kind, bin);
-    ctx.prompts.outro(`import complete · no ${agentState.host.displayName} changes needed`);
-    return stageAManifest;
   }
 
-  ctx.prompts.note(
-    renderAgentStage(plan, agentState.host.displayName),
-    `${agentState.host.displayName} config changes`,
-  );
-  if (!opts.yes) {
-    const ok = await ctx.prompts.confirm({
-      message: `Replace ${plan.agentChanges.length} ${agentState.host.displayName} entr${
-        plan.agentChanges.length === 1 ? "y" : "ies"
-      } with the ratel-mcp entry?`,
-      initialValue: true,
-    });
-    if (ctx.prompts.isCancel(ok) || ok === false) {
-      ctx.log(
-        `${agentState.host.displayName} config changes skipped. Run \`ratel-mcp link\` (or re-run \`ratel-mcp import\`) to point ${agentState.host.displayName} at Ratel later.`,
-      );
-      ctx.prompts.outro(
-        `Ratel config changes applied · ${agentState.host.displayName} config changes skipped`,
-      );
-      return stageAManifest;
+  if (agentState && plan.agentChanges.length > 0 && bin) {
+    ctx.prompts.note(
+      renderAgentStage(plan, agentState.host.displayName),
+      `${agentState.host.displayName} config changes`,
+    );
+    if (!opts.yes) {
+      const ok = await ctx.prompts.confirm({
+        message: `Replace ${plan.agentChanges.length} ${agentState.host.displayName} entr${
+          plan.agentChanges.length === 1 ? "y" : "ies"
+        } with the ratel-mcp entry?`,
+        initialValue: true,
+      });
+      if (ctx.prompts.isCancel(ok) || ok === false) {
+        ctx.log(
+          `${agentState.host.displayName} config changes skipped. Run \`ratel-mcp link\` (or re-run \`ratel-mcp import\`) to point ${agentState.host.displayName} at Ratel later.`,
+        );
+        ctx.prompts.outro(
+          `Ratel config changes applied · ${agentState.host.displayName} config changes skipped`,
+        );
+        return stageAManifest;
+      }
     }
+    latestManifest = await tryExecute(ctx, plan.agentChanges, "import");
+    await maybeAutoInstallStatusline(ctx, agentState.host.kind, bin);
   }
 
-  const stageBManifest = await tryExecute(ctx, plan.agentChanges, "import");
-  ctx.prompts.note(`Backup created. Run \`ratel-mcp backup list\` to inspect backups.`, "Done");
-  await maybeAutoInstallStatusline(ctx, agentState.host.kind, bin);
-  ctx.prompts.outro(
-    `import complete · restart ${agentState.host.displayName} to pick up the new MCP entry`,
-  );
-  return stageBManifest;
+  if (selectedSkills.length > 0) {
+    ctx.prompts.note(renderSkillStage(selectedSkills), "Skill changes");
+    if (!opts.yes) {
+      const ok = await ctx.prompts.confirm({
+        message: `Manage ${selectedSkills.length} native skill${
+          selectedSkills.length === 1 ? "" : "s"
+        } through Ratel as invoke-only?`,
+        initialValue: true,
+      });
+      if (ctx.prompts.isCancel(ok) || ok === false) {
+        ctx.prompts.cancel("import cancelled (skill changes skipped)");
+        return latestManifest;
+      }
+    }
+    await activateSelectedSkills(ctx, skillPaths, selectedSkills, opts);
+  }
+
+  if (latestManifest) {
+    ctx.prompts.note(`Backup created. Run \`ratel-mcp backup list\` to inspect backups.`, "Done");
+  }
+  ctx.prompts.outro(renderCompletion(agentState, plan, selectedSkills));
+  return latestManifest;
 }
 
 async function resolveConflictStrategy(
@@ -322,6 +397,103 @@ function collectCandidates(state: AgentHostState): Candidate[] {
   return out;
 }
 
+function resolveSkillSource(
+  agentKind: SupportedAgentHostKind | undefined,
+  state: AgentHostState | null,
+): SkillSource | undefined {
+  if (agentKind) return skillSourceForAgentKind(agentKind);
+  return skillSourceForAgentKind(state?.host.kind);
+}
+
+function skillSourceForAgentKind(kind: string | undefined): SkillSource | undefined {
+  if (kind === "claude-code") return "claude";
+  if (kind === "codex") return "codex";
+  return undefined;
+}
+
+async function previewSkillCandidates(
+  paths: SkillManagePaths,
+  opts: { source?: SkillSource; now?: () => Date },
+): Promise<SkillPreview> {
+  const result = await activateSkills(paths, {
+    dryRun: true,
+    source: opts.source,
+    now: opts.now,
+  });
+  return {
+    candidates: result.moved.map((entry) => ({
+      id: entry.id,
+      source: entry.source ?? "claude",
+    })),
+    skipped: result.skipped,
+  };
+}
+
+async function selectSkillCandidates(
+  ctx: HandlerCtx,
+  candidates: SkillCandidate[],
+  opts: ImportFlowOptions,
+): Promise<SkillCandidate[] | null> {
+  if (candidates.length === 0) return [];
+  if (opts.yes) return candidates;
+  const picked = await ctx.prompts.multiselect<string>({
+    message: "Pick native skills to manage through Ratel",
+    options: candidates.map((skill) => ({
+      value: skillTagOf(skill),
+      label: `${skill.id} [${sourceLabel(skill.source)}]`,
+      hint: "Managed as invoke-only; native folder stays in place.",
+    })),
+    initialValues: candidates.map(skillTagOf),
+    required: false,
+  });
+  if (ctx.prompts.isCancel(picked)) return null;
+  const selected = new Set(picked as string[]);
+  return candidates.filter((skill) => selected.has(skillTagOf(skill)));
+}
+
+async function activateSelectedSkills(
+  ctx: HandlerCtx,
+  paths: SkillManagePaths,
+  skills: SkillCandidate[],
+  opts: ImportFlowOptions,
+): Promise<void> {
+  const idsBySource = new Map<SkillSource, string[]>();
+  for (const skill of skills) {
+    const ids = idsBySource.get(skill.source) ?? [];
+    ids.push(skill.id);
+    idsBySource.set(skill.source, ids);
+  }
+  const skipped: Array<{ id: string; reason: string }> = [];
+  let moved = 0;
+  for (const [source, ids] of idsBySource) {
+    const result = await activateSkills(paths, {
+      ids,
+      source,
+      logger: ctx.log,
+      now: opts.now,
+    });
+    moved += result.moved.length;
+    skipped.push(...result.skipped);
+  }
+  if (skipped.length > 0) {
+    throw new Error(skippedSkillsMessage(skipped));
+  }
+  ctx.log(`managing ${moved} skill${moved === 1 ? "" : "s"} as invoke-only`);
+}
+
+function skippedSkillsMessage(skipped: Array<{ id: string; reason: string }>): string {
+  const details = skipped.map((s) => `${s.id}: ${s.reason}`).join("; ");
+  return `could not manage selected skill${skipped.length === 1 ? "" : "s"} (${details})`;
+}
+
+function skillTagOf(skill: SkillCandidate): string {
+  return `${skill.source}:${skill.id}`;
+}
+
+function sourceLabel(source: SkillSource): string {
+  return source === "codex" ? "Codex" : "Claude Code";
+}
+
 function renderDetectedAgentSources(state: AgentHostState): string {
   const lines = [`${state.host.displayName} (${state.host.kind})`];
   for (const scopeState of state.scopes) {
@@ -334,6 +506,32 @@ function renderDetectedAgentSources(state: AgentHostState): string {
         nativeEntries.length === 1 ? "" : "s"
       })`,
     );
+  }
+  return lines.join("\n");
+}
+
+function renderDetectedSkills(preview: SkillPreview, paths: SkillManagePaths): string {
+  const lines: string[] = [];
+  const bySource = new Map<SkillSource, SkillCandidate[]>();
+  for (const skill of preview.candidates) {
+    const skills = bySource.get(skill.source) ?? [];
+    skills.push(skill);
+    bySource.set(skill.source, skills);
+  }
+  for (const source of ["claude", "codex"] as const) {
+    const skills = bySource.get(source) ?? [];
+    if (skills.length === 0) continue;
+    const dir = source === "claude" ? paths.nativeDir : paths.codexDir;
+    lines.push(
+      `- ${sourceLabel(source)}: ${dir} (${skills.length} skill${skills.length === 1 ? "" : "s"})`,
+    );
+  }
+  if (preview.skipped.length > 0) {
+    if (lines.length > 0) lines.push("");
+    lines.push("Already managed or skipped:");
+    for (const skipped of preview.skipped) {
+      lines.push(`  - ${skipped.id}: ${skipped.reason}`);
+    }
   }
   return lines.join("\n");
 }
@@ -442,7 +640,31 @@ async function resolveBin(ctx: HandlerCtx, opts: ImportFlowOptions): Promise<Res
   });
 }
 
-function renderSummary(plan: ImportPlan, agentHostName: string): string {
+function emptyImportPlan(): ImportPlan {
+  return {
+    ratelChanges: [],
+    agentChanges: [],
+    summary: {
+      movedFromUser: [],
+      movedFromProject: [],
+      movedFromLocal: [],
+      replacedFromUser: [],
+      replacedFromProject: [],
+      replacedFromLocal: [],
+      skipped: [],
+      conflicts: [],
+      conflictStrategy: "add-missing-only",
+      ratelEntryArgsByScope: {},
+      overwrittenRatelEntries: [],
+    },
+  };
+}
+
+function renderSummary(
+  plan: ImportPlan,
+  agentHostName: string,
+  selectedSkills: readonly SkillCandidate[],
+): string {
   const lines: string[] = [];
   if (plan.summary.movedFromUser.length > 0) {
     lines.push(`user: ${plan.summary.movedFromUser.join(", ")}`);
@@ -468,6 +690,13 @@ function renderSummary(plan: ImportPlan, agentHostName: string): string {
         agentHostName,
       )})`,
     );
+  }
+  if (selectedSkills.length > 0) {
+    lines.push("");
+    lines.push("Skills to manage:");
+    for (const skill of selectedSkills) {
+      lines.push(`  - ${skill.id} (${sourceLabel(skill.source)})`);
+    }
   }
   if (plan.summary.overwrittenRatelEntries.length > 0) {
     lines.push("");
@@ -535,4 +764,29 @@ function renderAgentStage(plan: ImportPlan, hostName = "agent"): string {
     }
   }
   return lines.join("\n");
+}
+
+function renderSkillStage(skills: readonly SkillCandidate[]): string {
+  return skills
+    .map((skill) => `manage ${skill.id} (${sourceLabel(skill.source)}) as invoke-only`)
+    .join("\n");
+}
+
+function renderCompletion(
+  agentState: AgentHostState | null,
+  plan: ImportPlan,
+  selectedSkills: readonly SkillCandidate[],
+): string {
+  const parts: string[] = ["import complete"];
+  if (agentState && plan.agentChanges.length > 0) {
+    parts.push(`restart ${agentState.host.displayName} to pick up the new MCP entry`);
+  } else if (agentState && plan.ratelChanges.length > 0) {
+    parts.push(`no ${agentState.host.displayName} changes needed`);
+  }
+  if (selectedSkills.length > 0) {
+    parts.push(
+      `managing ${selectedSkills.length} skill${selectedSkills.length === 1 ? "" : "s"} as invoke-only`,
+    );
+  }
+  return parts.join(" · ");
 }

--- a/apps/ratel-mcp/src/cli/handlers/import.ts
+++ b/apps/ratel-mcp/src/cli/handlers/import.ts
@@ -121,6 +121,7 @@ export async function runImport(
   }
 
   const workflowHostKind = resolveWorkflowHostKind(opts.agentKind, agentState);
+  let linkCommitted = false;
   let workflow = workflowHostKind
     ? await beginCliImportWorkflow(ctx, workflowHostKind, agentState)
     : null;
@@ -136,7 +137,7 @@ export async function runImport(
       if (opts.dryRun) {
         ctx.log(`would link ${detection.displayName} to Ratel before importing`);
       } else {
-        await runLink(ctx, {
+        const linkManifest = await runLink(ctx, {
           yes: true,
           bin: opts.bin,
           envVar: opts.envVar,
@@ -145,6 +146,7 @@ export async function runImport(
           agentKind: workflowHostKind ?? undefined,
           exists: opts.exists,
         });
+        linkCommitted = linkManifest !== null;
         if (agentState) {
           agentState = await agentHost.read({ env: ctx.env, fs: ctx.fs });
           candidates = collectCandidates(agentState);
@@ -213,7 +215,7 @@ export async function runImport(
       agentState.host.displayName,
     );
     if (conflictResolution.kind === "cancelled") {
-      ctx.prompts.cancel("import cancelled (no writes)");
+      ctx.prompts.cancel(importCancellationMessage(linkCommitted));
       return null;
     }
 
@@ -255,7 +257,7 @@ export async function runImport(
       initialValue: true,
     });
     if (ctx.prompts.isCancel(ok) || ok === false) {
-      ctx.prompts.cancel("import cancelled (no writes)");
+      ctx.prompts.cancel(importCancellationMessage(linkCommitted));
       return null;
     }
   }
@@ -558,6 +560,10 @@ async function activateSelectedSkills(
 function skippedSkillsMessage(skipped: Array<{ id: string; reason: string }>): string {
   const details = skipped.map((s) => `${s.id}: ${s.reason}`).join("; ");
   return `could not manage selected skill${skipped.length === 1 ? "" : "s"} (${details})`;
+}
+
+function importCancellationMessage(linkCommitted: boolean): string {
+  return linkCommitted ? "import cancelled · link retained" : "import cancelled (no writes)";
 }
 
 function skillTagOf(skill: SkillCandidate): string {

--- a/apps/ratel-mcp/src/cli/handlers/import.ts
+++ b/apps/ratel-mcp/src/cli/handlers/import.ts
@@ -67,6 +67,11 @@ interface SkillPreview {
   skipped: Array<{ id: string; reason: string }>;
 }
 
+interface SkillImportResult {
+  managed: number;
+  skipped: Array<{ id: string; reason: string }>;
+}
+
 type ConflictResolutionResult =
   | { kind: "resolved"; resolution: ConflictResolution }
   | { kind: "cancelled" };
@@ -246,6 +251,7 @@ export async function runImport(
     }
   }
 
+  let skillImportResult: SkillImportResult = { managed: 0, skipped: [] };
   if (selectedSkills.length > 0) {
     ctx.prompts.note(renderSkillStage(selectedSkills), "Skill changes");
     if (!opts.yes) {
@@ -260,7 +266,7 @@ export async function runImport(
         return latestManifest;
       }
     }
-    await activateSelectedSkills(ctx, skillPaths, selectedSkills, opts);
+    skillImportResult = await activateSelectedSkills(ctx, skillPaths, selectedSkills, opts);
   }
 
   const statuslineHostKind = agentState?.host.kind ?? opts.agentKind;
@@ -276,7 +282,9 @@ export async function runImport(
   if (latestManifest) {
     ctx.prompts.note(`Backup created. Run \`ratel-mcp backup list\` to inspect backups.`, "Done");
   }
-  ctx.prompts.outro(renderCompletion(agentState, plan, selectedSkills, agentChangesSkipped));
+  ctx.prompts.outro(
+    renderCompletion(agentState, plan, skillImportResult.managed, agentChangesSkipped),
+  );
   return latestManifest;
 }
 
@@ -463,7 +471,7 @@ async function activateSelectedSkills(
   paths: SkillManagePaths,
   skills: SkillCandidate[],
   opts: ImportFlowOptions,
-): Promise<void> {
+): Promise<SkillImportResult> {
   const idsBySource = new Map<SkillSource, string[]>();
   for (const skill of skills) {
     const ids = idsBySource.get(skill.source) ?? [];
@@ -471,7 +479,7 @@ async function activateSelectedSkills(
     idsBySource.set(skill.source, ids);
   }
   const skipped: Array<{ id: string; reason: string }> = [];
-  let moved = 0;
+  let managed = 0;
   for (const [source, ids] of idsBySource) {
     const result = await activateSkills(paths, {
       ids,
@@ -479,13 +487,14 @@ async function activateSelectedSkills(
       logger: ctx.log,
       now: opts.now,
     });
-    moved += result.managed.length;
+    managed += result.managed.length;
     skipped.push(...result.skipped);
   }
+  ctx.log(`managing ${managed} skill${managed === 1 ? "" : "s"} as invoke-only`);
   if (skipped.length > 0) {
-    throw new Error(skippedSkillsMessage(skipped));
+    ctx.log(`warning: ${skippedSkillsMessage(skipped)}`);
   }
-  ctx.log(`managing ${moved} skill${moved === 1 ? "" : "s"} as invoke-only`);
+  return { managed, skipped };
 }
 
 function skippedSkillsMessage(skipped: Array<{ id: string; reason: string }>): string {
@@ -782,7 +791,7 @@ function renderSkillStage(skills: readonly SkillCandidate[]): string {
 function renderCompletion(
   agentState: AgentHostState | null,
   plan: ImportPlan,
-  selectedSkills: readonly SkillCandidate[],
+  managedSkillCount: number,
   agentChangesSkipped = false,
 ): string {
   const parts: string[] = ["import complete"];
@@ -793,9 +802,9 @@ function renderCompletion(
   } else if (agentState && plan.ratelChanges.length > 0) {
     parts.push(`no ${agentState.host.displayName} changes needed`);
   }
-  if (selectedSkills.length > 0) {
+  if (managedSkillCount > 0) {
     parts.push(
-      `managing ${selectedSkills.length} skill${selectedSkills.length === 1 ? "" : "s"} as invoke-only`,
+      `managing ${managedSkillCount} skill${managedSkillCount === 1 ? "" : "s"} as invoke-only`,
     );
   }
   return parts.join(" · ");

--- a/apps/ratel-mcp/src/cli/handlers/import.ts
+++ b/apps/ratel-mcp/src/cli/handlers/import.ts
@@ -218,10 +218,8 @@ export async function runImport(
   }
 
   let latestManifest = stageAManifest;
-
-  if (agentState && plan.agentChanges.length === 0 && bin) {
-    await maybeAutoInstallStatusline(ctx, agentState.host.kind, bin);
-  }
+  let agentChangesApplied = false;
+  let agentChangesSkipped = false;
 
   if (agentState && plan.agentChanges.length > 0 && bin) {
     ctx.prompts.note(
@@ -239,14 +237,13 @@ export async function runImport(
         ctx.log(
           `${agentState.host.displayName} config changes skipped. Run \`ratel-mcp link\` (or re-run \`ratel-mcp import\`) to point ${agentState.host.displayName} at Ratel later.`,
         );
-        ctx.prompts.outro(
-          `Ratel config changes applied · ${agentState.host.displayName} config changes skipped`,
-        );
-        return stageAManifest;
+        agentChangesSkipped = true;
       }
     }
-    latestManifest = await tryExecute(ctx, plan.agentChanges, "import");
-    await maybeAutoInstallStatusline(ctx, agentState.host.kind, bin);
+    if (!agentChangesSkipped) {
+      latestManifest = await tryExecute(ctx, plan.agentChanges, "import");
+      agentChangesApplied = true;
+    }
   }
 
   if (selectedSkills.length > 0) {
@@ -266,10 +263,20 @@ export async function runImport(
     await activateSelectedSkills(ctx, skillPaths, selectedSkills, opts);
   }
 
+  const statuslineHostKind = agentState?.host.kind ?? opts.agentKind;
+  const shouldInstallStatusline =
+    statuslineHostKind === "claude-code" &&
+    (selectedSkills.length > 0 || agentChangesApplied || plan.agentChanges.length === 0) &&
+    !agentChangesSkipped;
+  if (shouldInstallStatusline) {
+    bin ??= opts.bin ?? (await resolveBin(ctx, opts));
+    await maybeAutoInstallStatusline(ctx, statuslineHostKind, bin);
+  }
+
   if (latestManifest) {
     ctx.prompts.note(`Backup created. Run \`ratel-mcp backup list\` to inspect backups.`, "Done");
   }
-  ctx.prompts.outro(renderCompletion(agentState, plan, selectedSkills));
+  ctx.prompts.outro(renderCompletion(agentState, plan, selectedSkills, agentChangesSkipped));
   return latestManifest;
 }
 
@@ -776,9 +783,12 @@ function renderCompletion(
   agentState: AgentHostState | null,
   plan: ImportPlan,
   selectedSkills: readonly SkillCandidate[],
+  agentChangesSkipped = false,
 ): string {
   const parts: string[] = ["import complete"];
-  if (agentState && plan.agentChanges.length > 0) {
+  if (agentState && agentChangesSkipped) {
+    parts.push(`${agentState.host.displayName} config changes skipped`);
+  } else if (agentState && plan.agentChanges.length > 0) {
     parts.push(`restart ${agentState.host.displayName} to pick up the new MCP entry`);
   } else if (agentState && plan.ratelChanges.length > 0) {
     parts.push(`no ${agentState.host.displayName} changes needed`);

--- a/apps/ratel-mcp/src/cli/handlers/link.test.ts
+++ b/apps/ratel-mcp/src/cli/handlers/link.test.ts
@@ -55,7 +55,7 @@ function ctxOf(
   return {
     logs,
     ctx: {
-      argv: { group: "mcp", verb: "link", configPaths: [], rest: [], extras: [], flags: {} },
+      argv: { group: "link", configPaths: [], rest: [], extras: [], flags: {} },
       env: { homeDir: HOME, projectRoot: withProjectRoot ? ROOT : undefined },
       fs,
       log: (m) => logs.push(m),

--- a/apps/ratel-mcp/src/cli/handlers/link.test.ts
+++ b/apps/ratel-mcp/src/cli/handlers/link.test.ts
@@ -104,7 +104,7 @@ describe("runLink", () => {
     expect(claude.mcpServers.other).toEqual({ type: "stdio", command: "elsewhere" });
   });
 
-  it("auto-installs the Claude Code statusline after linking", async () => {
+  it("does not install the Claude Code statusline as part of linking", async () => {
     const fs = new MemFs();
     fs.files.set(
       RATEL_USER,
@@ -114,16 +114,10 @@ describe("runLink", () => {
     const { ctx } = ctxOf(fs, autoConfirm(), false);
     await runLink(ctx, { bin: BIN, yes: true });
 
-    const settings = JSON.parse(fs.files.get("/home/u/.claude/settings.json") as string);
-    expect(settings.statusLine).toEqual({
-      type: "command",
-      command: "ratel-mcp statusline",
-      padding: 0,
-      refreshInterval: 30,
-    });
+    expect(fs.files.has("/home/u/.claude/settings.json")).toBe(false);
   });
 
-  it("leaves an existing non-Ratel statusline alone", async () => {
+  it("leaves an existing statusline untouched", async () => {
     const fs = new MemFs();
     fs.files.set(
       RATEL_USER,

--- a/apps/ratel-mcp/src/cli/handlers/link.ts
+++ b/apps/ratel-mcp/src/cli/handlers/link.ts
@@ -23,6 +23,14 @@ export interface LinkOptions {
   exists?: (path: string) => Promise<boolean>;
 }
 
+export const LINK_USAGE = `usage: ratel-mcp link [flags]
+
+Flags:
+  --agent auto|claude-code|codex
+                              choose the agent to link (default: auto)
+  --yes                       skip the confirmation prompt
+  --help                      show this help`;
+
 export async function runLink(
   ctx: HandlerCtx,
   opts: LinkOptions = {},

--- a/apps/ratel-mcp/src/cli/handlers/link.ts
+++ b/apps/ratel-mcp/src/cli/handlers/link.ts
@@ -22,6 +22,7 @@ export interface LinkOptions {
   workspaceRoot?: string;
   agentKind?: SupportedAgentHostKind;
   exists?: (path: string) => Promise<boolean>;
+  installStatusline?: boolean;
 }
 
 export async function runLink(
@@ -51,16 +52,6 @@ export async function runLink(
     : null;
   const ratelLocal = ratelLocalPath ? await readJson<RatelConfig>(ctx.fs, ratelLocalPath) : null;
 
-  const ratelKnown = new Set<string>();
-  for (const cfg of [ratelUser, ratelProject, ratelLocal]) {
-    if (cfg) for (const name of Object.keys(cfg.mcpServers)) ratelKnown.add(name);
-  }
-  if (ratelKnown.size === 0) {
-    ctx.prompts.note("No Ratel entries found at any scope. Nothing to link.");
-    ctx.prompts.outro("done");
-    return null;
-  }
-
   const bin = opts.bin ?? (await resolveBin(ctx, opts));
 
   const plan = await buildAgentLinkPlan({
@@ -77,7 +68,9 @@ export async function runLink(
   });
 
   if (plan.agentChanges.length === 0) {
-    await maybeAutoInstallStatusline(ctx, agentState.host.kind, bin);
+    if (opts.installStatusline !== false) {
+      await maybeAutoInstallStatusline(ctx, agentState.host.kind, bin);
+    }
     ctx.prompts.outro(`nothing to do (${agentState.host.displayName} already points at Ratel)`);
     return null;
   }
@@ -103,7 +96,9 @@ export async function runLink(
     action: "link",
   });
   ctx.prompts.note(`Backup created. Run \`ratel-mcp backup list\` to inspect backups.`, "Done");
-  await maybeAutoInstallStatusline(ctx, agentState.host.kind, bin);
+  if (opts.installStatusline !== false) {
+    await maybeAutoInstallStatusline(ctx, agentState.host.kind, bin);
+  }
   ctx.prompts.outro(
     `link complete · restart ${agentState.host.displayName} to pick up the new MCP entry`,
   );

--- a/apps/ratel-mcp/src/cli/handlers/link.ts
+++ b/apps/ratel-mcp/src/cli/handlers/link.ts
@@ -11,7 +11,6 @@ import {
   type SupportedAgentHostKind,
 } from "@ratel-ai/mcp-core";
 import { resolveCliRatelBin } from "../ratel-bin.js";
-import { maybeAutoInstallStatusline } from "./statusline.js";
 import type { HandlerCtx } from "./types.js";
 
 export interface LinkOptions {
@@ -22,7 +21,6 @@ export interface LinkOptions {
   workspaceRoot?: string;
   agentKind?: SupportedAgentHostKind;
   exists?: (path: string) => Promise<boolean>;
-  installStatusline?: boolean;
 }
 
 export async function runLink(
@@ -68,9 +66,6 @@ export async function runLink(
   });
 
   if (plan.agentChanges.length === 0) {
-    if (opts.installStatusline !== false) {
-      await maybeAutoInstallStatusline(ctx, agentState.host.kind, bin);
-    }
     ctx.prompts.outro(`nothing to do (${agentState.host.displayName} already points at Ratel)`);
     return null;
   }
@@ -96,9 +91,6 @@ export async function runLink(
     action: "link",
   });
   ctx.prompts.note(`Backup created. Run \`ratel-mcp backup list\` to inspect backups.`, "Done");
-  if (opts.installStatusline !== false) {
-    await maybeAutoInstallStatusline(ctx, agentState.host.kind, bin);
-  }
   ctx.prompts.outro(
     `link complete · restart ${agentState.host.displayName} to pick up the new MCP entry`,
   );

--- a/apps/ratel-mcp/src/cli/handlers/mcp.ts
+++ b/apps/ratel-mcp/src/cli/handlers/mcp.ts
@@ -19,8 +19,9 @@ Verbs:
   list    list MCP servers configured across Ratel scopes
   get     show one entry's resolved details
   edit    edit fields on an existing entry (interactive when no flags supplied)
-  import  migrate Claude Code MCP configs into Ratel (two stages: Ratel write, then Claude rewrite)
-  link    rewrite Claude Code's config to point at Ratel for entries already in Ratel scopes
+  import  migrate agent MCP configs and native skills into Ratel
+          (config import is two stages: Ratel write, then agent rewrite)
+  link    rewrite an agent config to point at Ratel for entries already in Ratel scopes
   auth    drive an interactive OAuth flow for one or all http/sse upstreams that need authorization
 
 Agent-aware verbs accept --agent auto|claude-code|codex (default: auto).

--- a/apps/ratel-mcp/src/cli/handlers/mcp.ts
+++ b/apps/ratel-mcp/src/cli/handlers/mcp.ts
@@ -1,10 +1,7 @@
-import { type ImportConflictStrategy, isSupportedAgentHostKind } from "@ratel-ai/mcp-core";
 import { ArgError } from "../args.js";
 import { runAdd } from "./add.js";
 import { runEdit } from "./edit.js";
 import { runMcpGet } from "./get.js";
-import { runImport } from "./import.js";
-import { runLink } from "./link.js";
 import { runMcpAuth } from "./mcp-auth.js";
 import { runMcpList } from "./mcp-list.js";
 import { runRemove } from "./remove.js";
@@ -19,17 +16,14 @@ Verbs:
   list    list MCP servers configured across Ratel scopes
   get     show one entry's resolved details
   edit    edit fields on an existing entry (interactive when no flags supplied)
-  import  migrate agent MCP configs and native skills into Ratel
-          (config import is two stages: Ratel write, then agent rewrite)
-  link    rewrite an agent config to point at Ratel for entries already in Ratel scopes
   auth    drive an interactive OAuth flow for one or all http/sse upstreams that need authorization
 
-Agent-aware verbs accept --agent auto|claude-code|codex (default: auto).
-
+To import agent MCP configs and skills, see \`ratel-mcp import\`.
+To point an agent at Ratel, see \`ratel-mcp link\`.
 To start the gateway, see \`ratel-mcp serve\`.`;
 
 export async function runMcp(ctx: HandlerCtx): Promise<void> {
-  const { verb, flags } = ctx.argv;
+  const { verb } = ctx.argv;
   switch (verb) {
     case "add":
       await runAdd(ctx);
@@ -46,51 +40,10 @@ export async function runMcp(ctx: HandlerCtx): Promise<void> {
     case "edit":
       await runEdit(ctx);
       return;
-    case "import":
-      await runImport(ctx, {
-        yes: flags.yes === true,
-        dryRun: flags["dry-run"] === true,
-        conflictStrategy: resolveImportConflictStrategy(flags["conflict-strategy"]),
-        agentKind: resolveAgentKind(flags.agent),
-      });
-      return;
-    case "link":
-      await runLink(ctx, { yes: flags.yes === true, agentKind: resolveAgentKind(flags.agent) });
-      return;
     case "auth":
       await runMcpAuth(ctx);
       return;
     default:
       throw new ArgError(`unknown mcp verb: ${verb}`);
   }
-}
-
-function resolveAgentKind(value: unknown) {
-  if (value === undefined || value === false || value === "auto") return undefined;
-  if (typeof value !== "string") {
-    throw new ArgError("--agent must be one of auto|claude-code|codex");
-  }
-  if (!isSupportedAgentHostKind(value)) {
-    throw new ArgError(`--agent must be one of auto|claude-code|codex, got "${value}"`);
-  }
-  return value;
-}
-
-function resolveImportConflictStrategy(value: unknown): ImportConflictStrategy | undefined {
-  if (value === undefined || value === false) return undefined;
-  if (typeof value !== "string") {
-    throw new ArgError(
-      "--conflict-strategy must be one of add-missing-only|replace-selected|replace-from-agent",
-    );
-  }
-  if (
-    value !== "add-missing-only" &&
-    value !== "replace-selected" &&
-    value !== "replace-from-agent"
-  ) {
-    throw new ArgError(
-      `--conflict-strategy must be one of add-missing-only|replace-selected|replace-from-agent, got "${value}"`,
-    );
-  }
-  return value;
 }

--- a/apps/ratel-mcp/src/cli/handlers/statusline.ts
+++ b/apps/ratel-mcp/src/cli/handlers/statusline.ts
@@ -1,5 +1,5 @@
 import {
-  ClaudeStatuslineConflictError,
+  getClaudeCodeStatuslineState,
   installClaudeCodeStatusline,
   type ResolvedBin,
   renderRatelStatusline,
@@ -10,33 +10,44 @@ import { resolveCliRatelBin } from "../ratel-bin.js";
 import { readStdin } from "../stdin.js";
 import type { HandlerCtx } from "./types.js";
 
-/**
- * Best-effort statusline install invoked after `link`/`import` wire up Claude
- * Code, so users get it without a separate `statusline install` step. Never
- * blocks or fails the caller: a pre-existing non-Ratel statusLine is left
- * alone (reported as a note) rather than treated as a conflict to resolve.
- */
-export async function maybeAutoInstallStatusline(
+export async function runStatuslineInstallStep(
   ctx: HandlerCtx,
-  agentHostKind: string,
-  bin: ResolvedBin,
-): Promise<void> {
-  if (agentHostKind !== "claude-code") return;
-  try {
-    const result = await installClaudeCodeStatusline(ctx, { bin });
-    if (result.changed) {
-      ctx.prompts.note(`Installed the Ratel statusline into ${result.path}`, "Statusline");
-    }
-  } catch (err) {
-    if (err instanceof ClaudeStatuslineConflictError) {
-      ctx.prompts.note(
-        "Skipped statusline install: a non-Ratel statusLine is already configured. Run `ratel-mcp statusline install --force` to replace it.",
-        "Statusline",
-      );
-      return;
-    }
-    throw err;
+  opts: { bin: ResolvedBin; yes?: boolean },
+): Promise<"installed" | "already-installed" | "skipped"> {
+  const state = await getClaudeCodeStatuslineState(ctx);
+  if (state.status === "installed") return "already-installed";
+
+  if (opts.yes && state.status === "other") {
+    ctx.prompts.note(
+      "Skipped statusline install: a non-Ratel statusLine is already configured. Run `ratel-mcp statusline install --force` to replace it.",
+      "Statusline",
+    );
+    return "skipped";
   }
+
+  if (!opts.yes) {
+    const answer = await ctx.prompts.confirm({
+      message:
+        state.status === "other"
+          ? "Replace the existing non-Ratel statusline with the Ratel statusline?"
+          : "Install the standalone Ratel statusline now?",
+      initialValue: true,
+    });
+    if (ctx.prompts.isCancel(answer) || answer === false) {
+      ctx.prompts.note("Skipped the standalone statusline install.", "Statusline");
+      return "skipped";
+    }
+  }
+
+  const result = await installClaudeCodeStatusline(ctx, {
+    bin: opts.bin,
+    force: state.status === "other",
+  });
+  if (result.changed) {
+    ctx.prompts.note(`Installed the Ratel statusline into ${result.path}`, "Statusline");
+    return "installed";
+  }
+  return "already-installed";
 }
 
 export const STATUSLINE_USAGE = `usage: ratel-mcp statusline [install|uninstall]

--- a/apps/ratel-mcp/src/ui/server.test.ts
+++ b/apps/ratel-mcp/src/ui/server.test.ts
@@ -413,7 +413,7 @@ describe("UI server — agent previews", () => {
     expect(agentRes.status).toBe(200);
     const claude = JSON.parse(session.fs.files.get(CLAUDE_PATH) as string);
     expect(claude.mcpServers.fs).toBeUndefined();
-    expect(claude.mcpServers["ratel-mcp"].command).toBe(process.argv[1]);
+    expect(claude.mcpServers["ratel-mcp"]).toBeUndefined();
   });
 
   it("rejects stale apply hashes", async () => {
@@ -449,10 +449,6 @@ describe("UI server — agent previews", () => {
 
   it("applies link to agent files only", async () => {
     session.fs.files.set(
-      USER_PATH,
-      JSON.stringify({ mcpServers: { fs: { type: "stdio", command: "echo" } } }),
-    );
-    session.fs.files.set(
       CLAUDE_PATH,
       JSON.stringify({ mcpServers: { fs: { type: "stdio", command: "echo" } } }),
     );
@@ -464,7 +460,7 @@ describe("UI server — agent previews", () => {
       })
     ).json()) as { selected: string[]; stageHashes: { agent: string } };
     expect(preview.selected).toEqual([]);
-    const beforeRatel = session.fs.files.get(USER_PATH);
+    expect(session.fs.files.has(USER_PATH)).toBe(false);
 
     const res = await fetch(apiUrl("/api/agent-apply/link"), {
       method: "POST",
@@ -475,7 +471,7 @@ describe("UI server — agent previews", () => {
       }),
     });
     expect(res.status).toBe(200);
-    expect(session.fs.files.get(USER_PATH)).toBe(beforeRatel);
+    expect(session.fs.files.has(USER_PATH)).toBe(false);
     const claude = JSON.parse(session.fs.files.get(CLAUDE_PATH) as string);
     expect(claude.mcpServers.fs.command).toBe("echo");
     expect(claude.mcpServers["ratel-mcp"].args).toContain(USER_PATH);

--- a/examples/claude-with-ratel/README.md
+++ b/examples/claude-with-ratel/README.md
@@ -60,6 +60,6 @@ Critical signal: every tool call you see in the UI is `mcp__ratel-mcp__*`. If yo
 
 To aggregate your own MCPs, edit `ratel-config.json`. The shape mirrors Claude Code's `mcpServers` field — for migrating your existing setup, copy the relevant entries from `~/.claude.json` here. Stdio and HTTP transports are supported; SSE and unknown types are skipped at runtime with a stderr warning. If one upstream fails to start, ratel-mcp logs it and continues — the session stays up.
 
-For a non-isolated installation (i.e. you want ratel-mcp to take over your real Claude Code MCP setup, not a sandboxed `--mcp-config` session), use the `ratel-mcp mcp import` wizard instead of this template.
+For a non-isolated installation (i.e. you want ratel-mcp to take over your real Claude Code MCP setup, not a sandboxed `--mcp-config` session), use the `ratel-mcp import` wizard instead of this template.
 
 For details on the library API itself (gateway construction, result wrapping, transport boundary adaptations), see the [repo README](../../README.md).

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -7,6 +7,10 @@
     ".": {
       "types": "./src/index.ts",
       "default": "./src/index.ts"
+    },
+    "./agent-import-workflow": {
+      "types": "./src/agent-import-workflow.ts",
+      "default": "./src/agent-import-workflow.ts"
     }
   },
   "scripts": {

--- a/packages/core/src/agent-host/claude-code.test.ts
+++ b/packages/core/src/agent-host/claude-code.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import type { ServerEntry } from "../lib/index.js";
 import { ClaudeCodeAgentHostAdapter } from "./claude-code.js";
-import type { AgentHostContext, AgentScope, GatewayLinkInput } from "./index.js";
+import type { AgentHostContext, AgentHostPlanInput, AgentScope } from "./index.js";
 
 const HOME = "/home/u";
 const ROOT = "/r";
@@ -37,8 +37,8 @@ function ctxOf(
 
 function linkInput(
   state: Awaited<ReturnType<ClaudeCodeAgentHostAdapter["read"]>>,
-  replacedEntriesByScope: Map<AgentScope, Set<string>>,
-): GatewayLinkInput {
+  removeEntriesByScope: Map<AgentScope, Set<string>>,
+): AgentHostPlanInput {
   return {
     state,
     bin: BIN,
@@ -47,7 +47,7 @@ function linkInput(
       project: RATEL_PROJECT,
       local: RATEL_LOCAL,
     },
-    replacedEntriesByScope,
+    removeEntriesByScope,
   };
 }
 
@@ -128,7 +128,7 @@ describe("ClaudeCodeAgentHostAdapter", () => {
     });
     const state = await adapter.read(ctx);
 
-    const changes = await adapter.link(
+    const changes = await adapter.planChanges(
       linkInput(
         state,
         new Map([
@@ -144,25 +144,13 @@ describe("ClaudeCodeAgentHostAdapter", () => {
     expect(after.version).toBe(7);
     expect(after.mcpServers.fs).toBeUndefined();
     expect(after.mcpServers.keep).toEqual({ type: "stdio", command: "keep" });
-    expect(after.mcpServers["ratel-mcp"]).toEqual({
-      type: "stdio",
-      command: "ratel-mcp",
-      args: ["serve", "--config", RATEL_USER],
-    });
+    expect(after.mcpServers["ratel-mcp"].args).toEqual(["serve", "--config", "old"]);
     expect(after.projects[ROOT].mcpServers.local).toBeUndefined();
     expect(after.projects[ROOT].mcpServers.untouched).toEqual({
       type: "stdio",
       command: "untouched",
     });
-    expect(after.projects[ROOT].mcpServers["ratel-mcp"].args).toEqual([
-      "serve",
-      "--config",
-      RATEL_USER,
-      "--config",
-      RATEL_PROJECT,
-      "--config",
-      RATEL_LOCAL,
-    ]);
+    expect(after.projects[ROOT].mcpServers["ratel-mcp"]).toBeUndefined();
     expect(after.projects["/elsewhere"]).toEqual({
       mcpServers: { other: { type: "stdio", command: "x" } },
     });
@@ -181,19 +169,15 @@ describe("ClaudeCodeAgentHostAdapter", () => {
     });
     const state = await adapter.read(ctx);
 
-    const changes = await adapter.link(linkInput(state, new Map([["project", new Set(["proj"])]])));
+    const changes = await adapter.planChanges(
+      linkInput(state, new Map([["project", new Set(["proj"])]])),
+    );
 
     expect(changes.changes).toHaveLength(1);
     expect(changes.changes[0].path).toBe(PROJECT_MCP);
     const after = JSON.parse(changes.changes[0].after);
     expect(after.mcpServers.proj).toBeUndefined();
     expect(after.mcpServers.keep).toEqual({ type: "stdio", command: "keep" });
-    expect(after.mcpServers["ratel-mcp"].args).toEqual([
-      "serve",
-      "--config",
-      RATEL_USER,
-      "--config",
-      RATEL_PROJECT,
-    ]);
+    expect(after.mcpServers["ratel-mcp"]).toBeUndefined();
   });
 });

--- a/packages/core/src/agent-host/claude-code.ts
+++ b/packages/core/src/agent-host/claude-code.ts
@@ -14,11 +14,11 @@ import type {
   AgentHostChangeSet,
   AgentHostContext,
   AgentHostDetection,
+  AgentHostPlanInput,
   AgentHostRemovedEntry,
   AgentHostState,
   AgentScope,
   AgentScopeState,
-  GatewayLinkInput,
   RatelConfigPaths,
 } from "./index.js";
 
@@ -65,7 +65,7 @@ export class ClaudeCodeAgentHostAdapter implements AgentHostAdapter {
     return { host: { kind: "claude-code", displayName: "Claude Code" }, scopes };
   }
 
-  async link(input: GatewayLinkInput): Promise<AgentHostChangeSet> {
+  async planChanges(input: AgentHostPlanInput): Promise<AgentHostChangeSet> {
     const changes: FileChange[] = [];
     const installedGatewayScopes: AgentScope[] = [];
     const removedNativeEntries: AgentHostRemovedEntry[] = [];
@@ -73,14 +73,15 @@ export class ClaudeCodeAgentHostAdapter implements AgentHostAdapter {
     const user = byScope.user;
     const project = byScope.project;
     const local = byScope.local;
-    const userRemove = input.replacedEntriesByScope.get("user");
-    const projectRemove = input.replacedEntriesByScope.get("project");
-    const localRemove = input.replacedEntriesByScope.get("local");
-    const userInstall = Boolean(userRemove?.size || input.installGatewayScopes?.has("user"));
-    const projectInstall = Boolean(
-      projectRemove?.size || input.installGatewayScopes?.has("project"),
-    );
-    const localInstall = Boolean(localRemove?.size || input.installGatewayScopes?.has("local"));
+    const userRemove = input.removeEntriesByScope.get("user");
+    const projectRemove = input.removeEntriesByScope.get("project");
+    const localRemove = input.removeEntriesByScope.get("local");
+    const userInstall = input.installGatewayScopes?.has("user") ?? false;
+    const projectInstall = input.installGatewayScopes?.has("project") ?? false;
+    const localInstall = input.installGatewayScopes?.has("local") ?? false;
+    const userWrite = Boolean(userRemove?.size || userInstall);
+    const projectWrite = Boolean(projectRemove?.size || projectInstall);
+    const localWrite = Boolean(localRemove?.size || localInstall);
     const userGateway = userInstall
       ? makeRatelGatewayEntry({ bin: input.bin, configPaths: [input.ratelConfigPaths.user] })
       : undefined;
@@ -104,25 +105,24 @@ export class ClaudeCodeAgentHostAdapter implements AgentHostAdapter {
         : undefined;
 
     const home = user ?? local;
-    if (home?.raw && (userInstall || localInstall)) {
+    if (home?.raw && (userWrite || localWrite)) {
       const next = rewriteHomeClaude(
         home.raw,
         userGateway,
         localGateway,
-        userInstall ? (userRemove ?? new Set()) : null,
-        localInstall ? (localRemove ?? new Set()) : null,
+        userWrite ? (userRemove ?? new Set()) : null,
+        localWrite ? (localRemove ?? new Set()) : null,
         deriveProjectRoot(input.ratelConfigPaths),
       );
       pushJsonWrite(changes, home.path, home.raw, next);
     }
-    if (project?.raw && projectInstall && projectGateway) {
+    if (project?.raw && projectWrite) {
       const next = rewriteProjectClaude(project.raw, projectGateway, projectRemove ?? new Set());
       pushJsonWrite(changes, project.path, project.raw, next);
     }
 
-    for (const [scope, names] of input.replacedEntriesByScope) {
+    for (const [scope, names] of input.removeEntriesByScope) {
       if (names.size === 0) continue;
-      installedGatewayScopes.push(scope);
       for (const name of names) removedNativeEntries.push({ scope, name });
     }
     for (const scope of input.installGatewayScopes ?? []) {
@@ -209,11 +209,11 @@ function rewriteHomeClaude(
   projectRoot: string | undefined,
 ): Record<string, unknown> {
   const out = JSON.parse(JSON.stringify(raw)) as Record<string, unknown>;
-  if (removeUser && userRatelEntry) {
+  if (removeUser) {
     const before = isPlainObject(out.mcpServers) ? (out.mcpServers as Record<string, unknown>) : {};
     out.mcpServers = mergeWithRatel(before, removeUser, userRatelEntry);
   }
-  if (removeLocal && localRatelEntry && projectRoot) {
+  if (removeLocal && projectRoot) {
     const absRoot = resolve(projectRoot);
     const projects = isPlainObject(out.projects) ? (out.projects as Record<string, unknown>) : {};
     const entry = isPlainObject(projects[absRoot])
@@ -231,7 +231,7 @@ function rewriteHomeClaude(
 
 function rewriteProjectClaude(
   raw: Record<string, unknown>,
-  ratelEntry: RatelGatewayEntry,
+  ratelEntry: RatelGatewayEntry | undefined,
   remove: ReadonlySet<string>,
 ): Record<string, unknown> {
   const out = JSON.parse(JSON.stringify(raw)) as Record<string, unknown>;
@@ -243,15 +243,15 @@ function rewriteProjectClaude(
 function mergeWithRatel(
   before: Record<string, unknown>,
   remove: ReadonlySet<string>,
-  ratelEntry: RatelGatewayEntry,
+  ratelEntry: RatelGatewayEntry | undefined,
 ): Record<string, unknown> {
   const next: Record<string, unknown> = {};
   for (const [name, entry] of Object.entries(before)) {
-    if (isServerEntry(entry) && isRatelGatewayEntry(name, entry)) continue;
+    if (ratelEntry && isServerEntry(entry) && isRatelGatewayEntry(name, entry)) continue;
     if (remove.has(name)) continue;
     next[name] = entry;
   }
-  next[ratelEntry.name] = ratelEntry.entry;
+  if (ratelEntry) next[ratelEntry.name] = ratelEntry.entry;
   return next;
 }
 

--- a/packages/core/src/agent-host/codex.ts
+++ b/packages/core/src/agent-host/codex.ts
@@ -16,11 +16,11 @@ import type {
   AgentHostChangeSet,
   AgentHostContext,
   AgentHostDetection,
+  AgentHostPlanInput,
   AgentHostRemovedEntry,
   AgentHostState,
   AgentScope,
   AgentScopeState,
-  GatewayLinkInput,
   RatelConfigPaths,
 } from "./index.js";
 
@@ -55,18 +55,21 @@ export class CodexAgentHostAdapter implements AgentHostAdapter {
     return { host: { kind: "codex", displayName: "Codex" }, scopes };
   }
 
-  async link(input: GatewayLinkInput): Promise<AgentHostChangeSet> {
+  async planChanges(input: AgentHostPlanInput): Promise<AgentHostChangeSet> {
     const changes: FileChange[] = [];
     const installedGatewayScopes: AgentScope[] = [];
     const removedNativeEntries: AgentHostRemovedEntry[] = [];
     const byScope = scopesByName(input.state);
     for (const scope of ["user", "project", "local"] as const) {
-      const names = input.replacedEntriesByScope.get(scope);
+      const names = input.removeEntriesByScope.get(scope);
       const state = byScope[scope];
       const configPaths = configChainForScope(scope, input.ratelConfigPaths);
-      const shouldInstall = Boolean(names?.size || input.installGatewayScopes?.has(scope));
-      if (!state || !shouldInstall || configPaths.length === 0) continue;
-      const gateway = makeRatelGatewayEntry({ bin: input.bin, configPaths });
+      const shouldInstall = input.installGatewayScopes?.has(scope) ?? false;
+      const shouldWrite = Boolean(names?.size || shouldInstall);
+      if (!state || !shouldWrite || configPaths.length === 0) continue;
+      const gateway = shouldInstall
+        ? makeRatelGatewayEntry({ bin: input.bin, configPaths })
+        : undefined;
       const next = rewriteCodexConfig(state.rawText ?? "", names ?? new Set(), gateway);
       if (next !== state.rawText) {
         changes.push({
@@ -76,7 +79,7 @@ export class CodexAgentHostAdapter implements AgentHostAdapter {
           after: next,
         });
       }
-      installedGatewayScopes.push(scope);
+      if (shouldInstall) installedGatewayScopes.push(scope);
       for (const name of names ?? []) removedNativeEntries.push({ scope, name });
     }
     return {
@@ -139,7 +142,7 @@ export function parseCodexMcpServers(text: string): Record<string, ServerEntry> 
 export function rewriteCodexConfig(
   text: string,
   remove: ReadonlySet<string>,
-  gateway: RatelGatewayEntry,
+  gateway: RatelGatewayEntry | undefined,
 ): string {
   const sections = findTomlTableSections(text);
   const entries = parseCodexMcpServers(text);
@@ -147,7 +150,9 @@ export function rewriteCodexConfig(
   for (const section of sections) {
     if (!isCodexServerRoot(section.path)) continue;
     const entry = entries[section.name];
-    if (entry && isRatelGatewayEntry(section.name, entry)) removeNames.add(section.name);
+    if (gateway && entry && isRatelGatewayEntry(section.name, entry)) {
+      removeNames.add(section.name);
+    }
   }
   const rootSectionNames = new Set(
     sections.filter((section) => isCodexServerRoot(section.path)).map((section) => section.name),
@@ -166,20 +171,21 @@ export function rewriteCodexConfig(
   }
   out += text.slice(cursor);
   const trimmed = out.trimEnd();
+  if (!gateway) return `${trimmed}${trimmed.length > 0 ? "\n" : ""}`;
   return `${trimmed}${trimmed.length > 0 ? "\n\n" : ""}${renderCodexServer(gateway.name, gateway.entry)}\n`;
 }
 
 function rewriteCodexConfigStructured(
   text: string,
   removeNames: ReadonlySet<string>,
-  gateway: RatelGatewayEntry,
+  gateway: RatelGatewayEntry | undefined,
 ): string {
   const root = parseToml(text) as Record<string, unknown>;
   const servers = isPlainObject(root.mcp_servers)
     ? { ...(root.mcp_servers as Record<string, unknown>) }
     : {};
   for (const name of removeNames) delete servers[name];
-  servers[gateway.name] = codexServerObject(gateway.entry);
+  if (gateway) servers[gateway.name] = codexServerObject(gateway.entry);
   root.mcp_servers = servers;
   return stringifyToml(root);
 }

--- a/packages/core/src/agent-host/index.test.ts
+++ b/packages/core/src/agent-host/index.test.ts
@@ -35,7 +35,7 @@ function adapter(input: {
         ],
       };
     },
-    async link() {
+    async planChanges() {
       return {
         changes: [],
         summary: {

--- a/packages/core/src/agent-host/index.ts
+++ b/packages/core/src/agent-host/index.ts
@@ -10,7 +10,7 @@ export type AgentScope = "user" | "project" | "local";
 export interface AgentHostAdapter {
   detect(ctx: AgentHostContext): Promise<AgentHostDetection>;
   read(ctx: AgentHostContext): Promise<AgentHostState>;
-  link(input: GatewayLinkInput): Promise<AgentHostChangeSet>;
+  planChanges(input: AgentHostPlanInput): Promise<AgentHostChangeSet>;
 }
 
 export interface AgentHostContext {
@@ -45,12 +45,12 @@ export interface AgentScopeState {
   rawText?: string;
 }
 
-export interface GatewayLinkInput {
+export interface AgentHostPlanInput {
   state: AgentHostState;
   bin: ResolvedBin;
   ratelConfigPaths: RatelConfigPaths;
   installGatewayScopes?: Set<AgentScope>;
-  replacedEntriesByScope: Map<AgentScope, Set<string>>;
+  removeEntriesByScope: Map<AgentScope, Set<string>>;
 }
 
 export interface RatelConfigPaths {
@@ -120,8 +120,8 @@ export class NamedAgentHostAdapter implements AgentHostAdapter {
     return (await this.ensureAdapter()).read(ctx);
   }
 
-  async link(input: GatewayLinkInput): Promise<AgentHostChangeSet> {
-    return (await this.ensureAdapter()).link(input);
+  async planChanges(input: AgentHostPlanInput): Promise<AgentHostChangeSet> {
+    return (await this.ensureAdapter()).planChanges(input);
   }
 
   private async ensureAdapter(): Promise<AgentHostAdapter> {
@@ -167,10 +167,10 @@ export class AutomaticAgentHostAdapter implements AgentHostAdapter {
     return adapter.read(ctx);
   }
 
-  async link(input: GatewayLinkInput): Promise<AgentHostChangeSet> {
+  async planChanges(input: AgentHostPlanInput): Promise<AgentHostChangeSet> {
     const adapter = this.selected;
     if (!adapter) throw new Error("Automatic agent host has not selected an adapter.");
-    return adapter.link(input);
+    return adapter.planChanges(input);
   }
 
   private async ensureSelected(ctx: AgentHostContext): Promise<AgentHostAdapter> {

--- a/packages/core/src/agent-import-workflow.test.ts
+++ b/packages/core/src/agent-import-workflow.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import {
+  advanceAgentImportWorkflow,
+  beginAgentImportWorkflow,
+  unlinkedAgentImportWarning,
+} from "./agent-import-workflow.js";
+
+describe("agent import workflow", () => {
+  it("gates an unlinked agent before import and allows linking or skipping", () => {
+    const initial = beginAgentImportWorkflow({
+      hostKind: "claude-code",
+      linked: false,
+      statuslineInstalled: false,
+    });
+
+    expect(initial.step).toBe("link");
+    expect(advanceAgentImportWorkflow(initial, { type: "link-completed" })).toMatchObject({
+      step: "import",
+      linkDecision: "linked-now",
+    });
+    expect(advanceAgentImportWorkflow(initial, { type: "link-skipped" })).toMatchObject({
+      step: "import",
+      linkDecision: "skipped",
+    });
+  });
+
+  it("starts linked agents at import and offers Claude statusline after completion", () => {
+    const initial = beginAgentImportWorkflow({
+      hostKind: "claude-code",
+      linked: true,
+      statuslineInstalled: false,
+    });
+
+    expect(initial).toMatchObject({ step: "import", linkDecision: "already-linked" });
+    const statusline = advanceAgentImportWorkflow(initial, { type: "import-completed" });
+    expect(statusline.step).toBe("statusline");
+    expect(advanceAgentImportWorkflow(statusline, { type: "statusline-completed" }).step).toBe(
+      "complete",
+    );
+  });
+
+  it("finishes after import when statusline is irrelevant or already installed", () => {
+    const codex = beginAgentImportWorkflow({
+      hostKind: "codex",
+      linked: true,
+      statuslineInstalled: false,
+    });
+    expect(advanceAgentImportWorkflow(codex, { type: "import-completed" }).step).toBe("complete");
+
+    const claude = beginAgentImportWorkflow({
+      hostKind: "claude-code",
+      linked: true,
+      statuslineInstalled: true,
+    });
+    expect(advanceAgentImportWorkflow(claude, { type: "import-completed" }).step).toBe("complete");
+  });
+
+  it("explains the consequence of importing without linking", () => {
+    expect(unlinkedAgentImportWarning("Claude Code")).toMatch(
+      /remove the selected MCP entries.*invoke-only.*other linked agents/is,
+    );
+  });
+});

--- a/packages/core/src/agent-import-workflow.test.ts
+++ b/packages/core/src/agent-import-workflow.test.ts
@@ -34,9 +34,13 @@ describe("agent import workflow", () => {
     expect(initial).toMatchObject({ step: "import", linkDecision: "already-linked" });
     const statusline = advanceAgentImportWorkflow(initial, { type: "import-completed" });
     expect(statusline.step).toBe("statusline");
-    expect(advanceAgentImportWorkflow(statusline, { type: "statusline-completed" }).step).toBe(
+    expect(advanceAgentImportWorkflow(statusline, { type: "statusline-installed" }).step).toBe(
       "complete",
     );
+    expect(advanceAgentImportWorkflow(statusline, { type: "statusline-skipped" })).toMatchObject({
+      step: "complete",
+      statuslineInstalled: false,
+    });
   });
 
   it("finishes after import when statusline is irrelevant or already installed", () => {

--- a/packages/core/src/agent-import-workflow.ts
+++ b/packages/core/src/agent-import-workflow.ts
@@ -1,9 +1,9 @@
-import type { SupportedAgentHostKind } from "./agent-host/index.js";
+export type AgentImportHostKind = "claude-code" | "codex";
 
 export type AgentImportLinkDecision = "already-linked" | "linked-now" | "skipped";
 
 interface AgentImportWorkflowContext {
-  hostKind: SupportedAgentHostKind;
+  hostKind: AgentImportHostKind;
   linkDecision: AgentImportLinkDecision | null;
   statuslineInstalled: boolean;
 }
@@ -18,7 +18,7 @@ export type AgentImportWorkflowEvent =
   | { type: "statusline-completed" };
 
 export function beginAgentImportWorkflow(input: {
-  hostKind: SupportedAgentHostKind;
+  hostKind: AgentImportHostKind;
   linked: boolean;
   statuslineInstalled: boolean;
 }): AgentImportWorkflowState {

--- a/packages/core/src/agent-import-workflow.ts
+++ b/packages/core/src/agent-import-workflow.ts
@@ -15,7 +15,8 @@ export type AgentImportWorkflowEvent =
   | { type: "link-completed" }
   | { type: "link-skipped" }
   | { type: "import-completed" }
-  | { type: "statusline-completed" };
+  | { type: "statusline-installed" }
+  | { type: "statusline-skipped" };
 
 export function beginAgentImportWorkflow(input: {
   hostKind: AgentImportHostKind;
@@ -46,8 +47,13 @@ export function advanceAgentImportWorkflow(
     const shouldOfferStatusline = state.hostKind === "claude-code" && !state.statuslineInstalled;
     return { ...state, step: shouldOfferStatusline ? "statusline" : "complete" };
   }
-  if (state.step === "statusline" && event.type === "statusline-completed") {
-    return { ...state, step: "complete", statuslineInstalled: true };
+  if (state.step === "statusline") {
+    if (event.type === "statusline-installed") {
+      return { ...state, step: "complete", statuslineInstalled: true };
+    }
+    if (event.type === "statusline-skipped") {
+      return { ...state, step: "complete" };
+    }
   }
   throw new Error(`invalid agent import workflow transition: ${state.step} + ${event.type}`);
 }

--- a/packages/core/src/agent-import-workflow.ts
+++ b/packages/core/src/agent-import-workflow.ts
@@ -1,0 +1,57 @@
+import type { SupportedAgentHostKind } from "./agent-host/index.js";
+
+export type AgentImportLinkDecision = "already-linked" | "linked-now" | "skipped";
+
+interface AgentImportWorkflowContext {
+  hostKind: SupportedAgentHostKind;
+  linkDecision: AgentImportLinkDecision | null;
+  statuslineInstalled: boolean;
+}
+
+export type AgentImportWorkflowState = AgentImportWorkflowContext &
+  ({ step: "link" } | { step: "import" } | { step: "statusline" } | { step: "complete" });
+
+export type AgentImportWorkflowEvent =
+  | { type: "link-completed" }
+  | { type: "link-skipped" }
+  | { type: "import-completed" }
+  | { type: "statusline-completed" };
+
+export function beginAgentImportWorkflow(input: {
+  hostKind: SupportedAgentHostKind;
+  linked: boolean;
+  statuslineInstalled: boolean;
+}): AgentImportWorkflowState {
+  return {
+    step: input.linked ? "import" : "link",
+    hostKind: input.hostKind,
+    linkDecision: input.linked ? "already-linked" : null,
+    statuslineInstalled: input.statuslineInstalled,
+  };
+}
+
+export function advanceAgentImportWorkflow(
+  state: AgentImportWorkflowState,
+  event: AgentImportWorkflowEvent,
+): AgentImportWorkflowState {
+  if (state.step === "link") {
+    if (event.type === "link-completed") {
+      return { ...state, step: "import", linkDecision: "linked-now" };
+    }
+    if (event.type === "link-skipped") {
+      return { ...state, step: "import", linkDecision: "skipped" };
+    }
+  }
+  if (state.step === "import" && event.type === "import-completed") {
+    const shouldOfferStatusline = state.hostKind === "claude-code" && !state.statuslineInstalled;
+    return { ...state, step: shouldOfferStatusline ? "statusline" : "complete" };
+  }
+  if (state.step === "statusline" && event.type === "statusline-completed") {
+    return { ...state, step: "complete", statuslineInstalled: true };
+  }
+  throw new Error(`invalid agent import workflow transition: ${state.step} + ${event.type}`);
+}
+
+export function unlinkedAgentImportWarning(agentDisplayName: string): string {
+  return `${agentDisplayName} is not linked to Ratel. Importing will remove the selected MCP entries and make the selected skills invoke-only in ${agentDisplayName}. Without linking, they will no longer be usable there, but they will remain available through Ratel for other linked agents.`;
+}

--- a/packages/core/src/import-plan.test.ts
+++ b/packages/core/src/import-plan.test.ts
@@ -4,9 +4,9 @@ import type {
   AgentHostChangeSet,
   AgentHostContext,
   AgentHostDetection,
+  AgentHostPlanInput,
   AgentHostState,
   AgentScope,
-  GatewayLinkInput,
 } from "./agent-host/index.js";
 import {
   buildAgentImportPlan,
@@ -76,7 +76,7 @@ function parseAfter(plan: ReturnType<typeof buildImportPlan>, path: string) {
 }
 
 class RecordingAgentHost implements AgentHostAdapter {
-  input: GatewayLinkInput | null = null;
+  input: AgentHostPlanInput | null = null;
 
   async detect(_ctx: AgentHostContext): Promise<AgentHostDetection> {
     return { displayName: "Test Agent", present: true, reasons: [], warnings: [] };
@@ -86,10 +86,10 @@ class RecordingAgentHost implements AgentHostAdapter {
     return agentState({});
   }
 
-  async link(input: GatewayLinkInput): Promise<AgentHostChangeSet> {
+  async planChanges(input: AgentHostPlanInput): Promise<AgentHostChangeSet> {
     this.input = input;
     const changes: FileChange[] = [];
-    for (const [scope, names] of input.replacedEntriesByScope) {
+    for (const [scope, names] of input.removeEntriesByScope) {
       changes.push({
         kind: "write",
         path: `/agent/${scope}.json`,
@@ -101,7 +101,7 @@ class RecordingAgentHost implements AgentHostAdapter {
       changes,
       summary: {
         host: input.state.host,
-        installedGatewayScopes: [...input.replacedEntriesByScope.keys()],
+        installedGatewayScopes: [...input.removeEntriesByScope.keys()],
         removedNativeEntries: [],
         warnings: [],
       },
@@ -251,7 +251,7 @@ describe("buildImportPlan", () => {
       }),
       agentHost,
     });
-    expect(agentHost.input?.replacedEntriesByScope.get("user")).toEqual(new Set(["fs"]));
+    expect(agentHost.input?.removeEntriesByScope.get("user")).toEqual(new Set(["fs"]));
     expect(agentPlan.agentChanges).toHaveLength(1);
   });
 
@@ -304,7 +304,7 @@ describe("buildImportPlan", () => {
       { selection: new Set(["fs"]) },
     );
 
-    expect(agentHost.input?.replacedEntriesByScope.get("user")).toEqual(new Set(["fs"]));
+    expect(agentHost.input?.removeEntriesByScope.get("user")).toEqual(new Set(["fs"]));
     expect(plan.agentChanges).toEqual([
       { kind: "write", path: "/agent/user.json", before: "{}\n", after: '{"replaced":["fs"]}' },
     ]);

--- a/packages/core/src/import-plan.ts
+++ b/packages/core/src/import-plan.ts
@@ -246,7 +246,7 @@ export async function buildAgentImportPlan(
   options: BuildImportPlanOptions = {},
 ): Promise<ImportPlan> {
   const base = buildImportPlan(inputs, options);
-  const replacedEntriesByScope = new Map<AgentScope, Set<string>>();
+  const removeEntriesByScope = new Map<AgentScope, Set<string>>();
   for (const scope of ["user", "project", "local"] as const) {
     const moved =
       scope === "user"
@@ -254,9 +254,9 @@ export async function buildAgentImportPlan(
         : scope === "project"
           ? base.summary.replacedFromProject
           : base.summary.replacedFromLocal;
-    if (moved.length > 0) replacedEntriesByScope.set(scope, new Set(moved));
+    if (moved.length > 0) removeEntriesByScope.set(scope, new Set(moved));
   }
-  const agentHostChanges = await inputs.agentHost.link({
+  const agentHostChanges = await inputs.agentHost.planChanges({
     state: inputs.agentState,
     bin: inputs.bin,
     ratelConfigPaths: {
@@ -264,7 +264,7 @@ export async function buildAgentImportPlan(
       project: inputs.ratelProjectPath,
       local: inputs.ratelLocalPath,
     },
-    replacedEntriesByScope,
+    removeEntriesByScope,
   });
   return {
     ...base,
@@ -276,8 +276,8 @@ export async function buildAgentImportPlan(
 export async function buildAgentLinkPlan(
   inputs: ImportInputs & { agentHost: AgentHostAdapter; agentState: AgentHostState },
 ): Promise<ImportPlan> {
-  const installGatewayScopes = collectRatelScopesWithEntries(inputs);
-  const agentHostChanges = await inputs.agentHost.link({
+  const installGatewayScopes = collectLinkableAgentScopes(inputs.agentState);
+  const agentHostChanges = await inputs.agentHost.planChanges({
     state: inputs.agentState,
     bin: inputs.bin,
     ratelConfigPaths: {
@@ -286,7 +286,7 @@ export async function buildAgentLinkPlan(
       local: inputs.ratelLocalPath,
     },
     installGatewayScopes,
-    replacedEntriesByScope: new Map(),
+    removeEntriesByScope: new Map(),
   });
   return {
     ratelChanges: [],
@@ -296,15 +296,9 @@ export async function buildAgentLinkPlan(
   };
 }
 
-function collectRatelScopesWithEntries(inputs: ImportInputs): Set<AgentScope> {
+function collectLinkableAgentScopes(state: AgentHostState): Set<AgentScope> {
   const out = new Set<AgentScope>();
-  if (Object.keys(inputs.ratelUser?.mcpServers ?? {}).length > 0) out.add("user");
-  if (inputs.ratelProjectPath && Object.keys(inputs.ratelProject?.mcpServers ?? {}).length > 0) {
-    out.add("project");
-  }
-  if (inputs.ratelLocalPath && Object.keys(inputs.ratelLocal?.mcpServers ?? {}).length > 0) {
-    out.add("local");
-  }
+  for (const scope of state.scopes) if (scope.available) out.add(scope.scope);
   return out;
 }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./agent-host/index.js";
+export * from "./agent-import-workflow.js";
 export * from "./backup.js";
 export * from "./gateway-entry.js";
 export * from "./hierarchy.js";

--- a/packages/core/src/operations.test.ts
+++ b/packages/core/src/operations.test.ts
@@ -221,7 +221,7 @@ describe("core operations — agent interop", () => {
     );
     const claude = JSON.parse(fs.files.get(CLAUDE_PATH) as string);
     expect(claude.mcpServers.fs).toBeUndefined();
-    expect(claude.mcpServers["ratel-mcp"].command).toBe("/usr/local/bin/ratel-mcp");
+    expect(claude.mcpServers["ratel-mcp"]).toBeUndefined();
   });
 
   it("rejects stale import plan hashes before applying", async () => {
@@ -362,7 +362,7 @@ describe("core operations — agent interop", () => {
     expect(JSON.parse(fs.files.get(USER_PATH) as string).mcpServers.fs.command).toBe("echo");
     const claude = JSON.parse(fs.files.get(CLAUDE_PATH) as string);
     expect(claude.mcpServers.fs).toBeUndefined();
-    expect(claude.mcpServers["ratel-mcp"].command).toBe("/usr/local/bin/ratel-mcp");
+    expect(claude.mcpServers["ratel-mcp"]).toBeUndefined();
   });
 
   it("links Claude Code non-interactively without removing native entries", async () => {

--- a/packages/core/src/operations.ts
+++ b/packages/core/src/operations.ts
@@ -409,20 +409,6 @@ export async function previewAgentLink(
     collectRatelKnownNames(await readAllRatelConfigs(ctx)),
   );
   const inputs = await buildAgentPlanInputs(ctx, agentHost, agentState, opts);
-  const ratelKnown = collectRatelKnownNames([
-    inputs.ratelUser,
-    inputs.ratelProject,
-    inputs.ratelLocal,
-  ]);
-
-  if (ratelKnown.size === 0) {
-    const plan = emptyAgentPlan("add-missing-only");
-    return toAgentPlanPreview("link", host, [], [], plan, input, {
-      emptyReason:
-        "No Ratel entries found at any scope. Import entries first, then link the agent.",
-    });
-  }
-
   const plan = await buildAgentLinkPlan(inputs);
   return toAgentPlanPreview("link", host, [], [], plan, input, {
     emptyReason:
@@ -514,15 +500,6 @@ export async function linkAgentToRatel(
   }
   const agentState = await agentHost.read({ env: ctx.env, fs: ctx.fs });
   const inputs = await buildAgentPlanInputs(ctx, agentHost, agentState, opts);
-
-  const ratelKnown = new Set<string>();
-  for (const cfg of [inputs.ratelUser, inputs.ratelProject, inputs.ratelLocal]) {
-    if (cfg) for (const name of Object.keys(cfg.mcpServers)) ratelKnown.add(name);
-  }
-  if (ratelKnown.size === 0) {
-    ctx.log?.("No Ratel entries found at any scope. Nothing to link.");
-    return null;
-  }
 
   const plan = await buildAgentLinkPlan(inputs);
   if (plan.agentChanges.length === 0) {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -17,6 +17,7 @@
     "@fontsource-variable/inter-tight": "^5.2.7",
     "@fontsource/jetbrains-mono": "^5.2.8",
     "@radix-ui/react-slot": "^1.2.4",
+    "@ratel-ai/mcp-core": "workspace:*",
     "@tanstack/react-form": "^1.33.0",
     "@tanstack/react-hotkeys": "^0.10.0",
     "@tanstack/react-router": "^1.170.9",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -20,6 +20,7 @@
     "@tanstack/react-form": "^1.33.0",
     "@tanstack/react-hotkeys": "^0.10.0",
     "@tanstack/react-router": "^1.170.9",
+    "@tanstack/react-virtual": "^3.14.5",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",

--- a/packages/ui/src/components/import-skills-dialog.tsx
+++ b/packages/ui/src/components/import-skills-dialog.tsx
@@ -139,6 +139,7 @@ export function ImportSkillsDialog(props: ImportSkillsDialogProps) {
           </p>
         ) : (
           <SkillImportPicker
+            title="Skills"
             onToggle={toggle}
             onToggleAll={toggleAll}
             resetKey={`${props.open}:${skills.length}`}
@@ -166,11 +167,13 @@ function skippedSkillsMessage(skipped: Array<{ id: string; reason: string }>): s
 export function SkillImportPicker(props: {
   className?: string;
   emptyLabel?: string;
+  flushScroll?: boolean;
   onToggle: (skill: SkillSummary) => void;
   onToggleAll: (skills: SkillSummary[], shouldSelect: boolean) => void;
   resetKey?: string;
   selected: Set<string>;
   skills: SkillSummary[];
+  title?: string;
 }) {
   const [query, setQuery] = useState("");
   const [visibleLimit, setVisibleLimit] = useState(INITIAL_SKILL_LIMIT);
@@ -221,7 +224,23 @@ export function SkillImportPicker(props: {
   };
 
   return (
-    <div className={cn("grid min-w-0 gap-2", props.className)}>
+    <div className={cn("grid min-w-0 gap-3", props.className)}>
+      {props.title ? (
+        <div className="flex min-w-0 items-center justify-between gap-3 px-1">
+          <h4 className="truncate font-medium text-sm">
+            {props.title} <span className="text-muted-foreground">({filtered.length})</span>
+          </h4>
+          <button
+            className="shrink-0 text-muted-foreground text-xs transition-colors hover:text-foreground disabled:pointer-events-none disabled:opacity-50"
+            disabled={filtered.length === 0}
+            onClick={() => props.onToggleAll(filtered, !allFilteredSelected)}
+            type="button"
+          >
+            {allFilteredSelected ? "Deselect all" : "Select all"}
+            {selectedCount > 0 ? ` · ${selectedCount}` : ""}
+          </button>
+        </div>
+      ) : null}
       <div className="relative">
         <SearchIcon className="-translate-y-1/2 pointer-events-none absolute top-1/2 left-2.5 size-4 text-muted-foreground" />
         <Input
@@ -231,86 +250,79 @@ export function SkillImportPicker(props: {
           value={query}
         />
       </div>
-      <button
-        className="flex items-center gap-2 px-1 text-left text-muted-foreground text-xs hover:text-foreground"
-        disabled={filtered.length === 0}
-        onClick={() => props.onToggleAll(filtered, !allFilteredSelected)}
-        type="button"
-      >
-        <Checkbox checked={allFilteredSelected} className="pointer-events-none" tabIndex={-1} />
-        {allFilteredSelected ? "Deselect matching" : "Select matching"} ({filtered.length})
-        {selectedCount > 0 ? <span className="ml-auto">{selectedCount} selected</span> : null}
-      </button>
       {filtered.length === 0 ? (
         <p className="rounded-md border border-border px-3 py-6 text-center text-muted-foreground text-sm">
           {props.emptyLabel ?? "No matching skills."}
         </p>
       ) : (
-        <div
-          data-skill-scroll
-          className="max-h-[55vh] min-h-52 overflow-auto rounded-md border border-border bg-background"
-          onScroll={maybeLoadMore}
-          ref={scrollRef}
-        >
-          <div className="relative w-full" style={{ height: `${rowVirtualizer.getTotalSize()}px` }}>
-            {rowVirtualizer.getVirtualItems().map((virtualRow) => {
-              const skill = loaded[virtualRow.index];
-              if (!skill) return null;
-              const isSelected = props.selected.has(skillKey(skill));
-              return (
-                <div
-                  data-index={virtualRow.index}
-                  key={skillKey(skill)}
-                  ref={rowVirtualizer.measureElement}
-                  className="absolute top-0 left-0 w-full px-2 py-1"
-                  style={{ transform: `translateY(${virtualRow.start}px)` }}
-                >
-                  <button
-                    className={cn(
-                      "flex w-full min-w-0 items-start gap-3 rounded-md border p-3 text-left transition-colors",
-                      isSelected
-                        ? "border-brand-green bg-brand-green/10"
-                        : "border-border bg-card hover:bg-muted/35",
-                    )}
-                    onClick={() => props.onToggle(skill)}
-                    type="button"
+        <div className={cn("border-border border-t", props.flushScroll && "-mx-4 sm:-mx-5")}>
+          <div
+            data-skill-scroll
+            className="max-h-[55vh] min-h-52 overflow-auto bg-background"
+            onScroll={maybeLoadMore}
+            ref={scrollRef}
+          >
+            <div
+              className="relative w-full"
+              style={{ height: `${rowVirtualizer.getTotalSize()}px` }}
+            >
+              {rowVirtualizer.getVirtualItems().map((virtualRow) => {
+                const skill = loaded[virtualRow.index];
+                if (!skill) return null;
+                const isSelected = props.selected.has(skillKey(skill));
+                return (
+                  <div
+                    data-index={virtualRow.index}
+                    key={skillKey(skill)}
+                    ref={rowVirtualizer.measureElement}
+                    className="absolute top-0 left-0 w-full"
+                    style={{ transform: `translateY(${virtualRow.start}px)` }}
                   >
-                    <Checkbox
-                      checked={isSelected}
-                      className="pointer-events-none mt-0.5"
-                      tabIndex={-1}
-                    />
-                    <SourceIcon className="mt-0.5" source={skill.source} />
-                    <span className="min-w-0 flex-1">
-                      <strong className="block truncate font-medium">{skill.name}</strong>
-                      {skill.description && (
-                        <span className="mt-0.5 line-clamp-2 break-words text-muted-foreground text-sm">
-                          {skill.description}
-                        </span>
+                    <button
+                      className={cn(
+                        "flex w-full min-w-0 items-start gap-3 border-border border-b px-3 py-2 text-left transition-colors",
+                        isSelected ? "bg-brand-green/10" : "bg-background hover:bg-muted/35",
                       )}
-                      {skill.tags.length > 0 ? (
-                        <span className="mt-2 flex flex-wrap gap-1">
-                          {skill.tags.slice(0, 4).map((tag) => (
-                            <span
-                              className="rounded bg-muted px-1.5 py-0.5 text-muted-foreground text-xs"
-                              key={tag}
-                            >
-                              {tag}
-                            </span>
-                          ))}
-                        </span>
-                      ) : null}
-                    </span>
-                  </button>
-                </div>
-              );
-            })}
-          </div>
-          {canLoadMore ? (
-            <div className="border-border border-t px-3 py-2 text-center text-muted-foreground text-xs">
-              Scroll to load more ({loaded.length} of {filtered.length})
+                      onClick={() => props.onToggle(skill)}
+                      type="button"
+                    >
+                      <Checkbox
+                        checked={isSelected}
+                        className="pointer-events-none mt-0.5"
+                        tabIndex={-1}
+                      />
+                      <SourceIcon className="mt-0.5" source={skill.source} />
+                      <span className="min-w-0 flex-1">
+                        <strong className="block truncate font-medium">{skill.name}</strong>
+                        {skill.description && (
+                          <span className="mt-0.5 line-clamp-2 break-words text-muted-foreground text-sm">
+                            {skill.description}
+                          </span>
+                        )}
+                        {skill.tags.length > 0 ? (
+                          <span className="mt-2 flex flex-wrap gap-1">
+                            {skill.tags.slice(0, 4).map((tag) => (
+                              <span
+                                className="rounded bg-muted px-1.5 py-0.5 text-muted-foreground text-xs"
+                                key={tag}
+                              >
+                                {tag}
+                              </span>
+                            ))}
+                          </span>
+                        ) : null}
+                      </span>
+                    </button>
+                  </div>
+                );
+              })}
             </div>
-          ) : null}
+            {canLoadMore ? (
+              <div className="border-border border-t px-3 py-2 text-center text-muted-foreground text-xs">
+                Scroll to load more ({loaded.length} of {filtered.length})
+              </div>
+            ) : null}
+          </div>
         </div>
       )}
     </div>

--- a/packages/ui/src/components/import-skills-dialog.tsx
+++ b/packages/ui/src/components/import-skills-dialog.tsx
@@ -1,4 +1,6 @@
-import { useEffect, useState } from "react";
+import { useVirtualizer } from "@tanstack/react-virtual";
+import { SearchIcon } from "lucide-react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useRatelApp } from "@/App";
 import { type SkillSource, SourceIcon } from "@/components/source-icon";
 import { Button } from "@/components/ui/button";
@@ -12,7 +14,9 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
 import type { SkillSummary } from "@/lib/skills";
+import { cn } from "@/lib/utils";
 
 interface ImportSkillsDialogProps {
   open: boolean;
@@ -26,12 +30,12 @@ interface ImportSkillsDialogProps {
 }
 
 /** A skill name can live in both Claude Code and Codex, so a row is keyed by source. */
-function skillKey(skill: SkillSummary): string {
+export function skillKey(skill: SkillSummary): string {
   return `${skill.source}:${skill.id}`;
 }
 
-/** Rows per page; long skill lists page rather than scroll forever. */
-const PAGE_SIZE = 6;
+const INITIAL_SKILL_LIMIT = 30;
+const LOAD_MORE_SKILL_COUNT = 30;
 
 interface ActivateSkillsResponse {
   managed: Array<{ id: string; mode: string }>;
@@ -50,22 +54,15 @@ export function ImportSkillsDialog(props: ImportSkillsDialogProps) {
     ? props.available.filter((skill) => skill.source === props.source)
     : props.available;
   const [selected, setSelected] = useState<Set<string>>(new Set());
-  const [page, setPage] = useState(0);
 
   // Start each session with a clean slate; the user opts in per skill (or all).
   useEffect(() => {
     if (props.open) {
       setSelected(new Set());
-      setPage(0);
     }
   }, [props.open]);
 
   const chosen = skills.filter((skill) => selected.has(skillKey(skill)));
-  const allSelected = skills.length > 0 && chosen.length === skills.length;
-  const pageCount = Math.max(1, Math.ceil(skills.length / PAGE_SIZE));
-  const safePage = Math.min(page, pageCount - 1);
-  const pageStart = safePage * PAGE_SIZE;
-  const visible = skills.slice(pageStart, pageStart + PAGE_SIZE);
 
   const toggle = (skill: SkillSummary) => {
     setSelected((current) => {
@@ -77,8 +74,16 @@ export function ImportSkillsDialog(props: ImportSkillsDialogProps) {
     });
   };
 
-  const toggleAll = () => {
-    setSelected(allSelected ? new Set() : new Set(skills.map(skillKey)));
+  const toggleAll = (items: SkillSummary[], shouldSelect: boolean) => {
+    setSelected((current) => {
+      const next = new Set(current);
+      for (const skill of items) {
+        const key = skillKey(skill);
+        if (shouldSelect) next.add(key);
+        else next.delete(key);
+      }
+      return next;
+    });
   };
 
   const submit = async () => {
@@ -133,78 +138,13 @@ export function ImportSkillsDialog(props: ImportSkillsDialogProps) {
             No external skills to manage.
           </p>
         ) : (
-          <div className="grid gap-2">
-            <button
-              className="flex items-center gap-2 px-1 text-left text-muted-foreground text-xs hover:text-foreground"
-              onClick={toggleAll}
-              type="button"
-            >
-              <Checkbox checked={allSelected} className="pointer-events-none" tabIndex={-1} />
-              {allSelected ? "Deselect all" : "Select all"} ({skills.length})
-            </button>
-            <ul className="grid max-h-[55vh] gap-2 overflow-y-auto pr-1">
-              {visible.map((skill) => {
-                const isSelected = selected.has(skillKey(skill));
-                return (
-                  <li key={skillKey(skill)}>
-                    <button
-                      className={`flex w-full min-w-0 items-start gap-3 rounded-md border p-3 text-left transition-colors ${
-                        isSelected
-                          ? "border-brand-green bg-brand-green/10"
-                          : "border-border bg-card hover:bg-muted/35"
-                      }`}
-                      onClick={() => toggle(skill)}
-                      type="button"
-                    >
-                      <Checkbox
-                        checked={isSelected}
-                        className="pointer-events-none mt-0.5"
-                        tabIndex={-1}
-                      />
-                      <SourceIcon className="mt-0.5" source={skill.source} />
-                      <span className="min-w-0 flex-1">
-                        <strong className="block truncate font-medium">{skill.name}</strong>
-                        {skill.description && (
-                          <span className="mt-0.5 line-clamp-2 break-words text-muted-foreground text-sm">
-                            {skill.description}
-                          </span>
-                        )}
-                      </span>
-                    </button>
-                  </li>
-                );
-              })}
-            </ul>
-            {pageCount > 1 && (
-              <div className="flex items-center justify-between px-1 text-muted-foreground text-xs">
-                <span>
-                  {pageStart + 1}–{Math.min(pageStart + PAGE_SIZE, skills.length)} of{" "}
-                  {skills.length}
-                </span>
-                <div className="flex items-center gap-2">
-                  <Button
-                    disabled={safePage === 0}
-                    onClick={() => setPage(safePage - 1)}
-                    size="sm"
-                    variant="outline"
-                  >
-                    Prev
-                  </Button>
-                  <span>
-                    {safePage + 1} / {pageCount}
-                  </span>
-                  <Button
-                    disabled={safePage >= pageCount - 1}
-                    onClick={() => setPage(safePage + 1)}
-                    size="sm"
-                    variant="outline"
-                  >
-                    Next
-                  </Button>
-                </div>
-              </div>
-            )}
-          </div>
+          <SkillImportPicker
+            onToggle={toggle}
+            onToggleAll={toggleAll}
+            resetKey={`${props.open}:${skills.length}`}
+            selected={selected}
+            skills={skills}
+          />
         )}
 
         <DialogFooter>
@@ -221,4 +161,158 @@ export function ImportSkillsDialog(props: ImportSkillsDialogProps) {
 function skippedSkillsMessage(skipped: Array<{ id: string; reason: string }>): string {
   const details = skipped.map((s) => `${s.id}: ${s.reason}`).join("; ");
   return `Could not manage selected skill${skipped.length === 1 ? "" : "s"} (${details})`;
+}
+
+export function SkillImportPicker(props: {
+  className?: string;
+  emptyLabel?: string;
+  onToggle: (skill: SkillSummary) => void;
+  onToggleAll: (skills: SkillSummary[], shouldSelect: boolean) => void;
+  resetKey?: string;
+  selected: Set<string>;
+  skills: SkillSummary[];
+}) {
+  const [query, setQuery] = useState("");
+  const [visibleLimit, setVisibleLimit] = useState(INITIAL_SKILL_LIMIT);
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const normalizedQuery = query.trim().toLowerCase();
+  const filtered = useMemo(() => {
+    if (!normalizedQuery) return props.skills;
+    return props.skills.filter((skill) => {
+      const haystack = [skill.name, skill.id, skill.description, ...skill.tags]
+        .join(" ")
+        .toLowerCase();
+      return haystack.includes(normalizedQuery);
+    });
+  }, [normalizedQuery, props.skills]);
+  const loaded = filtered.slice(0, visibleLimit);
+  const allFilteredSelected =
+    filtered.length > 0 && filtered.every((skill) => props.selected.has(skillKey(skill)));
+  const selectedCount = filtered.filter((skill) => props.selected.has(skillKey(skill))).length;
+  const canLoadMore = loaded.length < filtered.length;
+
+  const rowVirtualizer = useVirtualizer({
+    count: loaded.length,
+    estimateSize: () => 86,
+    getScrollElement: () => scrollRef.current,
+    overscan: 6,
+  });
+
+  const updateQuery = (value: string) => {
+    setQuery(value);
+    setVisibleLimit(INITIAL_SKILL_LIMIT);
+    scrollRef.current?.scrollTo({ top: 0 });
+  };
+
+  useEffect(() => {
+    if (props.resetKey === undefined) return;
+    setQuery("");
+    setVisibleLimit(INITIAL_SKILL_LIMIT);
+    scrollRef.current?.scrollTo({ top: 0 });
+  }, [props.resetKey]);
+
+  const maybeLoadMore = () => {
+    const el = scrollRef.current;
+    if (!el || !canLoadMore) return;
+    const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight;
+    if (distanceFromBottom < 160) {
+      setVisibleLimit((current) => Math.min(filtered.length, current + LOAD_MORE_SKILL_COUNT));
+    }
+  };
+
+  return (
+    <div className={cn("grid min-w-0 gap-2", props.className)}>
+      <div className="relative">
+        <SearchIcon className="-translate-y-1/2 pointer-events-none absolute top-1/2 left-2.5 size-4 text-muted-foreground" />
+        <Input
+          className="pl-8"
+          onChange={(event) => updateQuery(event.target.value)}
+          placeholder="Search skills"
+          value={query}
+        />
+      </div>
+      <button
+        className="flex items-center gap-2 px-1 text-left text-muted-foreground text-xs hover:text-foreground"
+        disabled={filtered.length === 0}
+        onClick={() => props.onToggleAll(filtered, !allFilteredSelected)}
+        type="button"
+      >
+        <Checkbox checked={allFilteredSelected} className="pointer-events-none" tabIndex={-1} />
+        {allFilteredSelected ? "Deselect matching" : "Select matching"} ({filtered.length})
+        {selectedCount > 0 ? <span className="ml-auto">{selectedCount} selected</span> : null}
+      </button>
+      {filtered.length === 0 ? (
+        <p className="rounded-md border border-border px-3 py-6 text-center text-muted-foreground text-sm">
+          {props.emptyLabel ?? "No matching skills."}
+        </p>
+      ) : (
+        <div
+          data-skill-scroll
+          className="max-h-[55vh] min-h-52 overflow-auto rounded-md border border-border bg-background"
+          onScroll={maybeLoadMore}
+          ref={scrollRef}
+        >
+          <div className="relative w-full" style={{ height: `${rowVirtualizer.getTotalSize()}px` }}>
+            {rowVirtualizer.getVirtualItems().map((virtualRow) => {
+              const skill = loaded[virtualRow.index];
+              if (!skill) return null;
+              const isSelected = props.selected.has(skillKey(skill));
+              return (
+                <div
+                  data-index={virtualRow.index}
+                  key={skillKey(skill)}
+                  ref={rowVirtualizer.measureElement}
+                  className="absolute top-0 left-0 w-full px-2 py-1"
+                  style={{ transform: `translateY(${virtualRow.start}px)` }}
+                >
+                  <button
+                    className={cn(
+                      "flex w-full min-w-0 items-start gap-3 rounded-md border p-3 text-left transition-colors",
+                      isSelected
+                        ? "border-brand-green bg-brand-green/10"
+                        : "border-border bg-card hover:bg-muted/35",
+                    )}
+                    onClick={() => props.onToggle(skill)}
+                    type="button"
+                  >
+                    <Checkbox
+                      checked={isSelected}
+                      className="pointer-events-none mt-0.5"
+                      tabIndex={-1}
+                    />
+                    <SourceIcon className="mt-0.5" source={skill.source} />
+                    <span className="min-w-0 flex-1">
+                      <strong className="block truncate font-medium">{skill.name}</strong>
+                      {skill.description && (
+                        <span className="mt-0.5 line-clamp-2 break-words text-muted-foreground text-sm">
+                          {skill.description}
+                        </span>
+                      )}
+                      {skill.tags.length > 0 ? (
+                        <span className="mt-2 flex flex-wrap gap-1">
+                          {skill.tags.slice(0, 4).map((tag) => (
+                            <span
+                              className="rounded bg-muted px-1.5 py-0.5 text-muted-foreground text-xs"
+                              key={tag}
+                            >
+                              {tag}
+                            </span>
+                          ))}
+                        </span>
+                      ) : null}
+                    </span>
+                  </button>
+                </div>
+              );
+            })}
+          </div>
+          {canLoadMore ? (
+            <div className="border-border border-t px-3 py-2 text-center text-muted-foreground text-xs">
+              Scroll to load more ({loaded.length} of {filtered.length})
+            </div>
+          ) : null}
+        </div>
+      )}
+    </div>
+  );
 }

--- a/packages/ui/src/lib/agent-import-flow.test.ts
+++ b/packages/ui/src/lib/agent-import-flow.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { linkThenRefreshImportPreview } from "./agent-import-flow";
+import { importStatuslineAction, linkThenRefreshImportPreview } from "./agent-import-flow";
 
 describe("linkThenRefreshImportPreview", () => {
   it("loads a fresh import preview after linking succeeds", async () => {
@@ -26,5 +26,17 @@ describe("linkThenRefreshImportPreview", () => {
       linkThenRefreshImportPreview(async () => false, loadImportPreview),
     ).resolves.toBeNull();
     expect(loadImportPreview).not.toHaveBeenCalled();
+  });
+});
+
+describe("importStatuslineAction", () => {
+  it("makes replacing a non-Ratel statusline explicit", () => {
+    expect(importStatuslineAction("other")).toEqual({
+      actionLabel: "Replace statusline",
+      description:
+        "Import is complete. Replace the existing non-Ratel Claude Code statusline with the standalone Ratel statusline?",
+      force: true,
+      title: "Replace the existing statusline?",
+    });
   });
 });

--- a/packages/ui/src/lib/agent-import-flow.test.ts
+++ b/packages/ui/src/lib/agent-import-flow.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it, vi } from "vitest";
+import { linkThenRefreshImportPreview } from "./agent-import-flow";
+
+describe("linkThenRefreshImportPreview", () => {
+  it("loads a fresh import preview after linking succeeds", async () => {
+    const order: string[] = [];
+    const link = vi.fn(async () => {
+      order.push("link");
+      return true;
+    });
+    const loadImportPreview = vi.fn(async () => {
+      order.push("preview");
+      return { stageHashes: { agent: "fresh" } };
+    });
+
+    await expect(linkThenRefreshImportPreview(link, loadImportPreview)).resolves.toEqual({
+      stageHashes: { agent: "fresh" },
+    });
+    expect(order).toEqual(["link", "preview"]);
+  });
+
+  it("does not load a preview when linking fails", async () => {
+    const loadImportPreview = vi.fn(async () => ({ stageHashes: { agent: "unused" } }));
+
+    await expect(
+      linkThenRefreshImportPreview(async () => false, loadImportPreview),
+    ).resolves.toBeNull();
+    expect(loadImportPreview).not.toHaveBeenCalled();
+  });
+});

--- a/packages/ui/src/lib/agent-import-flow.ts
+++ b/packages/ui/src/lib/agent-import-flow.ts
@@ -1,0 +1,7 @@
+export async function linkThenRefreshImportPreview<T>(
+  link: () => Promise<boolean>,
+  loadImportPreview: () => Promise<T>,
+): Promise<T | null> {
+  if (!(await link())) return null;
+  return loadImportPreview();
+}

--- a/packages/ui/src/lib/agent-import-flow.ts
+++ b/packages/ui/src/lib/agent-import-flow.ts
@@ -5,3 +5,24 @@ export async function linkThenRefreshImportPreview<T>(
   if (!(await link())) return null;
   return loadImportPreview();
 }
+
+export function importStatuslineAction(
+  status: "not-installed" | "installed" | "other" | undefined,
+) {
+  if (status === "other") {
+    return {
+      actionLabel: "Replace statusline",
+      description:
+        "Import is complete. Replace the existing non-Ratel Claude Code statusline with the standalone Ratel statusline?",
+      force: true,
+      title: "Replace the existing statusline?",
+    } as const;
+  }
+  return {
+    actionLabel: "Install statusline",
+    description:
+      "Import is complete. Install the standalone Claude Code statusline to show context usage and Ratel telemetry.",
+    force: false,
+    title: "Install the Ratel statusline?",
+  } as const;
+}

--- a/packages/ui/src/pages/AgentSetupPage.tsx
+++ b/packages/ui/src/pages/AgentSetupPage.tsx
@@ -1085,7 +1085,7 @@ function SetupRecap(props: {
   );
 }
 
-type ImportScene = "recap" | "strategy" | "pick-conflicts" | "review";
+type ImportScene = "skills" | "entries" | "strategy" | "pick-conflicts" | "review";
 
 function ImportSceneDialog(props: {
   hostKind: AgentHostKind;
@@ -1101,7 +1101,7 @@ function ImportSceneDialog(props: {
   request: <T>(path: string, init?: JsonRequestInit) => Promise<T>;
   skills: SkillSummary[];
 }) {
-  const [scene, setScene] = useState<ImportScene>("recap");
+  const [scene, setScene] = useState<ImportScene>("skills");
   const [committing, setCommitting] = useState(false);
   const [draftPreview, setDraftPreview] = useState<AgentPlanPreview>(props.preview);
   const [draftSelection, setDraftSelection] = useState<string[]>(props.preview.selected);
@@ -1114,10 +1114,19 @@ function ImportSceneDialog(props: {
   const requiresConflictSelection =
     draftSelection.length > 0 && conflicts.length > 0 && conflictStrategy === "replace-selected";
   const hasSelectedImport = draftSelection.length > 0 || selectedSkills.length > 0;
-  const goAfterRecap = () =>
+  const hasSelectableEntries = props.preview.candidates.length > 0;
+  const canLeaveSkills = selectedSkills.length > 0 || hasSelectableEntries;
+  const goAfterSkills = () => setScene(hasSelectableEntries ? "entries" : "review");
+  const goAfterEntries = () =>
     setScene(draftSelection.length > 0 && conflicts.length > 0 ? "strategy" : "review");
   const goAfterStrategy = () =>
     setScene(conflictStrategy === "replace-selected" ? "pick-conflicts" : "review");
+  const previousReviewScene = () => {
+    if (requiresConflictSelection) return "pick-conflicts";
+    if (draftSelection.length > 0 && conflicts.length > 0) return "strategy";
+    if (hasSelectableEntries) return "entries";
+    return "skills";
+  };
 
   useEffect(() => {
     if (!props.open) return;
@@ -1192,12 +1201,12 @@ function ImportSceneDialog(props: {
       open={props.open}
       onOpenChange={(open) => {
         props.onOpenChange(open);
-        if (open) setScene("recap");
+        if (open) setScene("skills");
       }}
       scene={scene}
       title="Import"
     >
-      {scene === "recap" ? (
+      {scene === "skills" ? (
         <ScenePanel
           flushFooter
           footer={
@@ -1205,56 +1214,15 @@ function ImportSceneDialog(props: {
               <Button onClick={() => props.onOpenChange(false)} type="button" variant="outline">
                 Cancel
               </Button>
-              <Button disabled={!hasSelectedImport} onClick={goAfterRecap} type="button">
+              <Button disabled={!canLeaveSkills} onClick={goAfterSkills} type="button">
                 Continue
               </Button>
             </>
           }
-          kicker="Import"
-          title="Choose what to import"
+          kicker="Skills"
+          title="Choose skills"
         >
           <div className="grid gap-3">
-            {props.preview.candidates.length > 0 ? (
-              <div className="grid gap-2">
-                <h4 className="px-1 font-medium text-sm">
-                  MCP entries{" "}
-                  <span className="text-muted-foreground">({props.preview.candidates.length})</span>
-                </h4>
-                <SceneScrollSection className="max-h-60">
-                  {props.preview.candidates.map((candidate) => {
-                    const isSelected = selected.has(candidate.name);
-                    return (
-                      <button
-                        className={cn(
-                          "grid w-full gap-1 border-border border-b px-3 py-2 text-left transition-colors last:border-b-0",
-                          isSelected ? "bg-brand-green/10" : "bg-background hover:bg-muted/35",
-                        )}
-                        key={`${candidate.scope}:${candidate.name}`}
-                        onClick={() =>
-                          setDraftSelection((current) => toggleSelection(current, candidate.name))
-                        }
-                        type="button"
-                      >
-                        <div className="flex min-w-0 items-center justify-between gap-2">
-                          <span className="flex min-w-0 items-center gap-2">
-                            <Checkbox
-                              checked={isSelected}
-                              className="pointer-events-none"
-                              tabIndex={-1}
-                            />
-                            <span className="truncate font-medium">{candidate.name}</span>
-                          </span>
-                          <Badge variant="outline">{candidate.scope}</Badge>
-                        </div>
-                        <span className="truncate pl-6 text-xs text-muted-foreground">
-                          {summarizeEntry(candidate.entry)}
-                        </span>
-                      </button>
-                    );
-                  })}
-                </SceneScrollSection>
-              </div>
-            ) : null}
             {props.skills.length > 0 ? (
               <div className="grid gap-2">
                 <h4 className="px-1 font-medium text-sm">
@@ -1269,6 +1237,65 @@ function ImportSceneDialog(props: {
                   skills={props.skills}
                 />
               </div>
+            ) : (
+              <p className="rounded-md border border-border px-3 py-6 text-center text-muted-foreground text-sm">
+                No external skills to manage for this agent.
+              </p>
+            )}
+          </div>
+        </ScenePanel>
+      ) : null}
+      {scene === "entries" ? (
+        <ScenePanel
+          flushFooter
+          footer={
+            <>
+              <Button onClick={() => setScene("skills")} type="button" variant="outline">
+                Back
+              </Button>
+              <Button disabled={!hasSelectedImport} onClick={goAfterEntries} type="button">
+                Continue
+              </Button>
+            </>
+          }
+          kicker="Tools"
+          title="Choose tool entries"
+        >
+          <div className="grid gap-3">
+            {props.preview.candidates.length > 0 ? (
+              <SceneScrollSection className="max-h-72">
+                {props.preview.candidates.map((candidate) => {
+                  const isSelected = selected.has(candidate.name);
+                  return (
+                    <button
+                      className={cn(
+                        "grid w-full gap-1 border-border border-b px-3 py-2 text-left transition-colors last:border-b-0",
+                        isSelected ? "bg-brand-green/10" : "bg-background hover:bg-muted/35",
+                      )}
+                      key={`${candidate.scope}:${candidate.name}`}
+                      onClick={() =>
+                        setDraftSelection((current) => toggleSelection(current, candidate.name))
+                      }
+                      type="button"
+                    >
+                      <div className="flex min-w-0 items-center justify-between gap-2">
+                        <span className="flex min-w-0 items-center gap-2">
+                          <Checkbox
+                            checked={isSelected}
+                            className="pointer-events-none"
+                            tabIndex={-1}
+                          />
+                          <span className="truncate font-medium">{candidate.name}</span>
+                        </span>
+                        <Badge variant="outline">{candidate.scope}</Badge>
+                      </div>
+                      <span className="truncate pl-6 text-xs text-muted-foreground">
+                        {summarizeEntry(candidate.entry)}
+                      </span>
+                    </button>
+                  );
+                })}
+              </SceneScrollSection>
             ) : null}
           </div>
         </ScenePanel>
@@ -1277,7 +1304,7 @@ function ImportSceneDialog(props: {
         <ScenePanel
           footer={
             <>
-              <Button onClick={() => setScene("recap")} type="button" variant="outline">
+              <Button onClick={() => setScene("entries")} type="button" variant="outline">
                 Back
               </Button>
               <Button onClick={goAfterStrategy} type="button">
@@ -1349,15 +1376,7 @@ function ImportSceneDialog(props: {
           footer={
             <>
               <Button
-                onClick={() =>
-                  setScene(
-                    requiresConflictSelection
-                      ? "pick-conflicts"
-                      : conflicts.length > 0
-                        ? "strategy"
-                        : "recap",
-                  )
-                }
+                onClick={() => setScene(previousReviewScene())}
                 type="button"
                 variant="outline"
               >
@@ -1374,7 +1393,7 @@ function ImportSceneDialog(props: {
             </>
           }
           kicker="Review"
-          title="Review config changes"
+          title="Review import"
           wide
         >
           <SceneScrollSection className="grid max-h-[65vh] gap-4">

--- a/packages/ui/src/pages/AgentSetupPage.tsx
+++ b/packages/ui/src/pages/AgentSetupPage.tsx
@@ -1191,6 +1191,7 @@ function ImportSceneDialog(props: {
   const [draftSkillSelection, setDraftSkillSelection] = useState<Set<string>>(new Set());
   const [conflictStrategy, setConflictStrategy] = useState<ConflictStrategy>("add-missing-only");
   const [replaceConflicts, setReplaceConflicts] = useState<string[]>([]);
+  const wasOpenRef = useRef(false);
   const selected = new Set(draftSelection);
   const selectedSkills = props.skills.filter((skill) => draftSkillSelection.has(skillKey(skill)));
   const conflicts = draftPreview.plan.summary.conflicts;
@@ -1219,7 +1220,9 @@ function ImportSceneDialog(props: {
   };
 
   useEffect(() => {
-    if (!props.open) return;
+    const opening = props.open && !wasOpenRef.current;
+    wasOpenRef.current = props.open;
+    if (!opening) return;
     setScene(props.workflow.step === "link" ? "link" : "skills");
     setWorkflow(props.workflow);
     setDraftPreview(props.preview);

--- a/packages/ui/src/pages/AgentSetupPage.tsx
+++ b/packages/ui/src/pages/AgentSetupPage.tsx
@@ -624,9 +624,8 @@ function AgentOperationPanel(props: {
       ) : null}
       {canImport ? (
         <SetupActionSection
-          description="Choose native MCP entries and skills to bring under Ratel in one reviewed flow."
-          icon={<Download />}
-          title="Import into Ratel"
+          description="Choose unmanaged MCP entries and native skills, resolve MCP conflicts, then apply them together."
+          title="Import MCPs and skills"
         >
           <PreviewFlow
             availableSkills={props.availableSkills}
@@ -642,8 +641,7 @@ function AgentOperationPanel(props: {
       ) : null}
       {canLink ? (
         <SetupActionSection
-          description="Write the Ratel gateway entry into this agent config."
-          icon={<LinkIcon />}
+          description="Add the Ratel gateway entry when this agent is not routed through Ratel yet."
           title="Link Ratel gateway"
         >
           <PreviewFlow
@@ -684,16 +682,11 @@ function ClaudeStatuslineSection(props: {
     : otherConfigured
       ? "Replace statusline"
       : "Install statusline";
-  const title = installed
-    ? "Remove Ratel statusline"
-    : otherConfigured
-      ? "Replace configured statusline"
-      : "Install Ratel statusline";
   const description = installed
-    ? "Remove the Ratel-owned command from Claude Code user settings."
+    ? "Remove the Ratel-owned statusLine command from Claude Code."
     : otherConfigured
-      ? "Replace the existing Claude Code statusLine command with Ratel."
-      : "Write the Ratel statusline command into Claude Code user settings.";
+      ? "Replace the existing Claude Code statusLine command with Ratel's statusline."
+      : "Show Claude context usage, Ratel enablement, and Ratel tool telemetry in the statusline.";
 
   const commit = async () => {
     const ok = await runAction(actionLabel, () =>
@@ -708,18 +701,18 @@ function ClaudeStatuslineSection(props: {
   };
 
   return (
-    <SetupActionSection
-      description="Manage the Claude Code user-level statusLine setting."
-      icon={<FileText />}
-      title="Claude statusline"
-    >
+    <SetupActionSection description={description} title={actionLabel}>
       <div className="grid gap-4 border border-border bg-background p-4 md:grid-cols-[minmax(0,1fr)_auto] md:items-center">
         <div>
-          <h4 className="font-medium">{title}</h4>
-          <p className="mt-1 text-sm text-muted-foreground">{description}</p>
+          <p className="font-medium text-sm">Context and Ratel telemetry at a glance</p>
+          <p className="mt-1 max-w-xl text-muted-foreground text-xs">
+            Shows model, context-window usage, session duration, git branch, whether Ratel is
+            enabled, and the estimated tool tokens/tool count Ratel keeps out of Claude's prompt.
+          </p>
           {!props.state.ratelEnabled ? (
-            <p className="mt-2 text-sm text-amber-700 dark:text-amber-400">
-              Ratel MCP is not enabled in Claude Code.
+            <p className="mt-2 max-w-xl text-amber-700 text-xs dark:text-amber-400">
+              Ratel is not enabled in Claude Code yet, so the statusline will report that until the
+              gateway is linked or the plugin is enabled.
             </p>
           ) : null}
         </div>
@@ -739,16 +732,12 @@ function ClaudeStatuslineSection(props: {
 function SetupActionSection(props: {
   children: React.ReactNode;
   description: string;
-  icon: React.ReactNode;
   title: string;
 }) {
   return (
     <section className="grid gap-3">
       <div>
-        <h3 className="flex items-center gap-2 text-lg font-semibold tracking-tight">
-          {props.icon}
-          {props.title}
-        </h3>
+        <h3 className="text-lg font-semibold tracking-tight">{props.title}</h3>
         <p className="mt-1 text-sm text-muted-foreground">{props.description}</p>
       </div>
       {props.children}
@@ -1058,19 +1047,22 @@ function SetupRecap(props: {
   preview: AgentPlanPreview;
 }) {
   const changes = props.preview.plan.ratelChanges.length + props.preview.plan.agentChanges.length;
-  const importableCount =
-    props.preview.candidates.length + (props.flow === "import" ? props.availableSkills.length : 0);
+  const mcpCount = props.preview.candidates.length;
+  const skillCount = props.flow === "import" ? props.availableSkills.length : 0;
+  const importableCount = mcpCount + skillCount;
   const actionLabel = props.flow === "import" ? "Import" : "Link";
   return (
     <div className="grid gap-4 border border-border bg-background p-4 md:grid-cols-[minmax(0,1fr)_auto] md:items-center">
       <div>
-        <h4 className="font-medium">
-          {props.flow === "import" ? "Import into Ratel" : "Link Ratel gateway"}
-        </h4>
-        <p className="mt-1 text-sm text-muted-foreground">
+        <p className="font-medium text-sm">
           {props.flow === "import"
-            ? "Choose MCP entries and skills, resolve conflicts if needed, then review changes."
-            : "Review the exact agent config change before writing it."}
+            ? importAvailabilityLabel(mcpCount, skillCount)
+            : "One agent config change will be reviewed before writing."}
+        </p>
+        <p className="mt-1 text-muted-foreground text-xs">
+          {props.flow === "import"
+            ? "Skills are selected first; MCP conflict handling follows only when needed."
+            : "Native MCP entries are preserved."}
         </p>
       </div>
       <Button
@@ -1083,6 +1075,14 @@ function SetupRecap(props: {
       </Button>
     </div>
   );
+}
+
+function importAvailabilityLabel(mcpCount: number, skillCount: number) {
+  const parts: string[] = [];
+  if (mcpCount > 0) parts.push(`${mcpCount} MCP entr${mcpCount === 1 ? "y" : "ies"}`);
+  if (skillCount > 0) parts.push(`${skillCount} skill${skillCount === 1 ? "" : "s"}`);
+  if (parts.length === 0) return "Nothing available to import.";
+  return `${parts.join(" and ")} available.`;
 }
 
 type ImportScene = "skills" | "entries" | "strategy" | "pick-conflicts" | "review";
@@ -1224,17 +1224,16 @@ function ImportSceneDialog(props: {
         >
           <div className="grid gap-3">
             {props.skills.length > 0 ? (
-              <div className="grid gap-2">
-                <h4 className="px-1 font-medium text-sm">
-                  Skills <span className="text-muted-foreground">({props.skills.length})</span>
-                </h4>
+              <div className="grid">
                 <SkillImportPicker
                   className="[&_[data-skill-scroll]]:max-h-72"
+                  flushScroll
                   onToggle={toggleSkill}
                   onToggleAll={toggleSkills}
                   resetKey={`${props.open}:${props.skills.length}`}
                   selected={draftSkillSelection}
                   skills={props.skills}
+                  title="Skills"
                 />
               </div>
             ) : (

--- a/packages/ui/src/pages/AgentSetupPage.tsx
+++ b/packages/ui/src/pages/AgentSetupPage.tsx
@@ -50,6 +50,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { linkThenRefreshImportPreview } from "@/lib/agent-import-flow";
 import { availableSkillsForKind, fetchSkills, type SkillSummary } from "@/lib/skills";
 import { cn } from "@/lib/utils";
 
@@ -1192,6 +1193,7 @@ function ImportSceneDialog(props: {
   const [conflictStrategy, setConflictStrategy] = useState<ConflictStrategy>("add-missing-only");
   const [replaceConflicts, setReplaceConflicts] = useState<string[]>([]);
   const wasOpenRef = useRef(false);
+  const previewRequestIdRef = useRef(0);
   const selected = new Set(draftSelection);
   const selectedSkills = props.skills.filter((skill) => draftSkillSelection.has(skillKey(skill)));
   const conflicts = draftPreview.plan.summary.conflicts;
@@ -1232,33 +1234,32 @@ function ImportSceneDialog(props: {
     setReplaceConflicts([]);
   }, [props.open, props.preview, props.workflow]);
 
+  const loadDraftPreview = useCallback(async () => {
+    const requestId = ++previewRequestIdRef.current;
+    const body = await props.request<AgentPlanPreview>("/api/agent-preview/import", {
+      method: "POST",
+      body: {
+        hostKind: props.hostKind,
+        selection: draftSelection,
+        conflictStrategy,
+        replaceConflicts,
+      },
+    });
+    return requestId === previewRequestIdRef.current ? body : null;
+  }, [conflictStrategy, draftSelection, props.hostKind, props.request, replaceConflicts]);
+
   useEffect(() => {
     if (!props.open) return;
     let cancelled = false;
-    const loadDraftPreview = async () => {
-      const body = await props.request<AgentPlanPreview>("/api/agent-preview/import", {
-        method: "POST",
-        body: {
-          hostKind: props.hostKind,
-          selection: draftSelection,
-          conflictStrategy,
-          replaceConflicts,
-        },
-      });
-      if (!cancelled) setDraftPreview(body);
+    const refreshDraftPreview = async () => {
+      const body = await loadDraftPreview();
+      if (!cancelled && body) setDraftPreview(body);
     };
-    void loadDraftPreview();
+    void refreshDraftPreview();
     return () => {
       cancelled = true;
     };
-  }, [
-    conflictStrategy,
-    draftSelection,
-    props.hostKind,
-    props.open,
-    props.request,
-    replaceConflicts,
-  ]);
+  }, [loadDraftPreview, props.open]);
 
   const commit = async () => {
     setCommitting(true);
@@ -1282,7 +1283,13 @@ function ImportSceneDialog(props: {
   const linkAndContinue = async () => {
     setCommitting(true);
     try {
-      if (!(await props.onLink()) || workflow.step !== "link") return;
+      const refreshedPreview = await linkThenRefreshImportPreview(props.onLink, async () => {
+        const preview = await loadDraftPreview();
+        if (!preview) throw new Error("import preview refresh was superseded");
+        return preview;
+      });
+      if (!refreshedPreview || workflow.step !== "link") return;
+      setDraftPreview(refreshedPreview);
       setWorkflow(advanceAgentImportWorkflow(workflow, { type: "link-completed" }));
       setScene("skills");
     } finally {

--- a/packages/ui/src/pages/AgentSetupPage.tsx
+++ b/packages/ui/src/pages/AgentSetupPage.tsx
@@ -1,3 +1,9 @@
+import {
+  type AgentImportWorkflowState,
+  advanceAgentImportWorkflow,
+  beginAgentImportWorkflow,
+  unlinkedAgentImportWarning,
+} from "@ratel-ai/mcp-core/agent-import-workflow";
 import { useNavigate } from "@tanstack/react-router";
 import { type StructuredPatchHunk, structuredPatch } from "diff";
 import {
@@ -13,7 +19,7 @@ import {
   X,
 } from "lucide-react";
 import { AnimatePresence, motion } from "motion/react";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import useMeasure from "react-use-measure";
 import { type BackupManifest, type JsonRequestInit, type ServerEntry, useRatelApp } from "@/App";
 import { SkillImportPicker, skillKey } from "@/components/import-skills-dialog";
@@ -792,6 +798,15 @@ function PreviewFlow(props: {
   const friendlyNoOp = Boolean(
     preview?.emptyReason && linkedAndCovered && props.availableSkills.length === 0,
   );
+  const initialImportWorkflow = useMemo(
+    () =>
+      beginAgentImportWorkflow({
+        hostKind: props.hostKind,
+        linked: props.host.ratelEntryCount > 0,
+        statuslineInstalled: props.host.statusline?.status === "installed",
+      }),
+    [props.host.ratelEntryCount, props.host.statusline?.status, props.hostKind],
+  );
 
   const applyRatel = async (
     importPreview: AgentPlanPreview,
@@ -826,7 +841,7 @@ function PreviewFlow(props: {
     const path =
       props.flow === "import" ? "/api/agent-apply/import/agent" : "/api/agent-apply/link";
     const applied = await runAction(
-      props.flow === "import" ? "Agent config rewritten" : "Link complete",
+      props.flow === "import" ? "Source agent cleanup applied" : "Link complete",
       () =>
         props.request(path, {
           method: "POST",
@@ -842,6 +857,40 @@ function PreviewFlow(props: {
     if (!applied) return false;
     await props.onScanHosts();
     setRefreshNonce((value) => value + 1);
+    return true;
+  };
+
+  const applyLinkFromImport = async () => {
+    const linkPreview = await props.request<AgentPlanPreview>("/api/agent-preview/link", {
+      method: "POST",
+      body: { hostKind: props.hostKind },
+    });
+    if (linkPreview.plan.agentChanges.length > 0) {
+      const linked = await runAction("Link complete", () =>
+        props.request("/api/agent-apply/link", {
+          method: "POST",
+          body: {
+            hostKind: props.hostKind,
+            planHash: linkPreview.stageHashes.agent,
+          },
+        }),
+      );
+      if (!linked) return false;
+    }
+    await props.onScanHosts();
+    setRefreshNonce((value) => value + 1);
+    return true;
+  };
+
+  const installStatuslineFromImport = async () => {
+    const installed = await runAction("Install statusline", () =>
+      props.request("/api/claude-statusline/install", {
+        method: "POST",
+        body: { force: props.host.statusline?.status === "other" },
+      }),
+    );
+    if (!installed) return false;
+    await props.onScanHosts();
     return true;
   };
 
@@ -866,11 +915,14 @@ function PreviewFlow(props: {
       const skillsApplied = await activateSelectedSkills(selectedSkills);
       if (!skillsApplied) return false;
     }
-    setDialogOpen(false);
     return true;
   };
 
   const activateSelectedSkills = async (selectedSkills: SkillSummary[]) => {
+    type ActivateSkillsResponse = {
+      managed: Array<{ id: string; mode: string }>;
+      skipped?: Array<{ id: string; reason: string }>;
+    };
     const idsBySource = new Map<SkillSummary["source"], string[]>();
     for (const skill of selectedSkills) {
       if (skill.source !== "claude" && skill.source !== "codex") continue;
@@ -878,14 +930,24 @@ function PreviewFlow(props: {
       ids.push(skill.id);
       idsBySource.set(skill.source, ids);
     }
-    const applied = await runAction(
-      `Now managing ${selectedSkills.length} skill${selectedSkills.length === 1 ? "" : "s"}`,
-      async () => {
-        for (const [source, ids] of idsBySource) {
-          await props.request("/api/skills/activate", { method: "POST", body: { ids, source } });
-        }
-      },
-    );
+    const managed: ActivateSkillsResponse["managed"] = [];
+    const skipped: NonNullable<ActivateSkillsResponse["skipped"]> = [];
+    const applied = await runAction("Skill management complete", async () => {
+      for (const [source, ids] of idsBySource) {
+        const result = await props.request<ActivateSkillsResponse>("/api/skills/activate", {
+          method: "POST",
+          body: { ids, source },
+        });
+        managed.push(...result.managed);
+        skipped.push(...(result.skipped ?? []));
+      }
+      return {
+        log: [
+          `Now managing ${managed.length} skill${managed.length === 1 ? "" : "s"}`,
+          ...(skipped.length > 0 ? [skippedSkillsMessage(skipped)] : []),
+        ],
+      };
+    });
     if (!applied) return false;
     await props.onSkillsImported();
     setRefreshNonce((value) => value + 1);
@@ -931,11 +993,14 @@ function PreviewFlow(props: {
           {!friendlyNoOp && props.flow === "import" ? (
             <ImportSceneDialog
               onCommit={commitImport}
+              onInstallStatusline={installStatuslineFromImport}
+              onLink={applyLinkFromImport}
               onOpenChange={setDialogOpen}
               open={dialogOpen}
               preview={preview}
               request={props.request}
               hostKind={props.hostKind}
+              workflow={initialImportWorkflow}
               skills={props.availableSkills}
             />
           ) : null}
@@ -1085,7 +1150,19 @@ function importAvailabilityLabel(mcpCount: number, skillCount: number) {
   return `${parts.join(" and ")} available.`;
 }
 
-type ImportScene = "skills" | "entries" | "strategy" | "pick-conflicts" | "review";
+function skippedSkillsMessage(skipped: Array<{ id: string; reason: string }>) {
+  const details = skipped.map((skill) => `${skill.id}: ${skill.reason}`).join("; ");
+  return `Could not manage selected skill${skipped.length === 1 ? "" : "s"} (${details})`;
+}
+
+type ImportScene =
+  | "link"
+  | "skills"
+  | "entries"
+  | "strategy"
+  | "pick-conflicts"
+  | "review"
+  | "statusline";
 
 function ImportSceneDialog(props: {
   hostKind: AgentHostKind;
@@ -1095,13 +1172,19 @@ function ImportSceneDialog(props: {
     replaceConflicts: string[],
     selectedSkills: SkillSummary[],
   ) => Promise<boolean>;
+  onInstallStatusline: () => Promise<boolean>;
+  onLink: () => Promise<boolean>;
   onOpenChange: (open: boolean) => void;
   open: boolean;
   preview: AgentPlanPreview;
   request: <T>(path: string, init?: JsonRequestInit) => Promise<T>;
   skills: SkillSummary[];
+  workflow: AgentImportWorkflowState;
 }) {
-  const [scene, setScene] = useState<ImportScene>("skills");
+  const [scene, setScene] = useState<ImportScene>(
+    props.workflow.step === "link" ? "link" : "skills",
+  );
+  const [workflow, setWorkflow] = useState(props.workflow);
   const [committing, setCommitting] = useState(false);
   const [draftPreview, setDraftPreview] = useState<AgentPlanPreview>(props.preview);
   const [draftSelection, setDraftSelection] = useState<string[]>(props.preview.selected);
@@ -1137,12 +1220,14 @@ function ImportSceneDialog(props: {
 
   useEffect(() => {
     if (!props.open) return;
+    setScene(props.workflow.step === "link" ? "link" : "skills");
+    setWorkflow(props.workflow);
     setDraftPreview(props.preview);
     setDraftSelection(props.preview.selected);
     setDraftSkillSelection(new Set());
     setConflictStrategy("add-missing-only");
     setReplaceConflicts([]);
-  }, [props.open, props.preview]);
+  }, [props.open, props.preview, props.workflow]);
 
   useEffect(() => {
     if (!props.open) return;
@@ -1175,7 +1260,45 @@ function ImportSceneDialog(props: {
   const commit = async () => {
     setCommitting(true);
     try {
-      await props.onCommit(draftPreview, conflictStrategy, replaceConflicts, selectedSkills);
+      const committed = await props.onCommit(
+        draftPreview,
+        conflictStrategy,
+        replaceConflicts,
+        selectedSkills,
+      );
+      if (!committed || workflow.step !== "import") return;
+      const next = advanceAgentImportWorkflow(workflow, { type: "import-completed" });
+      setWorkflow(next);
+      if (next.step === "statusline") setScene("statusline");
+      else props.onOpenChange(false);
+    } finally {
+      setCommitting(false);
+    }
+  };
+
+  const linkAndContinue = async () => {
+    setCommitting(true);
+    try {
+      if (!(await props.onLink()) || workflow.step !== "link") return;
+      setWorkflow(advanceAgentImportWorkflow(workflow, { type: "link-completed" }));
+      setScene("skills");
+    } finally {
+      setCommitting(false);
+    }
+  };
+
+  const skipLink = () => {
+    if (workflow.step !== "link") return;
+    setWorkflow(advanceAgentImportWorkflow(workflow, { type: "link-skipped" }));
+    setScene("skills");
+  };
+
+  const installStatusline = async () => {
+    setCommitting(true);
+    try {
+      if (!(await props.onInstallStatusline()) || workflow.step !== "statusline") return;
+      setWorkflow(advanceAgentImportWorkflow(workflow, { type: "statusline-completed" }));
+      props.onOpenChange(false);
     } finally {
       setCommitting(false);
     }
@@ -1208,11 +1331,38 @@ function ImportSceneDialog(props: {
       open={props.open}
       onOpenChange={(open) => {
         props.onOpenChange(open);
-        if (open) setScene("skills");
+        if (open) setScene(props.workflow.step === "link" ? "link" : "skills");
       }}
       scene={scene}
       title="Import"
     >
+      {scene === "link" ? (
+        <ScenePanel
+          footer={
+            <>
+              <Button onClick={() => props.onOpenChange(false)} type="button" variant="outline">
+                Cancel import
+              </Button>
+              <Button disabled={committing} onClick={skipLink} type="button" variant="outline">
+                Continue without linking
+              </Button>
+              <Button disabled={committing} onClick={() => void linkAndContinue()} type="button">
+                <LinkIcon />
+                Link Ratel and continue
+              </Button>
+            </>
+          }
+          kicker="Link"
+          title="Link Ratel first?"
+        >
+          <Alert>
+            <AlertTitle>{props.preview.host.displayName} is not linked</AlertTitle>
+            <AlertDescription>
+              {unlinkedAgentImportWarning(props.preview.host.displayName)}
+            </AlertDescription>
+          </Alert>
+        </ScenePanel>
+      ) : null}
       {scene === "skills" ? (
         <ScenePanel
           flushFooter
@@ -1407,10 +1557,32 @@ function ImportSceneDialog(props: {
             <ChangeList
               changes={draftPreview.plan.agentChanges}
               defaultOpen
-              title={`${props.preview.host.displayName} config`}
+              title={`${props.preview.host.displayName} source cleanup`}
             />
             <SkillActivationReview skills={selectedSkills} />
           </SceneScrollSection>
+        </ScenePanel>
+      ) : null}
+      {scene === "statusline" ? (
+        <ScenePanel
+          footer={
+            <>
+              <Button onClick={() => props.onOpenChange(false)} type="button" variant="outline">
+                Skip
+              </Button>
+              <Button disabled={committing} onClick={() => void installStatusline()} type="button">
+                <FileText />
+                Install statusline
+              </Button>
+            </>
+          }
+          kicker="Statusline"
+          title="Install the Ratel statusline?"
+        >
+          <p className="text-sm text-muted-foreground">
+            Import is complete. Install the standalone Claude Code statusline to show context usage
+            and Ratel telemetry.
+          </p>
         </ScenePanel>
       ) : null}
     </SceneDialog>

--- a/packages/ui/src/pages/AgentSetupPage.tsx
+++ b/packages/ui/src/pages/AgentSetupPage.tsx
@@ -50,7 +50,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { linkThenRefreshImportPreview } from "@/lib/agent-import-flow";
+import { importStatuslineAction, linkThenRefreshImportPreview } from "@/lib/agent-import-flow";
 import { availableSkillsForKind, fetchSkills, type SkillSummary } from "@/lib/skills";
 import { cn } from "@/lib/utils";
 
@@ -883,11 +883,11 @@ function PreviewFlow(props: {
     return true;
   };
 
-  const installStatuslineFromImport = async () => {
-    const installed = await runAction("Install statusline", () =>
+  const installStatuslineFromImport = async (force: boolean) => {
+    const installed = await runAction(force ? "Replace statusline" : "Install statusline", () =>
       props.request("/api/claude-statusline/install", {
         method: "POST",
-        body: { force: props.host.statusline?.status === "other" },
+        body: { force },
       }),
     );
     if (!installed) return false;
@@ -1001,6 +1001,7 @@ function PreviewFlow(props: {
               preview={preview}
               request={props.request}
               hostKind={props.hostKind}
+              statuslineStatus={props.host.statusline?.status}
               workflow={initialImportWorkflow}
               skills={props.availableSkills}
             />
@@ -1173,13 +1174,14 @@ function ImportSceneDialog(props: {
     replaceConflicts: string[],
     selectedSkills: SkillSummary[],
   ) => Promise<boolean>;
-  onInstallStatusline: () => Promise<boolean>;
+  onInstallStatusline: (force: boolean) => Promise<boolean>;
   onLink: () => Promise<boolean>;
   onOpenChange: (open: boolean) => void;
   open: boolean;
   preview: AgentPlanPreview;
   request: <T>(path: string, init?: JsonRequestInit) => Promise<T>;
   skills: SkillSummary[];
+  statuslineStatus: ClaudeStatuslineState["status"] | undefined;
   workflow: AgentImportWorkflowState;
 }) {
   const [scene, setScene] = useState<ImportScene>(
@@ -1192,6 +1194,7 @@ function ImportSceneDialog(props: {
   const [draftSkillSelection, setDraftSkillSelection] = useState<Set<string>>(new Set());
   const [conflictStrategy, setConflictStrategy] = useState<ConflictStrategy>("add-missing-only");
   const [replaceConflicts, setReplaceConflicts] = useState<string[]>([]);
+  const statuslineAction = importStatuslineAction(props.statuslineStatus);
   const wasOpenRef = useRef(false);
   const previewRequestIdRef = useRef(0);
   const selected = new Set(draftSelection);
@@ -1306,7 +1309,11 @@ function ImportSceneDialog(props: {
   const installStatusline = async () => {
     setCommitting(true);
     try {
-      if (!(await props.onInstallStatusline()) || workflow.step !== "statusline") return;
+      if (
+        !(await props.onInstallStatusline(statuslineAction.force)) ||
+        workflow.step !== "statusline"
+      )
+        return;
       setWorkflow(advanceAgentImportWorkflow(workflow, { type: "statusline-installed" }));
       props.onOpenChange(false);
     } finally {
@@ -1588,17 +1595,14 @@ function ImportSceneDialog(props: {
               </Button>
               <Button disabled={committing} onClick={() => void installStatusline()} type="button">
                 <FileText />
-                Install statusline
+                {statuslineAction.actionLabel}
               </Button>
             </>
           }
           kicker="Statusline"
-          title="Install the Ratel statusline?"
+          title={statuslineAction.title}
         >
-          <p className="text-sm text-muted-foreground">
-            Import is complete. Install the standalone Claude Code statusline to show context usage
-            and Ratel telemetry.
-          </p>
+          <p className="text-sm text-muted-foreground">{statuslineAction.description}</p>
         </ScenePanel>
       ) : null}
     </SceneDialog>

--- a/packages/ui/src/pages/AgentSetupPage.tsx
+++ b/packages/ui/src/pages/AgentSetupPage.tsx
@@ -1115,7 +1115,6 @@ function ImportSceneDialog(props: {
     draftSelection.length > 0 && conflicts.length > 0 && conflictStrategy === "replace-selected";
   const hasSelectedImport = draftSelection.length > 0 || selectedSkills.length > 0;
   const hasSelectableEntries = props.preview.candidates.length > 0;
-  const canLeaveSkills = selectedSkills.length > 0 || hasSelectableEntries;
   const goAfterSkills = () => setScene(hasSelectableEntries ? "entries" : "review");
   const goAfterEntries = () =>
     setScene(draftSelection.length > 0 && conflicts.length > 0 ? "strategy" : "review");
@@ -1214,7 +1213,7 @@ function ImportSceneDialog(props: {
               <Button onClick={() => props.onOpenChange(false)} type="button" variant="outline">
                 Cancel
               </Button>
-              <Button disabled={!canLeaveSkills} onClick={goAfterSkills} type="button">
+              <Button onClick={goAfterSkills} type="button">
                 Continue
               </Button>
             </>

--- a/packages/ui/src/pages/AgentSetupPage.tsx
+++ b/packages/ui/src/pages/AgentSetupPage.tsx
@@ -16,7 +16,7 @@ import { AnimatePresence, motion } from "motion/react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import useMeasure from "react-use-measure";
 import { type BackupManifest, type JsonRequestInit, type ServerEntry, useRatelApp } from "@/App";
-import { ImportSkillsDialog } from "@/components/import-skills-dialog";
+import { SkillImportPicker, skillKey } from "@/components/import-skills-dialog";
 import {
   PageHeader,
   PageHeaderActions,
@@ -44,12 +44,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import {
-  agentKindToSkillSource,
-  availableSkillsForKind,
-  fetchSkills,
-  type SkillSummary,
-} from "@/lib/skills";
+import { availableSkillsForKind, fetchSkills, type SkillSummary } from "@/lib/skills";
 import { cn } from "@/lib/utils";
 
 type AgentHostKind = "claude-code" | "codex";
@@ -614,9 +609,9 @@ function AgentOperationPanel(props: {
   onSkillsImported: () => void | Promise<void>;
   request: <T>(path: string, init?: JsonRequestInit) => Promise<T>;
 }) {
-  const canImport = missingRatelEntryNames(props.host).length > 0;
+  const canImport =
+    missingRatelEntryNames(props.host).length > 0 || props.availableSkills.length > 0;
   const canLink = props.host.posture !== "unavailable" && props.host.ratelEntryCount === 0;
-  const canImportSkills = props.availableSkills.length > 0;
   const canManageStatusline = props.hostKind === "claude-code" && Boolean(props.host.statusline);
   return (
     <section className="-mx-4 grid gap-5 border-border border-y bg-muted/10 px-4 py-5 sm:-mx-6 sm:px-6">
@@ -627,25 +622,20 @@ function AgentOperationPanel(props: {
           state={props.host.statusline}
         />
       ) : null}
-      {canImportSkills ? (
-        <SkillImportSection
-          available={props.availableSkills}
-          onImported={props.onSkillsImported}
-          source={agentKindToSkillSource(props.hostKind)}
-        />
-      ) : null}
       {canImport ? (
         <SetupActionSection
-          description="Copy native MCP entries into Ratel. After review, selected entries are removed from the agent config."
+          description="Choose native MCP entries and skills to bring under Ratel in one reviewed flow."
           icon={<Download />}
-          title="Import native entries"
+          title="Import into Ratel"
         >
           <PreviewFlow
+            availableSkills={props.availableSkills}
             flow="import"
             host={props.host}
             hostKind={props.hostKind}
             key={`import:${props.hostKind}`}
             onScanHosts={props.onScanHosts}
+            onSkillsImported={props.onSkillsImported}
             request={props.request}
           />
         </SetupActionSection>
@@ -657,16 +647,18 @@ function AgentOperationPanel(props: {
           title="Link Ratel gateway"
         >
           <PreviewFlow
+            availableSkills={[]}
             flow="link"
             host={props.host}
             hostKind={props.hostKind}
             key={`link:${props.hostKind}`}
             onScanHosts={props.onScanHosts}
+            onSkillsImported={props.onSkillsImported}
             request={props.request}
           />
         </SetupActionSection>
       ) : null}
-      {!canImport && !canLink && !canImportSkills && !canManageStatusline ? (
+      {!canImport && !canLink && !canManageStatusline ? (
         <div>
           <h3 className="text-lg font-semibold tracking-tight">Nothing to do</h3>
           <p className="mt-1 text-sm text-muted-foreground">
@@ -744,42 +736,6 @@ function ClaudeStatuslineSection(props: {
   );
 }
 
-function SkillImportSection(props: {
-  available: SkillSummary[];
-  onImported: () => void | Promise<void>;
-  source: ReturnType<typeof agentKindToSkillSource>;
-}) {
-  const [open, setOpen] = useState(false);
-  const count = props.available.length;
-  return (
-    <SetupActionSection
-      description="Link this agent's skills into Ratel as invoke-only without moving their native folders."
-      icon={<Sparkles />}
-      title="Manage skills"
-    >
-      <div className="grid gap-4 border border-border bg-background p-4 md:grid-cols-[minmax(0,1fr)_auto] md:items-center">
-        <div>
-          <h4 className="font-medium">
-            {count} skill{count === 1 ? "" : "s"} not managed by Ratel
-          </h4>
-          <p className="mt-1 text-sm text-muted-foreground">Choose which to manage with Ratel.</p>
-        </div>
-        <Button className="min-h-12 px-6 text-base md:min-w-40" onClick={() => setOpen(true)}>
-          <Sparkles />
-          Manage skills
-        </Button>
-      </div>
-      <ImportSkillsDialog
-        available={props.available}
-        onImported={props.onImported}
-        onOpenChange={setOpen}
-        open={open}
-        source={props.source}
-      />
-    </SetupActionSection>
-  );
-}
-
 function SetupActionSection(props: {
   children: React.ReactNode;
   description: string;
@@ -801,10 +757,12 @@ function SetupActionSection(props: {
 }
 
 function PreviewFlow(props: {
+  availableSkills: SkillSummary[];
   flow: SetupFlow;
   host: DetectedAgentHostSummary;
   hostKind: AgentHostKind;
   onScanHosts: () => Promise<void>;
+  onSkillsImported: () => void | Promise<void>;
   request: <T>(path: string, init?: JsonRequestInit) => Promise<T>;
 }) {
   const { runAction } = useRatelApp();
@@ -842,7 +800,9 @@ function PreviewFlow(props: {
   const agentChanges = preview?.plan.agentChanges ?? [];
   const linkedAndCovered =
     props.host.ratelEntryCount > 0 && missingRatelEntryNames(props.host).length === 0;
-  const friendlyNoOp = Boolean(preview?.emptyReason && linkedAndCovered);
+  const friendlyNoOp = Boolean(
+    preview?.emptyReason && linkedAndCovered && props.availableSkills.length === 0,
+  );
 
   const applyRatel = async (
     importPreview: AgentPlanPreview,
@@ -900,6 +860,7 @@ function PreviewFlow(props: {
     importPreview: AgentPlanPreview,
     conflictStrategy: ConflictStrategy,
     replaceConflicts: string[],
+    selectedSkills: SkillSummary[],
   ) => {
     if (importPreview.plan.ratelChanges.length > 0) {
       const ratelApplied = await applyRatel(importPreview, conflictStrategy, replaceConflicts);
@@ -912,7 +873,33 @@ function PreviewFlow(props: {
       });
       if (!agentApplied) return false;
     }
+    if (selectedSkills.length > 0) {
+      const skillsApplied = await activateSelectedSkills(selectedSkills);
+      if (!skillsApplied) return false;
+    }
     setDialogOpen(false);
+    return true;
+  };
+
+  const activateSelectedSkills = async (selectedSkills: SkillSummary[]) => {
+    const idsBySource = new Map<SkillSummary["source"], string[]>();
+    for (const skill of selectedSkills) {
+      if (skill.source !== "claude" && skill.source !== "codex") continue;
+      const ids = idsBySource.get(skill.source) ?? [];
+      ids.push(skill.id);
+      idsBySource.set(skill.source, ids);
+    }
+    const applied = await runAction(
+      `Now managing ${selectedSkills.length} skill${selectedSkills.length === 1 ? "" : "s"}`,
+      async () => {
+        for (const [source, ids] of idsBySource) {
+          await props.request("/api/skills/activate", { method: "POST", body: { ids, source } });
+        }
+      },
+    );
+    if (!applied) return false;
+    await props.onSkillsImported();
+    setRefreshNonce((value) => value + 1);
     return true;
   };
 
@@ -939,9 +926,14 @@ function PreviewFlow(props: {
           {friendlyNoOp ? (
             <LinkedCoveredPreview flow={props.flow} host={props.host} />
           ) : (
-            <SetupRecap flow={props.flow} onOpen={() => setDialogOpen(true)} preview={preview} />
+            <SetupRecap
+              availableSkills={props.availableSkills}
+              flow={props.flow}
+              onOpen={() => setDialogOpen(true)}
+              preview={preview}
+            />
           )}
-          {preview.emptyReason && !friendlyNoOp ? (
+          {preview.emptyReason && !friendlyNoOp && props.availableSkills.length === 0 ? (
             <Alert>
               <AlertTitle>No changes available</AlertTitle>
               <AlertDescription>{preview.emptyReason}</AlertDescription>
@@ -955,6 +947,7 @@ function PreviewFlow(props: {
               preview={preview}
               request={props.request}
               hostKind={props.hostKind}
+              skills={props.availableSkills}
             />
           ) : null}
           {!friendlyNoOp && props.flow === "link" ? (
@@ -1058,24 +1051,31 @@ function backupFileSummary(count: number) {
   return `${count} config file${count === 1 ? "" : "s"} backed up`;
 }
 
-function SetupRecap(props: { flow: SetupFlow; onOpen: () => void; preview: AgentPlanPreview }) {
+function SetupRecap(props: {
+  availableSkills: SkillSummary[];
+  flow: SetupFlow;
+  onOpen: () => void;
+  preview: AgentPlanPreview;
+}) {
   const changes = props.preview.plan.ratelChanges.length + props.preview.plan.agentChanges.length;
+  const importableCount =
+    props.preview.candidates.length + (props.flow === "import" ? props.availableSkills.length : 0);
   const actionLabel = props.flow === "import" ? "Import" : "Link";
   return (
     <div className="grid gap-4 border border-border bg-background p-4 md:grid-cols-[minmax(0,1fr)_auto] md:items-center">
       <div>
         <h4 className="font-medium">
-          {props.flow === "import" ? "Import native entries" : "Link Ratel gateway"}
+          {props.flow === "import" ? "Import into Ratel" : "Link Ratel gateway"}
         </h4>
         <p className="mt-1 text-sm text-muted-foreground">
           {props.flow === "import"
-            ? "Choose entries, resolve conflicts if needed, then review the exact config changes."
+            ? "Choose MCP entries and skills, resolve conflicts if needed, then review changes."
             : "Review the exact agent config change before writing it."}
         </p>
       </div>
       <Button
         className="min-h-12 px-6 text-base md:min-w-40"
-        disabled={changes === 0}
+        disabled={props.flow === "import" ? importableCount === 0 : changes === 0}
         onClick={props.onOpen}
       >
         {props.flow === "import" ? <Download /> : <LinkIcon />}
@@ -1093,22 +1093,29 @@ function ImportSceneDialog(props: {
     preview: AgentPlanPreview,
     conflictStrategy: ConflictStrategy,
     replaceConflicts: string[],
+    selectedSkills: SkillSummary[],
   ) => Promise<boolean>;
   onOpenChange: (open: boolean) => void;
   open: boolean;
   preview: AgentPlanPreview;
   request: <T>(path: string, init?: JsonRequestInit) => Promise<T>;
+  skills: SkillSummary[];
 }) {
   const [scene, setScene] = useState<ImportScene>("recap");
   const [committing, setCommitting] = useState(false);
   const [draftPreview, setDraftPreview] = useState<AgentPlanPreview>(props.preview);
   const [draftSelection, setDraftSelection] = useState<string[]>(props.preview.selected);
+  const [draftSkillSelection, setDraftSkillSelection] = useState<Set<string>>(new Set());
   const [conflictStrategy, setConflictStrategy] = useState<ConflictStrategy>("add-missing-only");
   const [replaceConflicts, setReplaceConflicts] = useState<string[]>([]);
   const selected = new Set(draftSelection);
+  const selectedSkills = props.skills.filter((skill) => draftSkillSelection.has(skillKey(skill)));
   const conflicts = draftPreview.plan.summary.conflicts;
-  const requiresConflictSelection = conflicts.length > 0 && conflictStrategy === "replace-selected";
-  const goAfterRecap = () => setScene(conflicts.length > 0 ? "strategy" : "review");
+  const requiresConflictSelection =
+    draftSelection.length > 0 && conflicts.length > 0 && conflictStrategy === "replace-selected";
+  const hasSelectedImport = draftSelection.length > 0 || selectedSkills.length > 0;
+  const goAfterRecap = () =>
+    setScene(draftSelection.length > 0 && conflicts.length > 0 ? "strategy" : "review");
   const goAfterStrategy = () =>
     setScene(conflictStrategy === "replace-selected" ? "pick-conflicts" : "review");
 
@@ -1116,6 +1123,7 @@ function ImportSceneDialog(props: {
     if (!props.open) return;
     setDraftPreview(props.preview);
     setDraftSelection(props.preview.selected);
+    setDraftSkillSelection(new Set());
     setConflictStrategy("add-missing-only");
     setReplaceConflicts([]);
   }, [props.open, props.preview]);
@@ -1151,10 +1159,32 @@ function ImportSceneDialog(props: {
   const commit = async () => {
     setCommitting(true);
     try {
-      await props.onCommit(draftPreview, conflictStrategy, replaceConflicts);
+      await props.onCommit(draftPreview, conflictStrategy, replaceConflicts, selectedSkills);
     } finally {
       setCommitting(false);
     }
+  };
+
+  const toggleSkill = (skill: SkillSummary) => {
+    setDraftSkillSelection((current) => {
+      const next = new Set(current);
+      const key = skillKey(skill);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+  };
+
+  const toggleSkills = (skills: SkillSummary[], shouldSelect: boolean) => {
+    setDraftSkillSelection((current) => {
+      const next = new Set(current);
+      for (const skill of skills) {
+        const key = skillKey(skill);
+        if (shouldSelect) next.add(key);
+        else next.delete(key);
+      }
+      return next;
+    });
   };
 
   return (
@@ -1175,48 +1205,71 @@ function ImportSceneDialog(props: {
               <Button onClick={() => props.onOpenChange(false)} type="button" variant="outline">
                 Cancel
               </Button>
-              <Button onClick={goAfterRecap} type="button">
+              <Button disabled={!hasSelectedImport} onClick={goAfterRecap} type="button">
                 Continue
               </Button>
             </>
           }
-          kicker="Entries"
-          title="Choose entries to import"
+          kicker="Import"
+          title="Choose what to import"
         >
           <div className="grid gap-3">
-            <SceneScrollSection className="max-h-60">
-              {props.preview.candidates.map((candidate) => {
-                const isSelected = selected.has(candidate.name);
-                return (
-                  <button
-                    className={cn(
-                      "grid w-full gap-1 border-border border-b px-3 py-2 text-left transition-colors last:border-b-0",
-                      isSelected ? "bg-brand-green/10" : "bg-background hover:bg-muted/35",
-                    )}
-                    key={`${candidate.scope}:${candidate.name}`}
-                    onClick={() =>
-                      setDraftSelection((current) => toggleSelection(current, candidate.name))
-                    }
-                    type="button"
-                  >
-                    <div className="flex min-w-0 items-center justify-between gap-2">
-                      <span className="flex min-w-0 items-center gap-2">
-                        <Checkbox
-                          checked={isSelected}
-                          className="pointer-events-none"
-                          tabIndex={-1}
-                        />
-                        <span className="truncate font-medium">{candidate.name}</span>
-                      </span>
-                      <Badge variant="outline">{candidate.scope}</Badge>
-                    </div>
-                    <span className="truncate pl-6 text-xs text-muted-foreground">
-                      {summarizeEntry(candidate.entry)}
-                    </span>
-                  </button>
-                );
-              })}
-            </SceneScrollSection>
+            {props.preview.candidates.length > 0 ? (
+              <div className="grid gap-2">
+                <h4 className="px-1 font-medium text-sm">
+                  MCP entries{" "}
+                  <span className="text-muted-foreground">({props.preview.candidates.length})</span>
+                </h4>
+                <SceneScrollSection className="max-h-60">
+                  {props.preview.candidates.map((candidate) => {
+                    const isSelected = selected.has(candidate.name);
+                    return (
+                      <button
+                        className={cn(
+                          "grid w-full gap-1 border-border border-b px-3 py-2 text-left transition-colors last:border-b-0",
+                          isSelected ? "bg-brand-green/10" : "bg-background hover:bg-muted/35",
+                        )}
+                        key={`${candidate.scope}:${candidate.name}`}
+                        onClick={() =>
+                          setDraftSelection((current) => toggleSelection(current, candidate.name))
+                        }
+                        type="button"
+                      >
+                        <div className="flex min-w-0 items-center justify-between gap-2">
+                          <span className="flex min-w-0 items-center gap-2">
+                            <Checkbox
+                              checked={isSelected}
+                              className="pointer-events-none"
+                              tabIndex={-1}
+                            />
+                            <span className="truncate font-medium">{candidate.name}</span>
+                          </span>
+                          <Badge variant="outline">{candidate.scope}</Badge>
+                        </div>
+                        <span className="truncate pl-6 text-xs text-muted-foreground">
+                          {summarizeEntry(candidate.entry)}
+                        </span>
+                      </button>
+                    );
+                  })}
+                </SceneScrollSection>
+              </div>
+            ) : null}
+            {props.skills.length > 0 ? (
+              <div className="grid gap-2">
+                <h4 className="px-1 font-medium text-sm">
+                  Skills <span className="text-muted-foreground">({props.skills.length})</span>
+                </h4>
+                <SkillImportPicker
+                  className="[&_[data-skill-scroll]]:max-h-72"
+                  onToggle={toggleSkill}
+                  onToggleAll={toggleSkills}
+                  resetKey={`${props.open}:${props.skills.length}`}
+                  selected={draftSkillSelection}
+                  skills={props.skills}
+                />
+              </div>
+            ) : null}
           </div>
         </ScenePanel>
       ) : null}
@@ -1310,7 +1363,11 @@ function ImportSceneDialog(props: {
               >
                 Back
               </Button>
-              <Button disabled={committing} onClick={() => void commit()} type="button">
+              <Button
+                disabled={committing || !hasSelectedImport}
+                onClick={() => void commit()}
+                type="button"
+              >
                 <FileText />
                 Commit import
               </Button>
@@ -1327,6 +1384,7 @@ function ImportSceneDialog(props: {
               defaultOpen
               title={`${props.preview.host.displayName} config`}
             />
+            <SkillActivationReview skills={selectedSkills} />
           </SceneScrollSection>
         </ScenePanel>
       ) : null}
@@ -1378,6 +1436,36 @@ function LinkSceneDialog(props: {
         </SceneScrollSection>
       </ScenePanel>
     </SceneDialog>
+  );
+}
+
+function SkillActivationReview(props: { skills: SkillSummary[] }) {
+  if (props.skills.length === 0) return null;
+  return (
+    <div className="grid min-w-0 gap-2">
+      <h4 className="flex min-w-0 items-center gap-2 text-sm font-medium">
+        <Sparkles className="size-4" />
+        Skills
+      </h4>
+      <div className="divide-y divide-border border border-border bg-background">
+        {props.skills.map((skill) => (
+          <div
+            className="flex min-w-0 items-start justify-between gap-3 px-3 py-2"
+            key={skillKey(skill)}
+          >
+            <div className="min-w-0">
+              <p className="truncate font-medium text-sm">{skill.name}</p>
+              {skill.description ? (
+                <p className="line-clamp-2 text-muted-foreground text-xs">{skill.description}</p>
+              ) : null}
+            </div>
+            <Badge className="shrink-0" variant="outline">
+              {skill.source}
+            </Badge>
+          </div>
+        ))}
+      </div>
+    </div>
   );
 }
 

--- a/packages/ui/src/pages/AgentSetupPage.tsx
+++ b/packages/ui/src/pages/AgentSetupPage.tsx
@@ -1115,7 +1115,15 @@ function ImportSceneDialog(props: {
     draftSelection.length > 0 && conflicts.length > 0 && conflictStrategy === "replace-selected";
   const hasSelectedImport = draftSelection.length > 0 || selectedSkills.length > 0;
   const hasSelectableEntries = props.preview.candidates.length > 0;
-  const goAfterSkills = () => setScene(hasSelectableEntries ? "entries" : "review");
+  const goAfterSkills = () => {
+    if (hasSelectableEntries) {
+      setScene("entries");
+    } else if (selectedSkills.length > 0) {
+      setScene("review");
+    } else {
+      props.onOpenChange(false);
+    }
+  };
   const goAfterEntries = () =>
     setScene(draftSelection.length > 0 && conflicts.length > 0 ? "strategy" : "review");
   const goAfterStrategy = () =>
@@ -1214,7 +1222,7 @@ function ImportSceneDialog(props: {
                 Cancel
               </Button>
               <Button onClick={goAfterSkills} type="button">
-                Continue
+                {hasSelectableEntries || selectedSkills.length > 0 ? "Continue" : "Done"}
               </Button>
             </>
           }

--- a/packages/ui/src/pages/AgentSetupPage.tsx
+++ b/packages/ui/src/pages/AgentSetupPage.tsx
@@ -1300,11 +1300,17 @@ function ImportSceneDialog(props: {
     setCommitting(true);
     try {
       if (!(await props.onInstallStatusline()) || workflow.step !== "statusline") return;
-      setWorkflow(advanceAgentImportWorkflow(workflow, { type: "statusline-completed" }));
+      setWorkflow(advanceAgentImportWorkflow(workflow, { type: "statusline-installed" }));
       props.onOpenChange(false);
     } finally {
       setCommitting(false);
     }
+  };
+
+  const skipStatusline = () => {
+    if (workflow.step !== "statusline") return;
+    setWorkflow(advanceAgentImportWorkflow(workflow, { type: "statusline-skipped" }));
+    props.onOpenChange(false);
   };
 
   const toggleSkill = (skill: SkillSummary) => {
@@ -1570,7 +1576,7 @@ function ImportSceneDialog(props: {
         <ScenePanel
           footer={
             <>
-              <Button onClick={() => props.onOpenChange(false)} type="button" variant="outline">
+              <Button onClick={skipStatusline} type="button" variant="outline">
                 Skip
               </Button>
               <Button disabled={committing} onClick={() => void installStatusline()} type="button">

--- a/packages/ui/src/pages/SkillsPage.tsx
+++ b/packages/ui/src/pages/SkillsPage.tsx
@@ -81,6 +81,7 @@ export function SkillsPage() {
   const problems = ready?.problems ?? [];
   const canImport = available.length > 0;
   const canDeactivateAll = managed.length > 0;
+  const loading = state.status === "loading";
 
   return (
     <main className="flex w-full flex-1 flex-col gap-4 px-4 py-5 sm:px-6">
@@ -109,17 +110,16 @@ export function SkillsPage() {
         </PageHeaderContent>
         <PageHeaderActions className="hidden items-center sm:flex">
           <NewSkillDialog onCreated={load} />
-          {canImport && (
-            <Button
-              className="h-10"
-              onClick={() => setImportOpen(true)}
-              size="sm"
-              variant="outline"
-            >
-              <LinkIcon />
-              Manage skills
-            </Button>
-          )}
+          <Button
+            className="h-10"
+            disabled={loading || !canImport}
+            onClick={() => setImportOpen(true)}
+            size="sm"
+            variant="outline"
+          >
+            <LinkIcon />
+            Manage skills
+          </Button>
           {canDeactivateAll && (
             <Button
               className="h-10"

--- a/packages/ui/tsconfig.app.json
+++ b/packages/ui/tsconfig.app.json
@@ -23,7 +23,8 @@
       "noFallthroughCasesInSwitch": true,
 
       "paths": {
-         "@/*": ["./src/*"]
+         "@/*": ["./src/*"],
+         "@ratel-ai/mcp-core/agent-import-workflow": ["../core/src/agent-import-workflow.ts"]
       }
    },
    "include": ["src"],

--- a/packages/ui/vite.config.ts
+++ b/packages/ui/vite.config.ts
@@ -7,6 +7,9 @@ export default defineConfig({
   resolve: {
     alias: {
       "@": fileURLToPath(new URL("./src", import.meta.url)),
+      "@ratel-ai/mcp-core/agent-import-workflow": fileURLToPath(
+        new URL("../core/src/agent-import-workflow.ts", import.meta.url),
+      ),
     },
   },
   server: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,6 +81,9 @@ importers:
       '@fontsource-variable/inter-tight':
         specifier: ^5.2.7
         version: 5.2.7
+      '@ratel-ai/mcp-core':
+        specifier: workspace:*
+        version: link:../core
       '@fontsource/jetbrains-mono':
         specifier: ^5.2.8
         version: 5.2.8

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -96,6 +96,9 @@ importers:
       '@tanstack/react-router':
         specifier: ^1.170.9
         version: 1.170.9(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@tanstack/react-virtual':
+        specifier: ^3.14.5
+        version: 3.14.5(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -1536,6 +1539,12 @@ packages:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
+  '@tanstack/react-virtual@3.14.5':
+    resolution: {integrity: sha512-4EKRXh7zBLkbKbFmG3AUVkircuHd+7OdT1pocJSepxtfBd3qnrJgJ5rtPkRYyo9fmyVb2+pI2xPy5oYvMLQy6A==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   '@tanstack/router-core@1.171.7':
     resolution: {integrity: sha512-AboyQD0OPIu0adJi6HeCupTU9Wx7zr4q4ceJYQdBL3mLH18m4M57XXdzJdtzOg/twl8DtWej0RGJ12ma8CV1iQ==}
     engines: {node: '>=20.19'}
@@ -1545,6 +1554,9 @@ packages:
 
   '@tanstack/store@0.9.3':
     resolution: {integrity: sha512-8reSzl/qGWGGVKhBoxXPMWzATSbZLZFWhwBAFO9NAyp0TxzfBP0mIrGb8CP8KrQTmvzXlR/vFPPUrHTLBGyFyw==}
+
+  '@tanstack/virtual-core@3.17.3':
+    resolution: {integrity: sha512-8Np/TFELpI0ySuJoVmjvOrQYXH/8sTX0Biv9szhFhY39xOdAAY+smrMxjxOum/ux3eM8MUJQsEJ0/R0UpvC8dw==}
 
   '@ts-morph/common@0.27.0':
     resolution: {integrity: sha512-Wf29UqxWDpc+i61k3oIOzcUfQt79PIT9y/MWfAGlrkjg6lBC1hwDECLXPVJAhWjiGbfBCxZd65F/LIZF3+jeJQ==}
@@ -4895,6 +4907,12 @@ snapshots:
       react-dom: 19.2.6(react@19.2.6)
       use-sync-external-store: 1.6.0(react@19.2.6)
 
+  '@tanstack/react-virtual@3.14.5(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+    dependencies:
+      '@tanstack/virtual-core': 3.17.3
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+
   '@tanstack/router-core@1.171.7':
     dependencies:
       '@tanstack/history': 1.162.0
@@ -4905,6 +4923,8 @@ snapshots:
   '@tanstack/store@0.11.0': {}
 
   '@tanstack/store@0.9.3': {}
+
+  '@tanstack/virtual-core@3.17.3': {}
 
   '@ts-morph/common@0.27.0':
     dependencies:


### PR DESCRIPTION
## Summary

- Adds one explicit agent import workflow consumed by both the CLI and UI: conditional Link choice, Import commit, optional Claude Code Statusline step, then completion.
- Prompts unlinked source agents before selection with Link and continue, Continue without linking, or Cancel.
- Keeps responsibilities separate: Link installs only the Ratel gateway; Import writes selected entries to Ratel, removes the selected native MCP entries, and marks selected native skills invoke-only.
- Keeps source cleanup repeatable on every import and preserves successful skill imports when another selected skill is invalid.
- Moves agent setup to the top-level `ratel-mcp import` and `ratel-mcp link` commands.

## Reviewer follow-up

- Declining/skipping Link no longer drops selected skill imports.
- Invalid selected skills are reported as warnings without aborting successful config and skill changes.
- Claude Code skill-only imports now reach the standalone, skippable Statusline step.
- The earlier inline threads are outdated after the shared-flow refactor.

## Stack

Base branch: `main` (PR #23 is merged)

Head branch: `dev/unified-mcps-and-skills-import-flow`

## Validation

- Core, CLI app, and UI TypeScript checks
- Biome: 213 files checked
- Vitest: 49 files, 622 tests passed
- UI production build
