### PR TITLE
Handle plugin-based agent linking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this package are documented here. The format is based on 
 ## [Unreleased]
 
 ### Changed
+- Made Claude Code and Codex linking plugin-aware: enabled `ratel-local` plugins now count as host-level Ratel connections in CLI/UI import and link flows, avoiding a second explicit gateway; linking re-enables a disabled Codex plugin MCP server; explicit-plus-plugin duplicates are reported without automatic cleanup.
 - Renamed Ratel MCP to Ratel Local: the repository moved from `ratel-ai/ratel-mcp` to `ratel-ai/ratel-local`, the npm package changed from `@ratel-ai/mcp-server` to `@ratel-ai/ratel-local`, and the CLI changed from `ratel-mcp` to `ratel-local`. This is a breaking package/CLI rename: reinstall the new package and rename `$RATEL_MCP_BIN` to `$RATEL_LOCAL_BIN`. Existing agent gateway entries named `ratel-mcp` remain recognized during import/link migration, while rewritten entries use `ratel-local`.
 
 ## [0.4.0] - 2026-06-30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this package are documented here. The format is based on 
 ## [Unreleased]
 
 ### Changed
+- Made the Ratel Local plugin the preferred link path in both CLI and UI flows so Codex and Claude Code receive the bundled agent skills; when plugin installation fails, linking reports the failure and applies the reviewed, backed-up explicit MCP gateway fallback.
 - Made Claude Code and Codex linking plugin-aware: enabled `ratel-local` plugins now count as host-level Ratel connections in CLI/UI import and link flows, avoiding a second explicit gateway; linking re-enables a disabled Codex plugin MCP server; explicit-plus-plugin duplicates are reported without automatic cleanup.
 - Renamed Ratel MCP to Ratel Local: the repository moved from `ratel-ai/ratel-mcp` to `ratel-ai/ratel-local`, the npm package changed from `@ratel-ai/mcp-server` to `@ratel-ai/ratel-local`, and the CLI changed from `ratel-mcp` to `ratel-local`. This is a breaking package/CLI rename: reinstall the new package and rename `$RATEL_MCP_BIN` to `$RATEL_LOCAL_BIN`. Existing agent gateway entries named `ratel-mcp` remain recognized during import/link migration, while rewritten entries use `ratel-local`.
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Choose the setup that matches where you are starting:
 - **Migrate existing MCP servers:** install the CLI and import the servers already configured in Claude Code or Codex.
 - **Start fresh with the plugin:** let the plugin start Ratel Local, then add upstreams directly to Ratel Local configuration.
 
-Use one path per agent. Installing the plugin and then accepting the import rewrite registers Ratel Local twice.
+The CLI and UI recognize an enabled `ratel-local` plugin as an existing Ratel connection. Importing from a plugin-linked agent moves the selected native MCP entries into Ratel without adding a second explicit gateway, and `link` becomes a no-op. If the Codex plugin is enabled but its bundled Ratel MCP server is disabled, `link` re-enables that server instead of adding an explicit gateway. If both the plugin and an explicit Ratel MCP entry are present, Ratel Local reports the duplicate connection and leaves both installation paths unchanged.
 
 ### Migrate an existing MCP setup
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Choose the setup that matches where you are starting:
 - **Migrate existing MCP servers:** install the CLI and import the servers already configured in Claude Code or Codex.
 - **Start fresh with the plugin:** let the plugin start Ratel Local, then add upstreams directly to Ratel Local configuration.
 
-The CLI and UI recognize an enabled `ratel-local` plugin as an existing Ratel connection. Importing from a plugin-linked agent moves the selected native MCP entries into Ratel without adding a second explicit gateway, and `link` becomes a no-op. If the Codex plugin is enabled but its bundled Ratel MCP server is disabled, `link` re-enables that server instead of adding an explicit gateway. If both the plugin and an explicit Ratel MCP entry are present, Ratel Local reports the duplicate connection and leaves both installation paths unchanged.
+The CLI and UI prefer the `ratel-local` plugin when linking because it bundles the gateway and agent skills. If plugin installation fails, Ratel Local reports the failure and applies the reviewed explicit MCP gateway fallback instead. An enabled plugin is recognized as an existing Ratel connection, so importing does not add a second gateway and `link` becomes a no-op. If the Codex plugin is enabled but its bundled Ratel MCP server is disabled, `link` re-enables that server. If both the plugin and an explicit Ratel MCP entry are present, Ratel Local reports the duplicate connection and leaves both installation paths unchanged.
 
 ### Migrate an existing MCP setup
 
@@ -62,9 +62,9 @@ ratel-local import --agent codex
 
 The CLI and UI use the same import sequence. If the source agent is not linked, the first step offers to link and continue, continue without linking, or cancel. The confirmed import writes selected entries to Ratel, removes those MCP entries from the source agent, and marks selected native skills invoke-only. Skipping the link is useful when importing for another linked agent, but the imported MCPs and skills are no longer directly usable from the unlinked source agent. The wizard preserves MCP scopes and backs up every changed MCP or agent config file. Skill management is reversible: use **Stop managing** in the UI or `ratel-local skill deactivate` to remove Ratel's link and restore its metadata changes.
 
-Claude Code then offers a separate, skippable Ratel statusline step. Linking itself only installs the Ratel gateway entry; install or reinstall the statusline manually with `ratel-local statusline install`.
+Claude Code then offers a separate, skippable Ratel statusline step. Linking installs the agent plugin when possible and otherwise writes the explicit Ratel gateway fallback. Install or reinstall the statusline manually with `ratel-local statusline install`.
 
-If your upstreams are already in Ratel Local configuration, `link` adds Ratel Local to the agent without importing or removing native entries:
+If your upstreams are already in Ratel Local configuration, `link` installs the Ratel plugin without importing or removing native entries. If plugin installation fails, it clearly reports the failure before writing the reviewed MCP fallback:
 
 ```bash
 ratel-local link --agent claude-code

--- a/apps/ratel-local/plugin/.claude-plugin/plugin.json
+++ b/apps/ratel-local/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ratel-local",
   "displayName": "Ratel Local",
-  "version": "0.3.0-rc.0",
+  "version": "0.4.0",
   "description": "Ratel Local gateway plugin for exposing curated upstream MCP tools through search_capabilities and invoke_tool.",
   "author": {
     "name": "Agentified",

--- a/apps/ratel-local/plugin/.codex-plugin/plugin.json
+++ b/apps/ratel-local/plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ratel-local",
-  "version": "0.3.0-rc.0",
+  "version": "0.4.0",
   "description": "Ratel Local gateway plugin for exposing curated upstream MCP tools through search_capabilities and invoke_tool.",
   "author": {
     "name": "Agentified",

--- a/apps/ratel-local/scripts/check-pack.ts
+++ b/apps/ratel-local/scripts/check-pack.ts
@@ -5,6 +5,19 @@ import { fileURLToPath } from "node:url";
 const appRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const dist = resolve(appRoot, "dist");
 
+const packageJson = await readJson(resolve(appRoot, "package.json"));
+for (const manifestPath of [
+  "plugin/.codex-plugin/plugin.json",
+  "plugin/.claude-plugin/plugin.json",
+]) {
+  const manifest = await readJson(resolve(appRoot, manifestPath));
+  if (manifest.version !== packageJson.version) {
+    throw new Error(
+      `${manifestPath} version ${String(manifest.version)} does not match package version ${String(packageJson.version)}`,
+    );
+  }
+}
+
 await mustExist(resolve(dist, "bin.js"));
 await mustExist(resolve(dist, "index.js"));
 await mustExist(resolve(dist, "index.d.ts"));
@@ -34,6 +47,10 @@ async function mustExist(path: string): Promise<void> {
   } catch {
     throw new Error(`Missing required package artifact: ${path}`);
   }
+}
+
+async function readJson(path: string): Promise<{ version?: unknown }> {
+  return JSON.parse(await readFile(path, "utf8")) as { version?: unknown };
 }
 
 async function listFiles(dir: string): Promise<string[]> {

--- a/apps/ratel-local/src/agent-plugin.test.ts
+++ b/apps/ratel-local/src/agent-plugin.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import { type AgentPluginCommandRunner, installRatelAgentPlugin } from "./agent-plugin.js";
+
+describe("installRatelAgentPlugin", () => {
+  it("installs the Codex plugin directly when the Ratel marketplace is already available", async () => {
+    const commands: Array<{ command: string; args: string[] }> = [];
+    const runner: AgentPluginCommandRunner = async (command, args) => {
+      commands.push({ command, args: [...args] });
+      return { exitCode: 0, stdout: '{"installed":true}', stderr: "" };
+    };
+
+    const result = await installRatelAgentPlugin("codex", runner);
+
+    expect(result).toEqual({
+      installed: true,
+      message: "Ratel Local plugin installed for Codex.",
+    });
+    expect(commands).toEqual([
+      {
+        command: "codex",
+        args: ["plugin", "add", "ratel-local@ratel", "--json"],
+      },
+    ]);
+  });
+
+  it("adds the marketplace and retries when direct Claude Code installation fails", async () => {
+    const commands: Array<{ command: string; args: string[] }> = [];
+    const results = [
+      { exitCode: 1, stdout: "", stderr: "marketplace not found" },
+      { exitCode: 0, stdout: "marketplace added", stderr: "" },
+      { exitCode: 0, stdout: "plugin installed", stderr: "" },
+    ];
+    const runner: AgentPluginCommandRunner = async (command, args) => {
+      commands.push({ command, args: [...args] });
+      return results.shift() as (typeof results)[number];
+    };
+
+    const result = await installRatelAgentPlugin("claude-code", runner);
+
+    expect(result.installed).toBe(true);
+    expect(commands).toEqual([
+      {
+        command: "claude",
+        args: ["plugin", "install", "ratel-local@ratel", "--scope", "user"],
+      },
+      {
+        command: "claude",
+        args: ["plugin", "marketplace", "add", "ratel-ai/ratel-local"],
+      },
+      {
+        command: "claude",
+        args: ["plugin", "install", "ratel-local@ratel", "--scope", "user"],
+      },
+    ]);
+  });
+
+  it("returns the installation error so callers can explain an MCP fallback", async () => {
+    const runner: AgentPluginCommandRunner = async () => ({
+      exitCode: 127,
+      stdout: "",
+      stderr: "command not found: codex",
+    });
+
+    const result = await installRatelAgentPlugin("codex", runner);
+
+    expect(result).toEqual({
+      installed: false,
+      message: "codex plugin installation failed: command not found: codex",
+    });
+  });
+});

--- a/apps/ratel-local/src/agent-plugin.ts
+++ b/apps/ratel-local/src/agent-plugin.ts
@@ -1,0 +1,102 @@
+import { spawn } from "node:child_process";
+import type { SupportedAgentHostKind } from "@ratel-ai/ratel-local-core";
+
+export interface AgentPluginCommandResult {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+}
+
+export type AgentPluginCommandRunner = (
+  command: string,
+  args: readonly string[],
+) => Promise<AgentPluginCommandResult>;
+
+export interface AgentPluginInstallResult {
+  installed: boolean;
+  message: string;
+}
+
+export type AgentPluginInstaller = (
+  hostKind: SupportedAgentHostKind,
+) => Promise<AgentPluginInstallResult>;
+
+export const unavailableAgentPluginInstaller: AgentPluginInstaller = async (hostKind) => ({
+  installed: false,
+  message: `${hostKind === "codex" ? "Codex" : "Claude Code"} plugin installer is unavailable in this runtime.`,
+});
+
+export async function attemptRatelAgentPluginInstall(
+  hostKind: SupportedAgentHostKind,
+  installPlugin: AgentPluginInstaller,
+): Promise<AgentPluginInstallResult> {
+  try {
+    return await installPlugin(hostKind);
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    return {
+      installed: false,
+      message: `${hostKind === "codex" ? "Codex" : "Claude Code"} plugin installation failed: ${detail}`,
+    };
+  }
+}
+
+export async function installRatelAgentPlugin(
+  hostKind: SupportedAgentHostKind,
+  runCommand: AgentPluginCommandRunner = runAgentPluginCommand,
+): Promise<AgentPluginInstallResult> {
+  const displayName = hostKind === "codex" ? "Codex" : "Claude Code";
+  const command = hostKind === "codex" ? "codex" : "claude";
+  const installArgs =
+    hostKind === "codex"
+      ? ["plugin", "add", "ratel-local@ratel", "--json"]
+      : ["plugin", "install", "ratel-local@ratel", "--scope", "user"];
+  const installed = await runCommand(command, installArgs);
+  if (installed.exitCode === 0) {
+    return { installed: true, message: `Ratel Local plugin installed for ${displayName}.` };
+  }
+  const marketplaceArgs = ["plugin", "marketplace", "add", "ratel-ai/ratel-local"];
+  if (hostKind === "codex") marketplaceArgs.push("--json");
+  const marketplace = await runCommand(command, marketplaceArgs);
+  if (marketplace.exitCode === 0) {
+    const retried = await runCommand(command, installArgs);
+    if (retried.exitCode === 0) {
+      return { installed: true, message: `Ratel Local plugin installed for ${displayName}.` };
+    }
+    return { installed: false, message: commandFailureMessage(command, retried) };
+  }
+  return {
+    installed: false,
+    message: commandFailureMessage(command, marketplace),
+  };
+}
+
+export function runAgentPluginCommand(
+  command: string,
+  args: readonly string[],
+): Promise<AgentPluginCommandResult> {
+  return new Promise((resolve) => {
+    const child = spawn(command, [...args], { stdio: ["ignore", "pipe", "pipe"] });
+    let stdout = "";
+    let stderr = "";
+    child.stdout?.setEncoding("utf8");
+    child.stderr?.setEncoding("utf8");
+    child.stdout?.on("data", (chunk: string) => {
+      stdout += chunk;
+    });
+    child.stderr?.on("data", (chunk: string) => {
+      stderr += chunk;
+    });
+    child.once("error", (error) => {
+      resolve({ exitCode: -1, stdout, stderr: error.message });
+    });
+    child.once("close", (code) => {
+      resolve({ exitCode: code ?? -1, stdout, stderr });
+    });
+  });
+}
+
+function commandFailureMessage(command: string, result: AgentPluginCommandResult): string {
+  const detail = result.stderr.trim() || result.stdout.trim() || `exit code ${result.exitCode}`;
+  return `${command} plugin installation failed: ${detail}`;
+}

--- a/apps/ratel-local/src/cli/cli.ts
+++ b/apps/ratel-local/src/cli/cli.ts
@@ -12,6 +12,7 @@ import {
   type SupportedAgentHostKind,
   type TransportFactory,
 } from "@ratel-ai/ratel-local-core";
+import { type AgentPluginInstaller, installRatelAgentPlugin } from "../agent-plugin.js";
 import { ArgError, type ParsedArgs, parseArgs } from "./args.js";
 import { BACKUP_USAGE, runBackup } from "./handlers/backup.js";
 import { IMPORT_USAGE, runImport } from "./handlers/import.js";
@@ -36,6 +37,7 @@ export interface RunCliOptions {
   env?: HierarchyEnv;
   now?: () => Date;
   cliVersion?: string;
+  installAgentPlugin?: AgentPluginInstaller;
   stdin?: () => Promise<string>;
   stdout?: (message: string) => void;
 }
@@ -50,7 +52,7 @@ Commands:
   serve    start the gateway over stdio (use --config <path>; repeat for multi-file merge,
            or --auto-config to load user/project/local Ratel configs)
   import   migrate agent MCP configs and native skills into Ratel
-  link     point an agent at Ratel while preserving native MCP entries
+  link     install the agent plugin, falling back to MCP config when needed
   mcp      manage MCP servers (add, remove, list, get, edit, auth)
   backup   manage backup snapshots (list)
   skill    manage Claude Code/Codex skills through Ratel (activate, deactivate, list)
@@ -116,6 +118,7 @@ export async function runCli(argv: string[], options: RunCliOptions = {}): Promi
     fs: options.fs ?? nodeFs,
     log,
     prompts: options.prompts ?? silentPromptAdapter(),
+    installAgentPlugin: options.installAgentPlugin ?? installRatelAgentPlugin,
     stdin: options.stdin,
     stdout: options.stdout,
   };

--- a/apps/ratel-local/src/cli/handlers/import.test.ts
+++ b/apps/ratel-local/src/cli/handlers/import.test.ts
@@ -236,6 +236,83 @@ describe("runImport", () => {
     });
   });
 
+  it("imports through an enabled Claude plugin without writing an explicit gateway", async () => {
+    const fs = new MemFs();
+    fs.files.set(
+      HOME_CLAUDE,
+      JSON.stringify({ mcpServers: { fs: { type: "stdio", command: "echo" } } }),
+    );
+    fs.files.set(
+      CLAUDE_SETTINGS,
+      JSON.stringify({ enabledPlugins: { "ratel-local@ratel": true } }),
+    );
+    const { ctx } = ctxOf(fs, autoConfirm(), false);
+
+    await runImport(ctx, { bin: BIN, yes: true, agentKind: "claude-code" });
+
+    expect(JSON.parse(fs.files.get(RATEL_USER) as string).mcpServers.fs.command).toBe("echo");
+    const claude = JSON.parse(fs.files.get(HOME_CLAUDE) as string);
+    expect(claude.mcpServers.fs).toBeUndefined();
+    expect(claude.mcpServers["ratel-local"]).toBeUndefined();
+  });
+
+  it("imports through an enabled Codex plugin without writing an explicit gateway", async () => {
+    const fs = new MemFs();
+    fs.files.set(
+      HOME_CODEX,
+      `[plugins."ratel-local@ratel"]
+enabled = true
+
+[mcp_servers.fs]
+command = "echo"
+`,
+    );
+    const { ctx } = ctxOf(fs, autoConfirm(), false);
+
+    await runImport(ctx, { bin: BIN, yes: true, agentKind: "codex" });
+
+    expect(JSON.parse(fs.files.get(RATEL_USER) as string).mcpServers.fs.command).toBe("echo");
+    const codex = fs.files.get(HOME_CODEX) as string;
+    expect(codex).toContain(`[plugins."ratel-local@ratel"]`);
+    expect(codex).not.toContain("[mcp_servers.fs]");
+    expect(codex).not.toContain("[mcp_servers.ratel-local]");
+  });
+
+  it("reports duplicate plugin and explicit connections during import", async () => {
+    const fs = new MemFs();
+    fs.files.set(
+      HOME_CLAUDE,
+      JSON.stringify({
+        mcpServers: {
+          "ratel-local": { type: "stdio", command: "ratel-local" },
+        },
+      }),
+    );
+    fs.files.set(
+      CLAUDE_SETTINGS,
+      JSON.stringify({ enabledPlugins: { "ratel-local@ratel": true } }),
+    );
+    const notes: Array<{ message: string; title: string | undefined }> = [];
+    const { ctx } = ctxOf(
+      fs,
+      {
+        ...autoConfirm(),
+        note: (message, title) => notes.push({ message, title }),
+      },
+      false,
+    );
+
+    await runImport(ctx, { bin: BIN, yes: true, agentKind: "claude-code" });
+
+    expect(notes).toContainEqual(
+      expect.objectContaining({
+        title: "Duplicate Ratel connections",
+        message: expect.stringMatching(/duplicate Ratel connections/i),
+      }),
+    );
+    expect(notes.at(-1)?.message).toMatch(/No native Claude Code MCP servers/i);
+  });
+
   it("shows the detected agent and MCP source paths before selection", async () => {
     const fs = new MemFs();
     fs.files.set(

--- a/apps/ratel-local/src/cli/handlers/import.ts
+++ b/apps/ratel-local/src/cli/handlers/import.ts
@@ -10,12 +10,14 @@ import {
   conflictKey,
   executePlan,
   type FileChange,
+  getAgentHostRatelConnection,
   getClaudeCodeStatuslineState,
   type ImportConflict,
   type ImportConflictStrategy,
   type ImportPlan,
   isRatelGatewayEntry,
   NamedAgentHostAdapter,
+  pluginLinkNoOpMessage,
   probeEntryInstructions,
   type ResolvedBin,
   ratelConfigPath,
@@ -115,26 +117,36 @@ export async function runImport(
     source: resolveSkillSource(opts.agentKind, agentState),
     now: opts.now,
   });
+  const workflowHostKind = resolveWorkflowHostKind(opts.agentKind, agentState);
+  const connection =
+    workflowHostKind && agentState
+      ? await getAgentHostRatelConnection(workflowHostKind, agentState, ctx)
+      : null;
+  if (agentState && connection?.kind === "duplicate") {
+    ctx.prompts.note(
+      pluginLinkNoOpMessage(agentState.host.displayName, connection),
+      "Duplicate Ratel connections",
+    );
+  }
 
   if (!detection.present && skillPreview.candidates.length === 0) {
     ctx.prompts.note(
-      "No supported agent MCP servers or native skills found at any scope. Nothing to import.",
+      "No supported agent native MCP servers or native skills found at any scope. Nothing to import.",
     );
     ctx.prompts.outro("done");
     return null;
   }
   if (agentState && candidates.length === 0 && skillPreview.candidates.length === 0) {
     ctx.prompts.note(
-      `No ${agentState.host.displayName} MCP servers or native skills found at any scope. Nothing to import.`,
+      `No native ${agentState.host.displayName} MCP servers or native skills found at any scope. Nothing to import.`,
     );
     ctx.prompts.outro("done");
     return null;
   }
 
-  const workflowHostKind = resolveWorkflowHostKind(opts.agentKind, agentState);
   let linkCommitted = false;
   let workflow = workflowHostKind
-    ? await beginCliImportWorkflow(ctx, workflowHostKind, agentState)
+    ? await beginCliImportWorkflow(ctx, workflowHostKind, connection?.linked ?? true)
     : null;
   if (workflow?.step === "link") {
     const decision = opts.yes
@@ -307,9 +319,8 @@ export async function runImport(
 async function beginCliImportWorkflow(
   ctx: HandlerCtx,
   hostKind: SupportedAgentHostKind,
-  agentState: AgentHostState | null,
+  linked: boolean,
 ): Promise<AgentImportWorkflowState> {
-  const linked = agentState ? isAgentStateLinked(agentState) : true;
   const statuslineInstalled =
     hostKind === "claude-code"
       ? (await getClaudeCodeStatuslineState(ctx)).status === "installed"
@@ -325,12 +336,6 @@ function resolveWorkflowHostKind(
   return state?.host.kind === "claude-code" || state?.host.kind === "codex"
     ? state.host.kind
     : null;
-}
-
-function isAgentStateLinked(state: AgentHostState): boolean {
-  return state.scopes.some((scope) =>
-    Object.entries(scope.mcpServers).some(([name, entry]) => isRatelGatewayEntry(name, entry)),
-  );
 }
 
 async function selectUnlinkedAgentAction(

--- a/apps/ratel-local/src/cli/handlers/link.test.ts
+++ b/apps/ratel-local/src/cli/handlers/link.test.ts
@@ -61,6 +61,10 @@ function ctxOf(
       fs,
       log: (m) => logs.push(m),
       prompts,
+      installAgentPlugin: async () => ({
+        installed: false,
+        message: "test plugin installation failed",
+      }),
     },
   };
 }
@@ -75,6 +79,98 @@ function autoConfirm(): PromptAdapter {
 }
 
 describe("runLink", () => {
+  it("prefers installing the agent plugin and leaves MCP config unchanged on success", async () => {
+    const fs = new MemFs();
+    const claudeBefore = JSON.stringify({ mcpServers: { fs: { type: "stdio", command: "echo" } } });
+    fs.files.set(HOME_CLAUDE, claudeBefore);
+    const messages: string[] = [];
+    const prompts: PromptAdapter = {
+      ...autoConfirm(),
+      note(message) {
+        messages.push(message);
+      },
+      outro(message) {
+        messages.push(message);
+      },
+    };
+    const { ctx } = ctxOf(fs, prompts, false);
+
+    const manifest = await runLink(ctx, {
+      bin: BIN,
+      yes: true,
+      agentKind: "claude-code",
+      installPlugin: async () => ({
+        installed: true,
+        message: "Ratel Local plugin installed for Claude Code.",
+      }),
+    });
+
+    expect(manifest).toBeNull();
+    expect(fs.files.get(HOME_CLAUDE)).toBe(claudeBefore);
+    expect(messages.join("\n")).toMatch(/plugin installed/i);
+    expect(messages.join("\n")).toMatch(/reload|restart/i);
+  });
+
+  it("explains the plugin failure before applying the MCP fallback", async () => {
+    const fs = new MemFs();
+    fs.files.set(HOME_CODEX, '[mcp_servers.fs]\ncommand = "echo"\n');
+    const messages: string[] = [];
+    const prompts: PromptAdapter = {
+      ...autoConfirm(),
+      note(message) {
+        messages.push(message);
+      },
+      outro(message) {
+        messages.push(message);
+      },
+    };
+    const { ctx } = ctxOf(fs, prompts, false);
+
+    const manifest = await runLink(ctx, {
+      bin: BIN,
+      yes: true,
+      agentKind: "codex",
+      installPlugin: async () => ({
+        installed: false,
+        message: "codex plugin installation failed: marketplace unavailable",
+      }),
+    });
+
+    expect(manifest).not.toBeNull();
+    expect(fs.files.get(HOME_CODEX)).toContain("[mcp_servers.ratel-local]");
+    expect(messages.join("\n")).toMatch(/plugin installation failed/i);
+    expect(messages.join("\n")).toMatch(/explicit MCP gateway/i);
+    expect(messages.join("\n")).toMatch(/MCP fallback link complete/i);
+  });
+
+  it("falls back to MCP config when the plugin installer throws unexpectedly", async () => {
+    const fs = new MemFs();
+    fs.files.set(HOME_CLAUDE, JSON.stringify({ mcpServers: {} }));
+    const messages: string[] = [];
+    const prompts: PromptAdapter = {
+      ...autoConfirm(),
+      note(message) {
+        messages.push(message);
+      },
+    };
+    const { ctx } = ctxOf(fs, prompts, false);
+
+    const manifest = await runLink(ctx, {
+      bin: BIN,
+      yes: true,
+      agentKind: "claude-code",
+      installPlugin: async () => {
+        throw new Error("unexpected installer crash");
+      },
+    });
+
+    expect(manifest).not.toBeNull();
+    const claude = JSON.parse(fs.files.get(HOME_CLAUDE) as string);
+    expect(claude.mcpServers["ratel-local"]).toBeDefined();
+    expect(messages.join("\n")).toMatch(/unexpected installer crash/i);
+    expect(messages.join("\n")).toMatch(/falling back/i);
+  });
+
   it("does nothing when Claude is already linked through the plugin", async () => {
     const fs = new MemFs();
     fs.files.set(

--- a/apps/ratel-local/src/cli/handlers/link.test.ts
+++ b/apps/ratel-local/src/cli/handlers/link.test.ts
@@ -9,6 +9,7 @@ const ROOT = "/r";
 const BIN: ResolvedBin = { command: "ratel-local", args: [], source: "path" };
 
 const HOME_CLAUDE = "/home/u/.claude.json";
+const CLAUDE_SETTINGS = "/home/u/.claude/settings.json";
 const HOME_CODEX = "/home/u/.codex/config.toml";
 const PROJECT_MCP = "/r/.mcp.json";
 const RATEL_USER = "/home/u/.ratel/config.json";
@@ -74,6 +75,51 @@ function autoConfirm(): PromptAdapter {
 }
 
 describe("runLink", () => {
+  it("does nothing when Claude is already linked through the plugin", async () => {
+    const fs = new MemFs();
+    fs.files.set(
+      CLAUDE_SETTINGS,
+      JSON.stringify({ enabledPlugins: { "ratel-local@ratel": true } }),
+    );
+    const messages: string[] = [];
+    const prompts: PromptAdapter = {
+      ...silentPromptAdapter(),
+      outro(message) {
+        messages.push(message);
+      },
+    };
+    const { ctx } = ctxOf(fs, prompts, false);
+
+    const manifest = await runLink(ctx, { yes: true, agentKind: "claude-code" });
+
+    expect(manifest).toBeNull();
+    expect(fs.files.has(HOME_CLAUDE)).toBe(false);
+    expect(messages.join("\n")).toMatch(/linked through the Ratel Local plugin/i);
+  });
+
+  it("re-enables a disabled Codex plugin MCP instead of adding an explicit gateway", async () => {
+    const fs = new MemFs();
+    fs.files.set(
+      HOME_CODEX,
+      `[plugins."ratel-local@ratel"]
+enabled = true
+
+[plugins."ratel-local@ratel".mcp_servers.ratel-local]
+enabled = false
+`,
+    );
+    const { ctx } = ctxOf(fs, autoConfirm(), false);
+
+    const manifest = await runLink(ctx, { yes: true, agentKind: "codex" });
+
+    expect(manifest).not.toBeNull();
+    const codex = fs.files.get(HOME_CODEX) as string;
+    expect(codex).toContain(
+      `[plugins."ratel-local@ratel".mcp_servers.ratel-local]\nenabled = true`,
+    );
+    expect(codex).not.toContain("[mcp_servers.ratel-local]");
+  });
+
   it("writes the Ratel gateway without removing Claude native entries", async () => {
     const fs = new MemFs();
     fs.files.set(

--- a/apps/ratel-local/src/cli/handlers/link.ts
+++ b/apps/ratel-local/src/cli/handlers/link.ts
@@ -1,10 +1,14 @@
 import type { BackupManifest, RatelConfig } from "@ratel-ai/ratel-local-core";
 import {
   AutomaticAgentHostAdapter,
+  buildAgentHostRatelPluginLinkChanges,
   buildAgentLinkPlan,
-  type buildImportPlan,
   executePlan,
+  findAgentHostRatelPluginConnection,
+  getAgentHostRatelConnection,
+  type ImportPlan,
   NamedAgentHostAdapter,
+  pluginLinkNoOpMessage,
   type ResolvedBin,
   ratelConfigPath,
   readJson,
@@ -42,49 +46,75 @@ export async function runLink(
     : new AutomaticAgentHostAdapter();
   const detection = await agentHost.detect({ env: ctx.env, fs: ctx.fs });
   if (!detection.present) {
+    const pluginHost = await findAgentHostRatelPluginConnection(ctx, opts.agentKind);
+    if (pluginHost) {
+      ctx.prompts.outro(
+        pluginLinkNoOpMessage(pluginHost.state.host.displayName, pluginHost.connection),
+      );
+      return null;
+    }
     ctx.prompts.note("No supported agent config found. Nothing to link.");
     ctx.prompts.outro("done");
     return null;
   }
   const agentState = await agentHost.read({ env: ctx.env, fs: ctx.fs });
+  const hostKind = resolveHostKind(opts.agentKind, agentState.host.kind);
+  const connection = await getAgentHostRatelConnection(hostKind, agentState, ctx);
+  if (connection.plugin) {
+    ctx.prompts.outro(pluginLinkNoOpMessage(agentState.host.displayName, connection));
+    return null;
+  }
 
-  const ratelUserPath = ratelConfigPath("user", ctx.env);
-  const ratelProjectPath = ctx.env.projectRoot ? ratelConfigPath("project", ctx.env) : undefined;
-  const ratelLocalPath = ctx.env.projectRoot ? ratelConfigPath("local", ctx.env) : undefined;
+  const pluginChanges = buildAgentHostRatelPluginLinkChanges(hostKind, agentState, connection);
+  const enablingPlugin = pluginChanges.length > 0;
 
-  const ratelUser = await readJson<RatelConfig>(ctx.fs, ratelUserPath);
-  const ratelProject = ratelProjectPath
-    ? await readJson<RatelConfig>(ctx.fs, ratelProjectPath)
-    : null;
-  const ratelLocal = ratelLocalPath ? await readJson<RatelConfig>(ctx.fs, ratelLocalPath) : null;
+  let plan: Pick<ImportPlan, "agentChanges">;
+  if (enablingPlugin) {
+    plan = { agentChanges: pluginChanges };
+  } else {
+    const ratelUserPath = ratelConfigPath("user", ctx.env);
+    const ratelProjectPath = ctx.env.projectRoot ? ratelConfigPath("project", ctx.env) : undefined;
+    const ratelLocalPath = ctx.env.projectRoot ? ratelConfigPath("local", ctx.env) : undefined;
 
-  const bin = opts.bin ?? (await resolveBin(ctx, opts));
+    const ratelUser = await readJson<RatelConfig>(ctx.fs, ratelUserPath);
+    const ratelProject = ratelProjectPath
+      ? await readJson<RatelConfig>(ctx.fs, ratelProjectPath)
+      : null;
+    const ratelLocal = ratelLocalPath ? await readJson<RatelConfig>(ctx.fs, ratelLocalPath) : null;
 
-  const plan = await buildAgentLinkPlan({
-    agentHost,
-    agentState,
-    ratelUser,
-    ratelProject,
-    ratelLocal,
-    bin,
-    ratelUserPath,
-    ratelProjectPath,
-    ratelLocalPath,
-    projectRoot: ctx.env.projectRoot,
-  });
+    const bin = opts.bin ?? (await resolveBin(ctx, opts));
+
+    plan = await buildAgentLinkPlan({
+      agentHost,
+      agentState,
+      ratelUser,
+      ratelProject,
+      ratelLocal,
+      bin,
+      ratelUserPath,
+      ratelProjectPath,
+      ratelLocalPath,
+      projectRoot: ctx.env.projectRoot,
+    });
+  }
 
   if (plan.agentChanges.length === 0) {
     ctx.prompts.outro(`nothing to do (${agentState.host.displayName} already points at Ratel)`);
     return null;
   }
 
-  ctx.prompts.note(renderAgentStage(plan), `${agentState.host.displayName} rewrites`);
+  ctx.prompts.note(
+    renderAgentStage(plan, enablingPlugin),
+    `${agentState.host.displayName} rewrites`,
+  );
 
   if (!opts.yes) {
     const ok = await ctx.prompts.confirm({
-      message: `Write the ratel-local gateway into ${plan.agentChanges.length} ${
-        agentState.host.displayName
-      } config file${plan.agentChanges.length === 1 ? "" : "s"}?`,
+      message: enablingPlugin
+        ? `Re-enable the Ratel Local plugin MCP server in ${agentState.host.displayName}?`
+        : `Write the ratel-local gateway into ${plan.agentChanges.length} ${
+            agentState.host.displayName
+          } config file${plan.agentChanges.length === 1 ? "" : "s"}?`,
       initialValue: true,
     });
     if (ctx.prompts.isCancel(ok) || ok === false) {
@@ -105,6 +135,15 @@ export async function runLink(
   return manifest;
 }
 
+function resolveHostKind(
+  requested: SupportedAgentHostKind | undefined,
+  detected: string,
+): SupportedAgentHostKind {
+  if (requested) return requested;
+  if (detected === "claude-code" || detected === "codex") return detected;
+  throw new Error(`Unsupported agent host ${JSON.stringify(detected)}`);
+}
+
 async function resolveBin(ctx: HandlerCtx, opts: LinkOptions): Promise<ResolvedBin> {
   return resolveCliRatelBin(ctx, {
     envVar: opts.envVar ?? process.env.RATEL_LOCAL_BIN,
@@ -114,13 +153,15 @@ async function resolveBin(ctx: HandlerCtx, opts: LinkOptions): Promise<ResolvedB
   });
 }
 
-function renderAgentStage(plan: ReturnType<typeof buildImportPlan>): string {
+function renderAgentStage(plan: Pick<ImportPlan, "agentChanges">, enablingPlugin: boolean): string {
   const lines = plan.agentChanges.map(
     (c) => `write ${c.path}${c.before === null ? " (new file)" : ""}`,
   );
   lines.push("");
   lines.push(
-    "The ratel-local gateway entry will be written for the available Ratel scopes. Native agent MCP entries are preserved.",
+    enablingPlugin
+      ? "The disabled Ratel Local plugin MCP server will be re-enabled. No explicit gateway will be added."
+      : "The ratel-local gateway entry will be written for the available Ratel scopes. Native agent MCP entries are preserved.",
   );
   return lines.join("\n");
 }

--- a/apps/ratel-local/src/cli/handlers/link.ts
+++ b/apps/ratel-local/src/cli/handlers/link.ts
@@ -14,6 +14,11 @@ import {
   readJson,
   type SupportedAgentHostKind,
 } from "@ratel-ai/ratel-local-core";
+import {
+  type AgentPluginInstaller,
+  attemptRatelAgentPluginInstall,
+  unavailableAgentPluginInstaller,
+} from "../../agent-plugin.js";
 import { resolveCliRatelBin } from "../ratel-bin.js";
 import type { HandlerCtx } from "./types.js";
 
@@ -24,6 +29,7 @@ export interface LinkOptions {
   whichResult?: string;
   workspaceRoot?: string;
   agentKind?: SupportedAgentHostKind;
+  installPlugin?: AgentPluginInstaller;
   exists?: (path: string) => Promise<boolean>;
 }
 
@@ -112,15 +118,32 @@ export async function runLink(
     const ok = await ctx.prompts.confirm({
       message: enablingPlugin
         ? `Re-enable the Ratel Local plugin MCP server in ${agentState.host.displayName}?`
-        : `Write the ratel-local gateway into ${plan.agentChanges.length} ${
-            agentState.host.displayName
-          } config file${plan.agentChanges.length === 1 ? "" : "s"}?`,
+        : `Install the Ratel Local plugin for ${agentState.host.displayName}? If plugin installation fails, Ratel will write the reviewed MCP gateway fallback.`,
       initialValue: true,
     });
     if (ctx.prompts.isCancel(ok) || ok === false) {
       ctx.prompts.cancel("link cancelled");
       return null;
     }
+  }
+
+  let usedMcpFallback = false;
+  if (!enablingPlugin) {
+    const installPlugin =
+      opts.installPlugin ?? ctx.installAgentPlugin ?? unavailableAgentPluginInstaller;
+    const pluginResult = await attemptRatelAgentPluginInstall(hostKind, installPlugin);
+    if (pluginResult.installed) {
+      ctx.prompts.note(pluginResult.message, "Plugin installed");
+      ctx.prompts.outro(
+        `plugin link complete · reload or restart ${agentState.host.displayName} to load Ratel Local`,
+      );
+      return null;
+    }
+    usedMcpFallback = true;
+    ctx.prompts.note(
+      `${pluginResult.message}\nFalling back to the reviewed explicit MCP gateway configuration.`,
+      "Plugin installation failed",
+    );
   }
 
   const manifest = await executePlan(plan.agentChanges, {
@@ -130,7 +153,9 @@ export async function runLink(
   });
   ctx.prompts.note(`Backup created. Run \`ratel-local backup list\` to inspect backups.`, "Done");
   ctx.prompts.outro(
-    `link complete · restart ${agentState.host.displayName} to pick up the new MCP entry`,
+    usedMcpFallback
+      ? `MCP fallback link complete · restart ${agentState.host.displayName} to pick up the new MCP entry`
+      : `link complete · restart ${agentState.host.displayName} to pick up the new MCP entry`,
   );
   return manifest;
 }
@@ -161,7 +186,7 @@ function renderAgentStage(plan: Pick<ImportPlan, "agentChanges">, enablingPlugin
   lines.push(
     enablingPlugin
       ? "The disabled Ratel Local plugin MCP server will be re-enabled. No explicit gateway will be added."
-      : "The ratel-local gateway entry will be written for the available Ratel scopes. Native agent MCP entries are preserved.",
+      : "Ratel will install the agent plugin first. If installation fails, the ratel-local gateway changes above will be written as an explicit MCP fallback. Native agent MCP entries are preserved.",
   );
   return lines.join("\n");
 }

--- a/apps/ratel-local/src/cli/handlers/types.ts
+++ b/apps/ratel-local/src/cli/handlers/types.ts
@@ -1,4 +1,5 @@
 import type { BackupFs, HierarchyEnv, JsonFs } from "@ratel-ai/ratel-local-core";
+import type { AgentPluginInstaller } from "../../agent-plugin.js";
 import type { ParsedArgs } from "../args.js";
 import type { PromptAdapter } from "../prompts.js";
 
@@ -8,6 +9,7 @@ export interface HandlerCtx {
   fs: JsonFs & BackupFs;
   log: (message: string) => void;
   prompts: PromptAdapter;
+  installAgentPlugin?: AgentPluginInstaller;
   stdin?: () => Promise<string>;
   stdout?: (message: string) => void;
 }

--- a/apps/ratel-local/src/ui/routes.ts
+++ b/apps/ratel-local/src/ui/routes.ts
@@ -23,6 +23,7 @@ import {
   previewAgentImport,
   previewAgentLink,
   type ResolvedBin,
+  removeAgentRatelMcpFallback,
   removeServerEntry,
   type ServerEntry,
   type SupportedAgentHostKind,
@@ -641,6 +642,46 @@ export async function applyLink(
   const { result, log } = await withCapture(ctx, (c) => applyAgentLink(c, input, interop));
   if (!result) log.push("nothing to apply");
   return ok({ mode: "config", log });
+}
+
+export async function repairAgentConnection(
+  ctx: HandlerCtx,
+  body: Record<string, unknown>,
+): Promise<ApiResponse> {
+  const hostKind = requiredHostKind(body.hostKind);
+  const hosts = await getAgentHostsState(ctx);
+  const host = hosts.hosts.find((candidate) => candidate.kind === hostKind);
+  if (!host) throw new Error("Agent configuration is unavailable. Scan again and retry.");
+
+  if (host.connection.kind !== "duplicate" && host.connection.kind !== "explicit") {
+    throw new Error(
+      host.connection.kind === "plugin"
+        ? `${host.displayName} is already connected through the Ratel plugin.`
+        : `${host.displayName} does not have a Ratel connection to upgrade or repair.`,
+    );
+  }
+
+  const log: string[] = [];
+  if (host.connection.kind === "explicit") {
+    const installPlugin = ctx.installAgentPlugin ?? unavailableAgentPluginInstaller;
+    const pluginResult = await attemptRatelAgentPluginInstall(hostKind, installPlugin);
+    log.push(pluginResult.message);
+    if (!pluginResult.installed) {
+      throw new Error(`${pluginResult.message}\nYour existing MCP connection was left unchanged.`);
+    }
+  }
+
+  const captured = await withCapture(ctx, (c) =>
+    removeAgentRatelMcpFallback(c, { hostKind }, { envVar: resolveRatelBin() }),
+  );
+  log.push(...captured.log);
+  if (!captured.result) throw new Error("No explicit Ratel MCP fallback was found to remove.");
+  log.push(
+    host.connection.kind === "duplicate"
+      ? "Duplicate installation fixed. Ratel is now connected through the plugin."
+      : "Upgrade complete. Ratel is now connected through the plugin.",
+  );
+  return ok({ mode: host.connection.kind === "duplicate" ? "repaired" : "promoted", log });
 }
 
 export async function installClaudeStatuslineRoute(

--- a/apps/ratel-local/src/ui/routes.ts
+++ b/apps/ratel-local/src/ui/routes.ts
@@ -18,7 +18,6 @@ import {
   importAgentServers,
   installClaudeCodeStatusline,
   isDirectoryEntry,
-  linkAgentToRatel,
   loadSkills,
   parseSkillMd,
   previewAgentImport,
@@ -29,6 +28,11 @@ import {
   type SupportedAgentHostKind,
   uninstallClaudeCodeStatusline,
 } from "@ratel-ai/ratel-local-core";
+import {
+  attemptRatelAgentPluginInstall,
+  unavailableAgentPluginInstaller,
+} from "../agent-plugin.js";
+import { runLink } from "../cli/handlers/link.js";
 import type { HandlerCtx } from "../cli/handlers/types.js";
 import {
   activateSkills,
@@ -542,9 +546,25 @@ export async function doImport(ctx: HandlerCtx): Promise<ApiResponse> {
 }
 
 export async function doLink(ctx: HandlerCtx): Promise<ApiResponse> {
-  const { log } = await withCapture(ctx, (c) =>
-    linkAgentToRatel(c, { envVar: resolveRatelBin() }).then(() => undefined),
-  );
+  const log: string[] = [];
+  const captureCtx: HandlerCtx = {
+    ...ctx,
+    log: (message) => log.push(message),
+    prompts: {
+      ...ctx.prompts,
+      intro() {},
+      note(message, title) {
+        log.push(title ? `${title}: ${message}` : message);
+      },
+      outro(message) {
+        log.push(message);
+      },
+      cancel(message) {
+        if (message) log.push(message);
+      },
+    },
+  };
+  await runLink(captureCtx, { yes: true, envVar: resolveRatelBin() });
   return ok({ log });
 }
 
@@ -590,11 +610,37 @@ export async function applyLink(
   ctx: HandlerCtx,
   body: Record<string, unknown>,
 ): Promise<ApiResponse> {
-  const { result, log } = await withCapture(ctx, (c) =>
-    applyAgentLink(c, normalizeApplyLinkBody(body), { envVar: resolveRatelBin() }),
-  );
+  const input = normalizeApplyLinkBody(body);
+  const interop = { envVar: resolveRatelBin() };
+  const preview = await previewAgentLink(ctx, input, interop);
+  if (input.planHash !== preview.stageHashes.agent) {
+    throw new Error("preview is stale; scan again and review the latest changes before applying");
+  }
+  const shouldInstallPlugin =
+    preview.host.connection.kind === "none" && preview.plan.agentChanges.length > 0;
+  if (shouldInstallPlugin) {
+    const installPlugin = ctx.installAgentPlugin ?? unavailableAgentPluginInstaller;
+    const pluginResult = await attemptRatelAgentPluginInstall(input.hostKind, installPlugin);
+    if (pluginResult.installed) {
+      return ok({
+        mode: "plugin",
+        log: [
+          pluginResult.message,
+          `Reload or restart ${preview.host.displayName} to load the plugin.`,
+        ],
+      });
+    }
+    const { result, log } = await withCapture(ctx, (c) => applyAgentLink(c, input, interop));
+    log.unshift(
+      pluginResult.message,
+      "Plugin installation failed; applied the reviewed explicit MCP gateway fallback instead.",
+    );
+    if (!result) log.push("nothing to apply");
+    return ok({ mode: "mcp-fallback", log });
+  }
+  const { result, log } = await withCapture(ctx, (c) => applyAgentLink(c, input, interop));
   if (!result) log.push("nothing to apply");
-  return ok({ log });
+  return ok({ mode: "config", log });
 }
 
 export async function installClaudeStatuslineRoute(

--- a/apps/ratel-local/src/ui/server.test.ts
+++ b/apps/ratel-local/src/ui/server.test.ts
@@ -21,6 +21,7 @@ const PROJECT_PATH = "/r/.ratel/config.json";
 const LOCAL_PATH = "/r/.ratel/config.local.json";
 const CLAUDE_PATH = "/home/u/.claude.json";
 const CLAUDE_SETTINGS_PATH = "/home/u/.claude/settings.json";
+const CODEX_PATH = "/home/u/.codex/config.toml";
 
 class MemFs implements BackupFs, JsonFs {
   files = new Map<string, string>();
@@ -346,6 +347,73 @@ describe("UI server — agent previews", () => {
     expect(body.hosts.find((host) => host.kind === "claude-code")?.statusline?.ratelEnabled).toBe(
       true,
     );
+  });
+
+  it("surfaces Claude plugin linkage through host and import preview responses", async () => {
+    session.fs.files.set(
+      CLAUDE_PATH,
+      JSON.stringify({ mcpServers: { fs: { type: "stdio", command: "echo" } } }),
+    );
+    session.fs.files.set(
+      CLAUDE_SETTINGS_PATH,
+      JSON.stringify({ enabledPlugins: { "ratel-local@ratel": true } }),
+    );
+
+    const hostsRes = await fetch(apiUrl("/api/agent-hosts"), { headers: authHeaders() });
+    const hostsBody = (await hostsRes.json()) as {
+      hosts: Array<{ kind: string; connection: { kind: string; linked: boolean } }>;
+    };
+    expect(hostsBody.hosts.find((host) => host.kind === "claude-code")?.connection).toEqual(
+      expect.objectContaining({ kind: "plugin", linked: true }),
+    );
+
+    const previewRes = await fetch(apiUrl("/api/agent-preview/import"), {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify({ hostKind: "claude-code" }),
+    });
+    const preview = (await previewRes.json()) as {
+      host: { connection: { kind: string; linked: boolean } };
+      plan: { agentChanges: unknown[] };
+    };
+    expect(preview.host.connection).toEqual(
+      expect.objectContaining({ kind: "plugin", linked: true }),
+    );
+    expect(preview.plan.agentChanges).toHaveLength(1);
+  });
+
+  it("surfaces Codex plugin linkage through host and import preview responses", async () => {
+    session.fs.files.set(
+      CODEX_PATH,
+      `[plugins."ratel-local@ratel"]
+enabled = true
+
+[mcp_servers.fs]
+command = "echo"
+`,
+    );
+
+    const hostsRes = await fetch(apiUrl("/api/agent-hosts"), { headers: authHeaders() });
+    const hostsBody = (await hostsRes.json()) as {
+      hosts: Array<{ kind: string; connection: { kind: string; linked: boolean } }>;
+    };
+    expect(hostsBody.hosts.find((host) => host.kind === "codex")?.connection).toEqual(
+      expect.objectContaining({ kind: "plugin", linked: true }),
+    );
+
+    const previewRes = await fetch(apiUrl("/api/agent-preview/import"), {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify({ hostKind: "codex" }),
+    });
+    const preview = (await previewRes.json()) as {
+      host: { connection: { kind: string; linked: boolean } };
+      plan: { agentChanges: unknown[] };
+    };
+    expect(preview.host.connection).toEqual(
+      expect.objectContaining({ kind: "plugin", linked: true }),
+    );
+    expect(preview.plan.agentChanges).toHaveLength(1);
   });
 
   it("previews import without writing files", async () => {

--- a/apps/ratel-local/src/ui/server.test.ts
+++ b/apps/ratel-local/src/ui/server.test.ts
@@ -62,6 +62,10 @@ function makeCtx(fs: MemFs, env?: HierarchyEnv): HandlerCtx {
     fs,
     log: () => {},
     prompts: silentPromptAdapter(),
+    installAgentPlugin: async () => ({
+      installed: false,
+      message: "test plugin installation failed",
+    }),
   };
 }
 
@@ -69,6 +73,7 @@ interface ServerSession {
   handle: UiServerHandle;
   token: string;
   fs: MemFs;
+  ctx: HandlerCtx;
   assetDir: string;
 }
 
@@ -78,7 +83,7 @@ async function spin(env?: HierarchyEnv): Promise<ServerSession> {
   const token = newSessionToken();
   const assetDir = await makeAssetDir();
   const handle = await startUiServer({ ctx, token, assetDir });
-  return { handle, token, fs, assetDir };
+  return { handle, token, fs, ctx, assetDir };
 }
 
 let session: ServerSession;
@@ -306,6 +311,25 @@ describe("UI server — /api/config", () => {
 });
 
 describe("UI server — agent previews", () => {
+  it("uses plugin-first linking through the legacy /api/link endpoint", async () => {
+    const claudeBefore = JSON.stringify({ mcpServers: {} });
+    session.fs.files.set(CLAUDE_PATH, claudeBefore);
+    session.ctx.installAgentPlugin = async () => ({
+      installed: true,
+      message: "Ratel Local plugin installed for Claude Code.",
+    });
+
+    const res = await fetch(apiUrl("/api/link"), {
+      method: "POST",
+      headers: authHeaders(),
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { log: string[] };
+    expect(body.log.join("\n")).toMatch(/plugin installed/i);
+    expect(session.fs.files.get(CLAUDE_PATH)).toBe(claudeBefore);
+  });
+
   it("detects supported hosts without writing files", async () => {
     session.fs.files.set(
       CLAUDE_PATH,
@@ -539,10 +563,79 @@ command = "echo"
       }),
     });
     expect(res.status).toBe(200);
+    const body = (await res.json()) as { mode: string; log: string[] };
+    expect(body.mode).toBe("mcp-fallback");
+    expect(body.log.join("\n")).toMatch(/plugin installation failed/i);
+    expect(body.log.join("\n")).toMatch(/explicit MCP gateway fallback/i);
     expect(session.fs.files.has(USER_PATH)).toBe(false);
     const claude = JSON.parse(session.fs.files.get(CLAUDE_PATH) as string);
     expect(claude.mcpServers.fs.command).toBe("echo");
     expect(claude.mcpServers["ratel-local"].args).toContain(USER_PATH);
+  });
+
+  it("installs the plugin first and skips the MCP fallback when installation succeeds", async () => {
+    const claudeBefore = JSON.stringify({
+      mcpServers: { fs: { type: "stdio", command: "echo" } },
+    });
+    session.fs.files.set(CLAUDE_PATH, claudeBefore);
+    session.ctx.installAgentPlugin = async () => ({
+      installed: true,
+      message: "Ratel Local plugin installed for Claude Code.",
+    });
+    const preview = (await (
+      await fetch(apiUrl("/api/agent-preview/link"), {
+        method: "POST",
+        headers: authHeaders(),
+        body: JSON.stringify({ hostKind: "claude-code" }),
+      })
+    ).json()) as { stageHashes: { agent: string } };
+
+    const res = await fetch(apiUrl("/api/agent-apply/link"), {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify({
+        hostKind: "claude-code",
+        planHash: preview.stageHashes.agent,
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { mode: string; log: string[] };
+    expect(body.mode).toBe("plugin");
+    expect(body.log.join("\n")).toMatch(/plugin installed/i);
+    expect(session.fs.files.get(CLAUDE_PATH)).toBe(claudeBefore);
+  });
+
+  it("does not run plugin installation when the reviewed link preview is stale", async () => {
+    session.fs.files.set(CLAUDE_PATH, JSON.stringify({ mcpServers: {} }));
+    let installCalls = 0;
+    session.ctx.installAgentPlugin = async () => {
+      installCalls += 1;
+      return { installed: true, message: "installed" };
+    };
+    const preview = (await (
+      await fetch(apiUrl("/api/agent-preview/link"), {
+        method: "POST",
+        headers: authHeaders(),
+        body: JSON.stringify({ hostKind: "claude-code" }),
+      })
+    ).json()) as { stageHashes: { agent: string } };
+    session.fs.files.set(
+      CLAUDE_PATH,
+      JSON.stringify({ mcpServers: { changed: { type: "stdio", command: "echo" } } }),
+    );
+
+    const res = await fetch(apiUrl("/api/agent-apply/link"), {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify({
+        hostKind: "claude-code",
+        planHash: preview.stageHashes.agent,
+      }),
+    });
+
+    expect(res.status).toBe(400);
+    expect(installCalls).toBe(0);
   });
 });
 

--- a/apps/ratel-local/src/ui/server.test.ts
+++ b/apps/ratel-local/src/ui/server.test.ts
@@ -637,6 +637,86 @@ command = "echo"
     expect(res.status).toBe(400);
     expect(installCalls).toBe(0);
   });
+
+  it("fixes a duplicate Claude Code installation without reinstalling the plugin", async () => {
+    session.fs.files.set(
+      CLAUDE_PATH,
+      JSON.stringify({
+        mcpServers: {
+          fs: { type: "stdio", command: "echo" },
+          "ratel-local": { type: "stdio", command: "ratel-local" },
+        },
+      }),
+    );
+    session.fs.files.set(
+      CLAUDE_SETTINGS_PATH,
+      JSON.stringify({ enabledPlugins: { "ratel-local@ratel": true } }),
+    );
+    let installCalls = 0;
+    session.ctx.installAgentPlugin = async () => {
+      installCalls += 1;
+      return { installed: true, message: "installed" };
+    };
+
+    const res = await fetch(apiUrl("/api/agent-connection/repair"), {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify({ hostKind: "claude-code" }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(installCalls).toBe(0);
+    const body = (await res.json()) as { mode: string; log: string[] };
+    expect(body.mode).toBe("repaired");
+    expect(body.log.join("\n")).toMatch(/duplicate installation fixed/i);
+    expect(JSON.parse(session.fs.files.get(CLAUDE_PATH) as string).mcpServers).toEqual({
+      fs: { type: "stdio", command: "echo" },
+    });
+  });
+
+  it("promotes a standalone Codex MCP connection to the plugin", async () => {
+    session.fs.files.set(
+      CODEX_PATH,
+      ["[mcp_servers.ratel-local]", 'command = "ratel-local"', ""].join("\n"),
+    );
+    session.ctx.installAgentPlugin = async (hostKind) => ({
+      installed: hostKind === "codex",
+      message: "Ratel Local plugin installed for Codex.",
+    });
+
+    const res = await fetch(apiUrl("/api/agent-connection/repair"), {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify({ hostKind: "codex" }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { mode: string; log: string[] };
+    expect(body.mode).toBe("promoted");
+    expect(body.log.join("\n")).toMatch(/upgrade complete/i);
+    expect(session.fs.files.get(CODEX_PATH)).not.toContain("mcp_servers.ratel-local");
+  });
+
+  it("keeps the standalone MCP connection when plugin promotion fails", async () => {
+    const before = JSON.stringify({
+      mcpServers: { "ratel-local": { type: "stdio", command: "ratel-local" } },
+    });
+    session.fs.files.set(CLAUDE_PATH, before);
+    session.ctx.installAgentPlugin = async () => ({
+      installed: false,
+      message: "Claude Code plugin installation failed: unavailable",
+    });
+
+    const res = await fetch(apiUrl("/api/agent-connection/repair"), {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify({ hostKind: "claude-code" }),
+    });
+
+    expect(res.status).toBe(400);
+    expect(session.fs.files.get(CLAUDE_PATH)).toBe(before);
+    expect(((await res.json()) as { error: string }).error).toMatch(/left unchanged/i);
+  });
 });
 
 describe("UI server — Claude statusline", () => {

--- a/apps/ratel-local/src/ui/server.ts
+++ b/apps/ratel-local/src/ui/server.ts
@@ -32,6 +32,7 @@ import {
   previewImport,
   previewLink,
   removeServer,
+  repairAgentConnection,
   uninstallClaudeStatuslineRoute,
   updateSkillRoute,
 } from "./routes.js";
@@ -218,6 +219,10 @@ async function route(
   if (method === "POST" && path === "/api/agent-apply/link") {
     const body = await readJsonBody(req);
     return applyLink(ctx, body);
+  }
+  if (method === "POST" && path === "/api/agent-connection/repair") {
+    const body = await readJsonBody(req);
+    return repairAgentConnection(ctx, body);
   }
   if (method === "POST" && path === "/api/claude-statusline/install") {
     const body = await readJsonBody(req);

--- a/packages/core/src/agent-host/codex.ts
+++ b/packages/core/src/agent-host/codex.ts
@@ -175,6 +175,41 @@ export function rewriteCodexConfig(
   return `${trimmed}${trimmed.length > 0 ? "\n\n" : ""}${renderCodexServer(gateway.name, gateway.entry)}\n`;
 }
 
+export function rewriteCodexPluginMcpServerEnabled(
+  text: string,
+  pluginName: string,
+  serverName: string,
+): string {
+  const root = parseToml(text) as Record<string, unknown>;
+  const plugins = isPlainObject(root.plugins) ? root.plugins : null;
+  const plugin = plugins && isPlainObject(plugins[pluginName]) ? plugins[pluginName] : null;
+  const servers = plugin && isPlainObject(plugin.mcp_servers) ? plugin.mcp_servers : null;
+  const server = servers && isPlainObject(servers[serverName]) ? servers[serverName] : null;
+  if (!server || server.enabled !== false) return text;
+
+  const section = findTomlTableSections(text).find(
+    ({ path }) =>
+      path.length === 4 &&
+      path[0] === "plugins" &&
+      path[1] === pluginName &&
+      path[2] === "mcp_servers" &&
+      path[3] === serverName,
+  );
+  if (section) {
+    const body = text.slice(section.headerEnd, section.end);
+    const nextBody = body.replace(
+      /^(\s*(?:enabled|"enabled"|'enabled')\s*=\s*)false(\s*(?:#.*)?)(\r?\n|$)/m,
+      "$1true$2$3",
+    );
+    if (nextBody !== body) {
+      return `${text.slice(0, section.headerEnd)}${nextBody}${text.slice(section.end)}`;
+    }
+  }
+
+  server.enabled = true;
+  return stringifyToml(root);
+}
+
 function rewriteCodexConfigStructured(
   text: string,
   removeNames: ReadonlySet<string>,

--- a/packages/core/src/agent-host/ratel-connection.ts
+++ b/packages/core/src/agent-host/ratel-connection.ts
@@ -1,0 +1,199 @@
+import { join } from "node:path";
+import { parse as parseToml } from "smol-toml";
+import { isRatelGatewayEntry } from "../gateway-entry.js";
+import type { FileChange } from "../import-plan.js";
+import { isPlainObject } from "../json.js";
+import { rewriteCodexPluginMcpServerEnabled } from "./codex.js";
+import {
+  type AgentHostContext,
+  type AgentHostState,
+  type AgentScope,
+  NamedAgentHostAdapter,
+  SUPPORTED_AGENT_HOSTS,
+  type SupportedAgentHostKind,
+} from "./index.js";
+
+export type RatelConnectionKind = "none" | "explicit" | "plugin" | "duplicate";
+
+export interface RatelConnectionState {
+  kind: RatelConnectionKind;
+  linked: boolean;
+  explicit: boolean;
+  plugin: boolean;
+  pluginDisabled?: boolean;
+}
+
+export async function getAgentHostRatelConnection(
+  kind: SupportedAgentHostKind,
+  state: AgentHostState | null,
+  ctx: AgentHostContext,
+  warnings: string[] = [],
+): Promise<RatelConnectionState> {
+  const explicit =
+    state?.scopes.some((scope) =>
+      Object.entries(scope.mcpServers).some(([name, entry]) => isRatelGatewayEntry(name, entry)),
+    ) ?? false;
+  const pluginState =
+    kind === "claude-code"
+      ? await detectClaudeRatelPlugin(ctx, warnings)
+      : detectCodexRatelPlugin(state, warnings);
+  const plugin = pluginState.enabled;
+  const connectionKind: RatelConnectionKind = explicit
+    ? plugin
+      ? "duplicate"
+      : "explicit"
+    : plugin
+      ? "plugin"
+      : "none";
+  return {
+    kind: connectionKind,
+    linked: explicit || plugin,
+    explicit,
+    plugin,
+    ...(pluginState.disabled ? { pluginDisabled: true } : {}),
+  };
+}
+
+interface PluginState {
+  enabled: boolean;
+  disabled: boolean;
+}
+
+function detectCodexRatelPlugin(state: AgentHostState | null, warnings: string[]): PluginState {
+  const user = state?.scopes.find((scope) => scope.scope === "user");
+  if (!user?.rawText) return { enabled: false, disabled: false };
+  try {
+    const root = parseToml(user.rawText);
+    if (!isPlainObject(root.plugins)) return { enabled: false, disabled: false };
+    const plugin = root.plugins["ratel-local@ratel"];
+    if (!isPlainObject(plugin) || plugin.enabled !== true) {
+      return { enabled: false, disabled: false };
+    }
+    const servers = isPlainObject(plugin.mcp_servers) ? plugin.mcp_servers : null;
+    const server = servers?.["ratel-local"];
+    const disabled = isPlainObject(server) && server.enabled === false;
+    return { enabled: !disabled, disabled };
+  } catch (err) {
+    warnings.push(`Failed to read Codex plugin settings: ${(err as Error).message}`);
+    return { enabled: false, disabled: false };
+  }
+}
+
+export function buildAgentHostRatelPluginLinkChanges(
+  kind: SupportedAgentHostKind,
+  state: AgentHostState,
+  connection: RatelConnectionState,
+): FileChange[] {
+  if (kind !== "codex" || connection.linked || !connection.pluginDisabled) return [];
+  const user = state.scopes.find((scope) => scope.scope === "user");
+  if (!user?.rawText) return [];
+  const after = rewriteCodexPluginMcpServerEnabled(
+    user.rawText,
+    "ratel-local@ratel",
+    "ratel-local",
+  );
+  if (after === user.rawText) return [];
+  return [{ kind: "write", path: user.path, before: user.rawText, after }];
+}
+
+export async function findAgentHostRatelPluginConnection(
+  ctx: AgentHostContext,
+  requestedKind?: SupportedAgentHostKind,
+): Promise<{ state: AgentHostState; connection: RatelConnectionState } | null> {
+  const kinds = requestedKind ? [requestedKind] : SUPPORTED_AGENT_HOSTS.map(({ kind }) => kind);
+  for (const kind of kinds) {
+    try {
+      const state = await new NamedAgentHostAdapter(kind).read(ctx);
+      const connection = await getAgentHostRatelConnection(kind, state, ctx);
+      if (connection.plugin) return { state, connection };
+    } catch {
+      // Normal detection reports readable host-config failures before this fallback is reached.
+    }
+  }
+  return null;
+}
+
+export function pluginLinkNoOpMessage(
+  displayName: string,
+  connection: RatelConnectionState,
+): string {
+  if (connection.kind === "duplicate") {
+    return `${displayName} has duplicate Ratel connections through the Ratel Local plugin and explicit MCP configuration. Link will not change either connection.`;
+  }
+  return `${displayName} is already linked through the Ratel Local plugin; no explicit gateway is needed.`;
+}
+
+async function detectClaudeRatelPlugin(
+  ctx: AgentHostContext,
+  warnings: string[],
+): Promise<PluginState> {
+  let enabled = false;
+  for (const { scope, path } of claudeSettingsPaths(ctx.env)) {
+    const settings = await readSettingsLenient(ctx, path, warnings, scope);
+    const decision = settings ? ratelPluginDecision(settings) : undefined;
+    if (decision === "disabled") enabled = false;
+    if (decision === "enabled") enabled = true;
+  }
+  return { enabled, disabled: false };
+}
+
+function ratelPluginDecision(
+  settings: Record<string, unknown>,
+): "enabled" | "disabled" | undefined {
+  if (pluginListHasRatel(settings.disabledPlugins)) return "disabled";
+  const enabled = settings.enabledPlugins;
+  if (Array.isArray(enabled)) return pluginListHasRatel(enabled) ? "enabled" : undefined;
+  if (isPlainObject(enabled)) {
+    let decision: "enabled" | "disabled" | undefined;
+    for (const [name, value] of Object.entries(enabled)) {
+      if (!isRatelPluginName(name)) continue;
+      decision = value === false ? "disabled" : "enabled";
+    }
+    return decision;
+  }
+  return undefined;
+}
+
+function pluginListHasRatel(value: unknown): boolean {
+  return (
+    Array.isArray(value) &&
+    value.some((item) => typeof item === "string" && isRatelPluginName(item))
+  );
+}
+
+function isRatelPluginName(value: string): boolean {
+  return value === "ratel-local" || value.startsWith("ratel-local@");
+}
+
+function claudeSettingsPaths(
+  env: AgentHostContext["env"],
+): Array<{ scope: AgentScope; path: string }> {
+  const paths: Array<{ scope: AgentScope; path: string }> = [
+    { scope: "user", path: join(env.homeDir, ".claude", "settings.json") },
+  ];
+  if (env.projectRoot) {
+    paths.push(
+      { scope: "project", path: join(env.projectRoot, ".claude", "settings.json") },
+      { scope: "local", path: join(env.projectRoot, ".claude", "settings.local.json") },
+    );
+  }
+  return paths;
+}
+
+async function readSettingsLenient(
+  ctx: AgentHostContext,
+  path: string,
+  warnings: string[],
+  scope: AgentScope,
+): Promise<Record<string, unknown> | null> {
+  try {
+    const text = await ctx.fs.read(path);
+    if (text === null) return null;
+    const parsed: unknown = JSON.parse(text);
+    if (!isPlainObject(parsed)) throw new Error(`${path}: root must be a JSON object`);
+    return parsed;
+  } catch (err) {
+    warnings.push(`Failed to read ${scope} settings: ${(err as Error).message}`);
+    return null;
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./agent-host/index.js";
+export * from "./agent-host/ratel-connection.js";
 export * from "./agent-import-workflow.js";
 export * from "./backup.js";
 export * from "./gateway-entry.js";

--- a/packages/core/src/operations.test.ts
+++ b/packages/core/src/operations.test.ts
@@ -13,6 +13,7 @@ import {
   linkAgentToRatel,
   previewAgentImport,
   previewAgentLink,
+  removeAgentRatelMcpFallback,
   removeServerEntry,
 } from "./operations.js";
 
@@ -341,6 +342,49 @@ command = "echo"
     expect(preview.plan.agentChanges).toEqual([]);
     expect(preview.emptyReason).toMatch(/duplicate Ratel connections/i);
     expect(fs.files.get(CLAUDE_PATH)).toBe(claudeBefore);
+  });
+
+  it("removes only the explicit Claude Ratel fallback", async () => {
+    const fs = new MemFs();
+    fs.files.set(
+      CLAUDE_PATH,
+      JSON.stringify({
+        mcpServers: {
+          fs: { type: "stdio", command: "echo" },
+          "ratel-local": { type: "stdio", command: "ratel-local" },
+        },
+      }),
+    );
+
+    await removeAgentRatelMcpFallback(
+      ctx(fs),
+      { hostKind: "claude-code" },
+      { envVar: "ratel-local" },
+    );
+
+    expect(JSON.parse(fs.files.get(CLAUDE_PATH) as string).mcpServers).toEqual({
+      fs: { type: "stdio", command: "echo" },
+    });
+  });
+
+  it("removes only the explicit Codex Ratel fallback", async () => {
+    const fs = new MemFs();
+    fs.files.set(
+      CODEX_PATH,
+      [
+        "[mcp_servers.fs]",
+        'command = "echo"',
+        "",
+        "[mcp_servers.ratel-local]",
+        'command = "ratel-local"',
+        "",
+      ].join("\n"),
+    );
+
+    await removeAgentRatelMcpFallback(ctx(fs), { hostKind: "codex" }, { envVar: "ratel-local" });
+
+    expect(fs.files.get(CODEX_PATH)).toContain("[mcp_servers.fs]");
+    expect(fs.files.get(CODEX_PATH)).not.toContain("[mcp_servers.ratel-local]");
   });
 
   it("previews and applies import in Ratel and agent stages", async () => {

--- a/packages/core/src/operations.test.ts
+++ b/packages/core/src/operations.test.ts
@@ -20,6 +20,8 @@ const HOME = "/home/u";
 const ROOT = "/repo";
 const USER_PATH = "/home/u/.ratel/config.json";
 const CLAUDE_PATH = "/home/u/.claude.json";
+const CLAUDE_SETTINGS_PATH = "/home/u/.claude/settings.json";
+const CODEX_PATH = "/home/u/.codex/config.toml";
 
 class MemFs implements BackupFs, JsonFs {
   files = new Map<string, string>();
@@ -143,6 +145,30 @@ describe("core operations — config state", () => {
 });
 
 describe("core operations — agent interop", () => {
+  it("reports an enabled Claude Ratel plugin as the host connection", async () => {
+    const fs = new MemFs();
+    fs.files.set(
+      CLAUDE_PATH,
+      JSON.stringify({ mcpServers: { fs: { type: "stdio", command: "echo" } } }),
+    );
+    fs.files.set(
+      CLAUDE_SETTINGS_PATH,
+      JSON.stringify({ enabledPlugins: { "ratel-local@ratel": true } }),
+    );
+
+    const state = await getAgentHostsState(ctx(fs));
+    const claude = state.hosts.find((host) => host.kind === "claude-code");
+
+    expect(claude?.connection).toEqual({
+      kind: "plugin",
+      linked: true,
+      explicit: false,
+      plugin: true,
+    });
+    expect(claude?.posture).toBe("mixed");
+    expect(claude?.ratelEntryCount).toBe(0);
+  });
+
   it("reports detected agent posture for supported hosts", async () => {
     const fs = new MemFs();
     let state = await getAgentHostsState(ctx(fs));
@@ -180,6 +206,141 @@ describe("core operations — agent interop", () => {
     );
     state = await getAgentHostsState(ctx(fs));
     expect(state.hosts.find((host) => host.kind === "claude-code")?.posture).toBe("mixed");
+  });
+
+  it("reports an enabled Codex Ratel plugin as the host connection", async () => {
+    const fs = new MemFs();
+    fs.files.set(
+      CODEX_PATH,
+      `[plugins."ratel-local@ratel"]
+enabled = true
+
+[mcp_servers.fs]
+command = "echo"
+`,
+    );
+
+    const state = await getAgentHostsState(ctx(fs));
+    const codex = state.hosts.find((host) => host.kind === "codex");
+
+    expect(codex?.connection).toEqual({
+      kind: "plugin",
+      linked: true,
+      explicit: false,
+      plugin: true,
+    });
+    expect(codex?.posture).toBe("mixed");
+    expect(codex?.ratelEntryCount).toBe(0);
+  });
+
+  it("does not treat an explicitly disabled Codex plugin as a connection", async () => {
+    const fs = new MemFs();
+    fs.files.set(
+      CODEX_PATH,
+      `[plugins."ratel-local@ratel"]
+enabled = false
+
+[mcp_servers.fs]
+command = "echo"
+`,
+    );
+
+    const state = await getAgentHostsState(ctx(fs));
+    const codex = state.hosts.find((host) => host.kind === "codex");
+
+    expect(codex?.connection).toEqual({
+      kind: "none",
+      linked: false,
+      explicit: false,
+      plugin: false,
+    });
+    expect(codex?.posture).toBe("not-linked");
+  });
+
+  it("re-enables a disabled Codex plugin MCP instead of adding an explicit gateway", async () => {
+    const fs = new MemFs();
+    fs.files.set(
+      CODEX_PATH,
+      `[plugins."ratel-local@ratel"]
+enabled = true
+
+[plugins."ratel-local@ratel".mcp_servers.ratel-local]
+enabled = false # keep this comment
+
+[mcp_servers.fs]
+command = "echo"
+`,
+    );
+
+    const state = await getAgentHostsState(ctx(fs));
+    const codex = state.hosts.find((host) => host.kind === "codex");
+    expect(codex?.connection).toEqual({
+      kind: "none",
+      linked: false,
+      explicit: false,
+      plugin: false,
+      pluginDisabled: true,
+    });
+
+    const preview = await previewAgentLink(ctx(fs), { hostKind: "codex" });
+    expect(preview.plan.agentChanges).toHaveLength(1);
+    expect(preview.plan.agentChanges[0]?.after).toContain("enabled = true # keep this comment");
+    expect(preview.plan.agentChanges[0]?.after).not.toContain("[mcp_servers.ratel-local]");
+
+    await applyAgentLink(ctx(fs), {
+      hostKind: "codex",
+      planHash: preview.stageHashes.agent,
+    });
+    const after = fs.files.get(CODEX_PATH) as string;
+    expect(after).toContain("enabled = true # keep this comment");
+    expect(after).not.toContain("[mcp_servers.ratel-local]");
+  });
+
+  it("keeps host discovery working when Claude plugin settings cannot be read", async () => {
+    const fs = new MemFs();
+    fs.files.set(
+      CLAUDE_PATH,
+      JSON.stringify({ mcpServers: { fs: { type: "stdio", command: "echo" } } }),
+    );
+    const read = fs.read.bind(fs);
+    fs.read = async (path: string) => {
+      if (path === CLAUDE_SETTINGS_PATH) throw new Error("permission denied");
+      return read(path);
+    };
+
+    const state = await getAgentHostsState(ctx(fs));
+    const claude = state.hosts.find((host) => host.kind === "claude-code");
+
+    expect(claude?.connection.linked).toBe(false);
+    expect(claude?.detection.warnings.join("\n")).toMatch(/permission denied/i);
+  });
+
+  it("reports plugin plus explicit MCP as a duplicate without changing either connection", async () => {
+    const fs = new MemFs();
+    const claudeBefore = JSON.stringify({
+      mcpServers: {
+        "ratel-local": { type: "stdio", command: "ratel-local" },
+      },
+    });
+    fs.files.set(CLAUDE_PATH, claudeBefore);
+    fs.files.set(
+      CLAUDE_SETTINGS_PATH,
+      JSON.stringify({ enabledPlugins: { "ratel-local@ratel": true } }),
+    );
+
+    const state = await getAgentHostsState(ctx(fs));
+    const claude = state.hosts.find((host) => host.kind === "claude-code");
+    expect(claude?.connection).toEqual({
+      kind: "duplicate",
+      linked: true,
+      explicit: true,
+      plugin: true,
+    });
+
+    const preview = await previewAgentLink(ctx(fs), { hostKind: "claude-code" });
+    expect(preview.plan.agentChanges).toEqual([]);
+    expect(preview.emptyReason).toMatch(/duplicate Ratel connections/i);
+    expect(fs.files.get(CLAUDE_PATH)).toBe(claudeBefore);
   });
 
   it("previews and applies import in Ratel and agent stages", async () => {
@@ -294,6 +455,27 @@ describe("core operations — agent interop", () => {
     expect(claude.mcpServers["ratel-local"].args).toContain(USER_PATH);
   });
 
+  it("previews link as a plugin-aware no-op without an explicit gateway", async () => {
+    const fs = new MemFs();
+    fs.files.set(
+      USER_PATH,
+      JSON.stringify({ mcpServers: { fs: { type: "stdio", command: "echo" } } }),
+    );
+    fs.files.set(
+      CLAUDE_PATH,
+      JSON.stringify({ mcpServers: { fs: { type: "stdio", command: "echo" } } }),
+    );
+    fs.files.set(
+      CLAUDE_SETTINGS_PATH,
+      JSON.stringify({ enabledPlugins: { "ratel-local@ratel": true } }),
+    );
+
+    const preview = await previewAgentLink(ctx(fs), { hostKind: "claude-code" });
+
+    expect(preview.plan.agentChanges).toEqual([]);
+    expect(preview.emptyReason).toMatch(/linked through the Ratel Local plugin/i);
+  });
+
   it("links the Ratel gateway even when native agent entries do not match Ratel entries", async () => {
     const fs = new MemFs();
     fs.files.set(
@@ -381,5 +563,24 @@ describe("core operations — agent interop", () => {
     const claude = JSON.parse(fs.files.get(CLAUDE_PATH) as string);
     expect(claude.mcpServers.fs.command).toBe("echo");
     expect(claude.mcpServers["ratel-local"].args).toContain(USER_PATH);
+  });
+
+  it("leaves plugin-linked Claude Code unchanged in the non-interactive link operation", async () => {
+    const fs = new MemFs();
+    fs.files.set(
+      CLAUDE_SETTINGS_PATH,
+      JSON.stringify({ enabledPlugins: { "ratel-local@ratel": true } }),
+    );
+    const logs: string[] = [];
+
+    const manifest = await linkAgentToRatel({
+      env: { homeDir: HOME, projectRoot: ROOT },
+      fs,
+      log: (message) => logs.push(message),
+    });
+
+    expect(manifest).toBeNull();
+    expect(fs.files.has(CLAUDE_PATH)).toBe(false);
+    expect(logs.join("\n")).toMatch(/linked through the Ratel Local plugin/i);
   });
 });

--- a/packages/core/src/operations.ts
+++ b/packages/core/src/operations.ts
@@ -329,6 +329,10 @@ export interface ApplyAgentLinkInput extends PreviewAgentLinkInput {
   planHash: string;
 }
 
+export interface RemoveAgentRatelMcpFallbackInput {
+  hostKind: SupportedAgentHostKind;
+}
+
 export async function getAgentHostsState(ctx: CoreContext): Promise<AgentHostsState> {
   const hosts: DetectedAgentHostSummary[] = [];
   const ratelKnownNames = collectRatelKnownNames(await readAllRatelConfigs(ctx));
@@ -547,6 +551,49 @@ export async function linkAgentToRatel(
 
   ctx.log?.(`Rewriting ${plan.agentChanges.length} ${agentState.host.displayName} config file(s).`);
   return executePlan(plan.agentChanges, { fs: ctx.fs, env: ctx.env, action: "link" });
+}
+
+export async function removeAgentRatelMcpFallback(
+  ctx: CoreContext,
+  input: RemoveAgentRatelMcpFallbackInput,
+  opts: AgentInteropOptions = {},
+): Promise<BackupManifest | null> {
+  const hostKind = assertSupportedAgentHostKind(input.hostKind);
+  const agentHost = new NamedAgentHostAdapter(hostKind);
+  const agentState = await agentHost.read({ env: ctx.env, fs: ctx.fs });
+  const removeEntriesByScope = new Map<AgentScope, Set<string>>();
+
+  for (const scope of agentState.scopes) {
+    const names = Object.entries(scope.mcpServers)
+      .filter(([name, entry]) => isRatelGatewayEntry(name, entry))
+      .map(([name]) => name);
+    if (names.length > 0) removeEntriesByScope.set(scope.scope, new Set(names));
+  }
+
+  if (removeEntriesByScope.size === 0) {
+    ctx.log?.(`${agentState.host.displayName} has no explicit Ratel MCP fallback to remove.`);
+    return null;
+  }
+
+  const inputs = await buildAgentPlanInputs(ctx, agentHost, agentState, opts);
+  const hostChanges = await agentHost.planChanges({
+    state: agentState,
+    bin: inputs.bin,
+    ratelConfigPaths: {
+      user: inputs.ratelUserPath,
+      ...(inputs.ratelProjectPath ? { project: inputs.ratelProjectPath } : {}),
+      ...(inputs.ratelLocalPath ? { local: inputs.ratelLocalPath } : {}),
+    },
+    removeEntriesByScope,
+  });
+  if (hostChanges.changes.length === 0) return null;
+
+  ctx.log?.(
+    `Removing ${hostChanges.summary.removedNativeEntries.length} explicit Ratel MCP fallback entr${
+      hostChanges.summary.removedNativeEntries.length === 1 ? "y" : "ies"
+    } from ${agentState.host.displayName}.`,
+  );
+  return executePlan(hostChanges.changes, { fs: ctx.fs, env: ctx.env, action: "link" });
 }
 
 async function defaultAuthRunner(config: RatelConfig, ctx: CoreContext) {

--- a/packages/core/src/operations.ts
+++ b/packages/core/src/operations.ts
@@ -14,6 +14,13 @@ import {
   NamedAgentHostAdapter,
   SUPPORTED_AGENT_HOSTS,
 } from "./agent-host/index.js";
+import {
+  buildAgentHostRatelPluginLinkChanges,
+  findAgentHostRatelPluginConnection,
+  getAgentHostRatelConnection,
+  pluginLinkNoOpMessage,
+  type RatelConnectionState,
+} from "./agent-host/ratel-connection.js";
 import { type BackupFs, type BackupManifest, listBackups, startBackup } from "./backup.js";
 import { isRatelGatewayEntry } from "./gateway-entry.js";
 import { ProjectRootNotFoundError, type RatelScope, ratelConfigPath } from "./hierarchy.js";
@@ -266,6 +273,7 @@ export interface DetectedAgentHostSummary {
   kind: SupportedAgentHostKind;
   displayName: string;
   detection: AgentHostDetection;
+  connection: RatelConnectionState;
   posture: AgentPosture;
   nativeEntryCount: number;
   ratelEntryCount: number;
@@ -333,11 +341,12 @@ export async function getAgentHostsState(ctx: CoreContext): Promise<AgentHostsSt
     } catch (err) {
       detection.warnings.push(`Failed to read ${host.displayName}: ${(err as Error).message}`);
     }
-    const summary = summarizeDetectedAgentHost(
+    const summary = await summarizeDetectedAgentHost(
       host.kind,
       host.displayName,
       detection,
       state,
+      ctx,
       ratelKnownNames,
     );
     if (host.kind === "claude-code") {
@@ -363,11 +372,12 @@ export async function previewAgentImport(
   const agentHost = new NamedAgentHostAdapter(hostKind);
   const detection = await agentHost.detect({ env: ctx.env, fs: ctx.fs });
   const agentState = await agentHost.read({ env: ctx.env, fs: ctx.fs });
-  const host = summarizeDetectedAgentHost(
+  const host = await summarizeDetectedAgentHost(
     hostKind,
     agentState.host.displayName,
     detection,
     agentState,
+    ctx,
     collectRatelKnownNames(await readAllRatelConfigs(ctx)),
   );
   const candidates = collectAgentCandidates(agentState);
@@ -401,13 +411,25 @@ export async function previewAgentLink(
   const agentHost = new NamedAgentHostAdapter(hostKind);
   const detection = await agentHost.detect({ env: ctx.env, fs: ctx.fs });
   const agentState = await agentHost.read({ env: ctx.env, fs: ctx.fs });
-  const host = summarizeDetectedAgentHost(
+  const host = await summarizeDetectedAgentHost(
     hostKind,
     agentState.host.displayName,
     detection,
     agentState,
+    ctx,
     collectRatelKnownNames(await readAllRatelConfigs(ctx)),
   );
+  if (host.connection.plugin) {
+    return toAgentPlanPreview("link", host, [], [], emptyAgentPlan("add-missing-only"), input, {
+      emptyReason: pluginLinkNoOpMessage(host.displayName, host.connection),
+    });
+  }
+  const pluginChanges = buildAgentHostRatelPluginLinkChanges(hostKind, agentState, host.connection);
+  if (pluginChanges.length > 0) {
+    const plan = emptyAgentPlan("add-missing-only");
+    plan.agentChanges = pluginChanges;
+    return toAgentPlanPreview("link", host, [], [], plan, input);
+  }
   const inputs = await buildAgentPlanInputs(ctx, agentHost, agentState, opts);
   const plan = await buildAgentLinkPlan(inputs);
   return toAgentPlanPreview("link", host, [], [], plan, input, {
@@ -495,10 +517,26 @@ export async function linkAgentToRatel(
   const agentHost = new AutomaticAgentHostAdapter();
   const detection = await agentHost.detect({ env: ctx.env, fs: ctx.fs });
   if (!detection.present) {
+    const pluginHost = await findAgentHostRatelPluginConnection(ctx);
+    if (pluginHost) {
+      ctx.log?.(pluginLinkNoOpMessage(pluginHost.state.host.displayName, pluginHost.connection));
+      return null;
+    }
     ctx.log?.("No supported agent config found. Nothing to link.");
     return null;
   }
   const agentState = await agentHost.read({ env: ctx.env, fs: ctx.fs });
+  const hostKind = assertSupportedAgentHostKind(agentState.host.kind);
+  const connection = await getAgentHostRatelConnection(hostKind, agentState, ctx);
+  if (connection.plugin) {
+    ctx.log?.(pluginLinkNoOpMessage(agentState.host.displayName, connection));
+    return null;
+  }
+  const pluginChanges = buildAgentHostRatelPluginLinkChanges(hostKind, agentState, connection);
+  if (pluginChanges.length > 0) {
+    ctx.log?.(`Re-enabling the Ratel Local plugin MCP server in ${agentState.host.displayName}.`);
+    return executePlan(pluginChanges, { fs: ctx.fs, env: ctx.env, action: "link" });
+  }
   const inputs = await buildAgentPlanInputs(ctx, agentHost, agentState, opts);
 
   const plan = await buildAgentLinkPlan(inputs);
@@ -543,26 +581,34 @@ function assertSupportedAgentHostKind(value: unknown): SupportedAgentHostKind {
   throw new Error(`agent host must be one of claude-code|codex, got ${JSON.stringify(value)}`);
 }
 
-function summarizeDetectedAgentHost(
+async function summarizeDetectedAgentHost(
   kind: SupportedAgentHostKind,
   displayName: string,
   detection: AgentHostDetection,
   state: AgentHostState | null,
+  ctx: Pick<CoreContext, "env" | "fs">,
   ratelKnownNames: ReadonlySet<string> = new Set(),
-): DetectedAgentHostSummary {
+): Promise<DetectedAgentHostSummary> {
   const scopes = state?.scopes.map(summarizeAgentScope) ?? [];
   const nativeEntryCount = scopes.reduce((sum, scope) => sum + scope.nativeEntryCount, 0);
   const ratelEntryCount = scopes.reduce((sum, scope) => sum + scope.ratelEntryCount, 0);
   const entryCount = nativeEntryCount + ratelEntryCount;
   const nativeEntryNames = [...new Set(scopes.flatMap((scope) => scope.nativeEntryNames))].sort();
   const ratelEntryNames = [...new Set(scopes.flatMap((scope) => scope.ratelEntryNames))].sort();
+  const connection = await getAgentHostRatelConnection(kind, state, ctx, detection.warnings);
   return {
     kind,
     displayName,
     detection,
-    posture: detection.present
-      ? classifyPosture({ available: true, nativeEntryCount, ratelEntryCount })
-      : "unavailable",
+    connection,
+    posture:
+      detection.present || connection.plugin
+        ? classifyPosture({
+            available: true,
+            nativeEntryCount,
+            linked: connection.linked,
+          })
+        : "unavailable",
     nativeEntryCount,
     ratelEntryCount,
     entryCount,
@@ -592,7 +638,11 @@ function summarizeAgentScope(scope: AgentScopeState): AgentScopePosture {
     displayName: scope.displayName,
     path: scope.path,
     available: scope.available,
-    posture: classifyPosture({ available: scope.available, nativeEntryCount, ratelEntryCount }),
+    posture: classifyPosture({
+      available: scope.available,
+      nativeEntryCount,
+      linked: ratelEntryCount > 0,
+    }),
     nativeEntryCount,
     ratelEntryCount,
     entryCount: nativeEntryCount + ratelEntryCount,
@@ -604,12 +654,12 @@ function summarizeAgentScope(scope: AgentScopeState): AgentScopePosture {
 function classifyPosture(input: {
   available: boolean;
   nativeEntryCount: number;
-  ratelEntryCount: number;
+  linked: boolean;
 }): AgentPosture {
   if (!input.available) return "unavailable";
-  if (input.nativeEntryCount === 0 && input.ratelEntryCount === 0) return "empty";
+  if (input.nativeEntryCount === 0 && !input.linked) return "empty";
   if (input.nativeEntryCount === 0) return "ratel-only";
-  if (input.ratelEntryCount === 0) return "not-linked";
+  if (!input.linked) return "not-linked";
   return "mixed";
 }
 

--- a/packages/core/src/statusline.ts
+++ b/packages/core/src/statusline.ts
@@ -1,8 +1,8 @@
 import { join } from "node:path";
 import { ClaudeCodeAgentHostAdapter } from "./agent-host/claude-code.js";
-import type { AgentScope } from "./agent-host/index.js";
+import type { AgentHostState } from "./agent-host/index.js";
+import { getAgentHostRatelConnection } from "./agent-host/ratel-connection.js";
 import { type BackupFs, type BackupManifest, startBackup } from "./backup.js";
-import { isRatelGatewayEntry } from "./gateway-entry.js";
 import type { HierarchyEnv } from "./hierarchy.js";
 import type { JsonFs } from "./io.js";
 import { writeJson } from "./io.js";
@@ -309,73 +309,18 @@ async function detectClaudeRatelEnabled(
   ctx: StatuslineContext,
   warnings: string[],
 ): Promise<{ enabled: boolean; sources: string[] }> {
-  const sources: string[] = [];
+  let state: AgentHostState | null = null;
   try {
-    const state = await new ClaudeCodeAgentHostAdapter().read({ env: ctx.env, fs: ctx.fs });
-    if (
-      state.scopes.some((scope) =>
-        Object.entries(scope.mcpServers).some(([name, entry]) => isRatelGatewayEntry(name, entry)),
-      )
-    ) {
-      sources.push("mcp-config");
-    }
+    state = await new ClaudeCodeAgentHostAdapter().read({ env: ctx.env, fs: ctx.fs });
   } catch (err) {
     warnings.push(`Failed to read Claude MCP config: ${(err as Error).message}`);
   }
-
-  let pluginEnabled = false;
-  for (const { scope, path } of claudeSettingsPaths(ctx.env)) {
-    const settings = await readSettingsLenient(ctx, path, warnings, scope);
-    const decision = settings ? ratelPluginDecision(settings) : undefined;
-    if (decision === "disabled") {
-      pluginEnabled = false;
-    } else if (decision === "enabled") {
-      pluginEnabled = true;
-    }
-  }
-  if (pluginEnabled) sources.push("plugin");
-  return { enabled: sources.length > 0, sources };
-}
-
-function ratelPluginDecision(
-  settings: Record<string, unknown>,
-): "enabled" | "disabled" | undefined {
-  if (pluginListHasRatel(settings.disabledPlugins)) return "disabled";
-  const enabled = settings.enabledPlugins;
-  if (Array.isArray(enabled)) return pluginListHasRatel(enabled) ? "enabled" : undefined;
-  if (isPlainObject(enabled)) {
-    let decision: "enabled" | "disabled" | undefined;
-    for (const [name, value] of Object.entries(enabled)) {
-      if (!isRatelPluginName(name)) continue;
-      decision = value === false ? "disabled" : "enabled";
-    }
-    return decision;
-  }
-  return undefined;
-}
-
-function pluginListHasRatel(value: unknown): boolean {
-  return (
-    Array.isArray(value) &&
-    value.some((item) => typeof item === "string" && isRatelPluginName(item))
-  );
-}
-
-function isRatelPluginName(value: string): boolean {
-  return value === "ratel-local" || value.startsWith("ratel-local@");
-}
-
-function claudeSettingsPaths(env: HierarchyEnv): Array<{ scope: AgentScope; path: string }> {
-  const paths: Array<{ scope: AgentScope; path: string }> = [
-    { scope: "user", path: claudeCodeUserSettingsPath(env) },
+  const connection = await getAgentHostRatelConnection("claude-code", state, ctx, warnings);
+  const sources = [
+    ...(connection.explicit ? ["mcp-config"] : []),
+    ...(connection.plugin ? ["plugin"] : []),
   ];
-  if (env.projectRoot) {
-    paths.push(
-      { scope: "project", path: join(env.projectRoot, ".claude", "settings.json") },
-      { scope: "local", path: join(env.projectRoot, ".claude", "settings.local.json") },
-    );
-  }
-  return paths;
+  return { enabled: connection.linked, sources };
 }
 
 async function readSettingsStrict(
@@ -398,13 +343,11 @@ async function readSettingsLenient(
   ctx: StatuslineContext,
   path: string,
   warnings: string[],
-  scope?: AgentScope,
 ): Promise<Record<string, unknown> | null> {
   try {
     return await readSettingsStrict(ctx, path);
   } catch (err) {
-    const prefix = scope ? `${scope} settings` : path;
-    warnings.push(`Failed to read ${prefix}: ${(err as Error).message}`);
+    warnings.push(`Failed to read ${path}: ${(err as Error).message}`);
     return null;
   }
 }

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -62,6 +62,7 @@ export type RatelScope = "user" | "project" | "local";
 export type AuthStatus = "n/a" | "needs auth" | "expired" | "ok" | "unsupported";
 type AgentHostKind = "claude-code" | "codex";
 type AgentPosture = "unavailable" | "empty" | "not-linked" | "ratel-only" | "mixed";
+type RatelConnectionKind = "none" | "explicit" | "plugin" | "duplicate";
 
 export interface ServerEntry {
   type: string;
@@ -144,10 +145,18 @@ interface ClaudeStatuslineState {
   warnings: string[];
 }
 
+interface RatelConnectionState {
+  kind: RatelConnectionKind;
+  linked: boolean;
+  explicit: boolean;
+  plugin: boolean;
+}
+
 interface DetectedAgentHostSummary {
   kind: AgentHostKind;
   displayName: string;
   detection: AgentHostDetection;
+  connection: RatelConnectionState;
   posture: AgentPosture;
   nativeEntryCount: number;
   ratelEntryCount: number;
@@ -601,7 +610,7 @@ function CommandMenu(props: {
                       className="items-start py-2"
                       key={item.kind}
                       onSelect={() => props.onSelectAgent(item.kind)}
-                      value={`${item.displayName} ${item.kind} ${item.statusLabel} ${item.postureLabel} ${item.nativeEntryCount} native ${item.ratelEntryCount} ratel ${item.missingRatelEntryCount} missing ${item.searchText}`}
+                      value={`${item.displayName} ${item.kind} ${item.statusLabel} ${item.postureLabel} ${item.nativeEntryCount} native ${item.connectionDetail} ${item.missingRatelEntryCount} missing ${item.searchText}`}
                     >
                       <Settings2 className="mt-0.5" />
                       <span className="grid min-w-0 flex-1 gap-1">
@@ -613,7 +622,7 @@ function CommandMenu(props: {
                         </span>
                         <span className="truncate text-xs text-muted-foreground">
                           {item.postureLabel} / {item.nativeEntryCount} native /{" "}
-                          {item.ratelEntryCount} Ratel
+                          {item.connectionDetail}
                           {item.missingRatelEntryCount > 0
                             ? ` / ${item.missingRatelEntryCount} missing`
                             : ""}
@@ -695,16 +704,17 @@ function commandAgentItems(hosts: readonly DetectedAgentHostSummary[]) {
       const status = commandAgentStatus(host);
       return {
         displayName: host.displayName,
+        connectionDetail: commandAgentConnectionDetail(host),
         kind: host.kind,
         missingRatelEntryCount: host.missingRatelEntryNames?.length ?? 0,
         nativeEntryCount: host.nativeEntryCount,
         postureLabel: AGENT_POSTURE_LABELS[host.posture],
-        ratelEntryCount: host.ratelEntryCount,
         searchText: [
           host.detection.reasons.join(" "),
           host.detection.warnings.join(" "),
           host.nativeEntryNames?.join(" "),
           host.ratelEntryNames?.join(" "),
+          host.connection.kind,
           host.scopes.map((scope) => scope.path).join(" "),
         ].join(" "),
         statusLabel: status.label,
@@ -714,11 +724,19 @@ function commandAgentItems(hosts: readonly DetectedAgentHostSummary[]) {
     .sort((a, b) => a.displayName.localeCompare(b.displayName));
 }
 
+function commandAgentConnectionDetail(host: DetectedAgentHostSummary): string {
+  if (host.connection.kind === "duplicate") {
+    return `plugin + ${host.ratelEntryCount} explicit Ratel`;
+  }
+  if (host.connection.kind === "plugin") return "Ratel plugin";
+  return `${host.ratelEntryCount} Ratel`;
+}
+
 const AGENT_POSTURE_LABELS: Record<AgentPosture, string> = {
   empty: "No MCP entries",
-  mixed: "Native and Ratel entries",
+  mixed: "Native entries with Ratel",
   "not-linked": "Native entries only",
-  "ratel-only": "Ratel gateway configured",
+  "ratel-only": "Ratel connected",
   unavailable: "Config unavailable",
 };
 
@@ -727,10 +745,13 @@ function commandAgentStatus(host: DetectedAgentHostSummary): {
   tone: "muted" | "success" | "warning";
 } {
   if (host.posture === "unavailable") return { label: "Unavailable", tone: "muted" };
-  if (host.ratelEntryCount > 0 && (host.missingRatelEntryNames?.length ?? 0) === 0) {
+  if (host.connection.kind === "duplicate") {
+    return { label: "Duplicate", tone: "warning" };
+  }
+  if (host.connection.linked && (host.missingRatelEntryNames?.length ?? 0) === 0) {
     return { label: "Linked", tone: "success" };
   }
-  if (host.ratelEntryCount > 0) return { label: "Mixed", tone: "warning" };
+  if (host.connection.linked) return { label: "Mixed", tone: "warning" };
   return { label: "Not linked", tone: "muted" };
 }
 

--- a/packages/ui/src/pages/AgentSetupPage.tsx
+++ b/packages/ui/src/pages/AgentSetupPage.tsx
@@ -657,8 +657,8 @@ function AgentOperationPanel(props: {
       ) : null}
       {canLink ? (
         <SetupActionSection
-          description="Add the Ratel gateway entry when this agent is not routed through Ratel yet."
-          title="Link Ratel gateway"
+          description="Install the Ratel plugin with its bundled skills, with a reviewed explicit MCP fallback if installation fails."
+          title="Link Ratel integration"
         >
           <PreviewFlow
             availableSkills={[]}
@@ -1133,12 +1133,12 @@ function SetupRecap(props: {
         <p className="font-medium text-sm">
           {props.flow === "import"
             ? importAvailabilityLabel(mcpCount, skillCount)
-            : "One agent config change will be reviewed before writing."}
+            : "Ratel will install the agent plugin, including its bundled skills."}
         </p>
         <p className="mt-1 text-muted-foreground text-xs">
           {props.flow === "import"
             ? "Skills are selected first; MCP conflict handling follows only when needed."
-            : "Native MCP entries are preserved."}
+            : "If plugin installation fails, the reviewed MCP fallback is applied and reported. Native MCP entries are preserved."}
         </p>
       </div>
       <Button
@@ -1650,14 +1650,21 @@ function LinkSceneDialog(props: {
           </>
         }
         kicker="Review"
-        title="Review config changes"
+        title="Review link and fallback"
         wide
       >
-        <SceneScrollSection className="max-h-[65vh]">
+        <SceneScrollSection className="grid max-h-[65vh] gap-4">
+          <Alert>
+            <AlertTitle>Plugin first</AlertTitle>
+            <AlertDescription>
+              Ratel will install the {props.preview.host.displayName} plugin first. If that fails,
+              it will report the failure and apply only the explicit MCP changes reviewed below.
+            </AlertDescription>
+          </Alert>
           <ChangeList
             changes={props.preview.plan.agentChanges}
             defaultOpen
-            title={`${props.preview.host.displayName} changes`}
+            title={`${props.preview.host.displayName} MCP fallback`}
           />
         </SceneScrollSection>
       </ScenePanel>

--- a/packages/ui/src/pages/AgentSetupPage.tsx
+++ b/packages/ui/src/pages/AgentSetupPage.tsx
@@ -16,6 +16,7 @@ import {
   RefreshCw,
   SearchIcon,
   Sparkles,
+  Wrench,
   X,
 } from "lucide-react";
 import { AnimatePresence, motion } from "motion/react";
@@ -628,6 +629,8 @@ function AgentOperationPanel(props: {
   const canImport =
     missingRatelEntryNames(props.host).length > 0 || props.availableSkills.length > 0;
   const canLink = props.host.posture !== "unavailable" && !props.host.connection.linked;
+  const canRepairConnection =
+    props.host.connection.kind === "duplicate" || props.host.connection.kind === "explicit";
   const canManageStatusline = props.hostKind === "claude-code" && Boolean(props.host.statusline);
   return (
     <section className="-mx-4 grid gap-5 border-border border-y bg-muted/10 px-4 py-5 sm:-mx-6 sm:px-6">
@@ -636,6 +639,13 @@ function AgentOperationPanel(props: {
           onScanHosts={props.onScanHosts}
           request={props.request}
           state={props.host.statusline}
+        />
+      ) : null}
+      {canRepairConnection ? (
+        <AgentConnectionRepairSection
+          host={props.host}
+          onScanHosts={props.onScanHosts}
+          request={props.request}
         />
       ) : null}
       {canImport ? (
@@ -672,7 +682,7 @@ function AgentOperationPanel(props: {
           />
         </SetupActionSection>
       ) : null}
-      {!canImport && !canLink && !canManageStatusline ? (
+      {!canImport && !canLink && !canRepairConnection && !canManageStatusline ? (
         <div>
           <h3 className="text-lg font-semibold tracking-tight">Nothing to do</h3>
           <p className="mt-1 text-sm text-muted-foreground">
@@ -682,6 +692,53 @@ function AgentOperationPanel(props: {
         </div>
       ) : null}
     </section>
+  );
+}
+
+function AgentConnectionRepairSection(props: {
+  host: DetectedAgentHostSummary;
+  onScanHosts: () => Promise<void>;
+  request: <T>(path: string, init?: JsonRequestInit) => Promise<T>;
+}) {
+  const { runAction } = useRatelApp();
+  const duplicate = props.host.connection.kind === "duplicate";
+  const actionLabel = duplicate ? "Fix duplicate installation" : "Switch to plugin";
+  const commit = async () => {
+    const ok = await runAction(actionLabel, () =>
+      props.request("/api/agent-connection/repair", {
+        method: "POST",
+        body: { hostKind: props.host.kind },
+      }),
+    );
+    if (ok) await props.onScanHosts();
+  };
+
+  return (
+    <SetupActionSection
+      description={
+        duplicate
+          ? `Ratel is connected to ${props.host.displayName} twice. Remove the extra MCP connection and keep the plugin.`
+          : `Replace the standalone MCP connection with the Ratel plugin, including its bundled skills. If plugin installation fails, your current connection stays unchanged.`
+      }
+      title={duplicate ? "Duplicate installation detected" : "Upgrade to the Ratel plugin"}
+    >
+      <div className="grid gap-4 border border-border bg-background p-4 md:grid-cols-[minmax(0,1fr)_auto] md:items-center">
+        <div>
+          <p className="font-medium text-sm">
+            {duplicate ? "Use one clean Ratel connection" : "Get the complete Ratel integration"}
+          </p>
+          <p className="mt-1 max-w-xl text-muted-foreground text-xs">
+            {duplicate
+              ? "Ratel will remove only its recognized standalone MCP entry. Other MCP servers and the plugin stay untouched."
+              : "Ratel installs the plugin first and removes the old MCP entry only after installation succeeds."}
+          </p>
+        </div>
+        <Button className="min-h-12 px-6 text-base md:min-w-44" onClick={() => void commit()}>
+          {duplicate ? <Wrench /> : <Sparkles />}
+          {actionLabel}
+        </Button>
+      </div>
+    </SetupActionSection>
   );
 }
 

--- a/packages/ui/src/pages/AgentSetupPage.tsx
+++ b/packages/ui/src/pages/AgentSetupPage.tsx
@@ -57,6 +57,7 @@ import { cn } from "@/lib/utils";
 type AgentHostKind = "claude-code" | "codex";
 type AgentScope = "user" | "project" | "local";
 type AgentPosture = "unavailable" | "empty" | "not-linked" | "ratel-only" | "mixed";
+type RatelConnectionKind = "none" | "explicit" | "plugin" | "duplicate";
 type ConflictStrategy = "add-missing-only" | "replace-from-agent" | "replace-selected";
 type SetupFlow = "import" | "link";
 
@@ -91,10 +92,18 @@ interface ClaudeStatuslineState {
   warnings: string[];
 }
 
+interface RatelConnectionState {
+  kind: RatelConnectionKind;
+  linked: boolean;
+  explicit: boolean;
+  plugin: boolean;
+}
+
 interface DetectedAgentHostSummary {
   kind: AgentHostKind;
   displayName: string;
   detection: AgentHostDetection;
+  connection: RatelConnectionState;
   posture: AgentPosture;
   nativeEntryCount: number;
   ratelEntryCount: number;
@@ -188,12 +197,12 @@ const POSTURE_COPY: Record<
   "ratel-only": {
     label: "Ratel only",
     tone: "secondary",
-    description: "Only Ratel gateway entries are configured.",
+    description: "Ratel is connected with no native MCP entries.",
   },
   mixed: {
     label: "Mixed",
     tone: "default",
-    description: "Native and Ratel entries are both present.",
+    description: "Native MCP entries exist alongside a Ratel connection.",
   },
 };
 
@@ -618,7 +627,7 @@ function AgentOperationPanel(props: {
 }) {
   const canImport =
     missingRatelEntryNames(props.host).length > 0 || props.availableSkills.length > 0;
-  const canLink = props.host.posture !== "unavailable" && props.host.ratelEntryCount === 0;
+  const canLink = props.host.posture !== "unavailable" && !props.host.connection.linked;
   const canManageStatusline = props.hostKind === "claude-code" && Boolean(props.host.statusline);
   return (
     <section className="-mx-4 grid gap-5 border-border border-y bg-muted/10 px-4 py-5 sm:-mx-6 sm:px-6">
@@ -795,7 +804,7 @@ function PreviewFlow(props: {
 
   const agentChanges = preview?.plan.agentChanges ?? [];
   const linkedAndCovered =
-    props.host.ratelEntryCount > 0 && missingRatelEntryNames(props.host).length === 0;
+    props.host.connection.linked && missingRatelEntryNames(props.host).length === 0;
   const friendlyNoOp = Boolean(
     preview?.emptyReason && linkedAndCovered && props.availableSkills.length === 0,
   );
@@ -803,10 +812,10 @@ function PreviewFlow(props: {
     () =>
       beginAgentImportWorkflow({
         hostKind: props.hostKind,
-        linked: props.host.ratelEntryCount > 0,
+        linked: props.host.connection.linked,
         statuslineInstalled: props.host.statusline?.status === "installed",
       }),
-    [props.host.ratelEntryCount, props.host.statusline?.status, props.hostKind],
+    [props.host.connection.linked, props.host.statusline?.status, props.hostKind],
   );
 
   const applyRatel = async (
@@ -2166,7 +2175,13 @@ function LinkStatusBadge(props: { host: DetectedAgentHostSummary }) {
   if (props.host.posture === "unavailable") {
     return <StatusBadge tone="muted">Unavailable</StatusBadge>;
   }
-  if (props.host.ratelEntryCount > 0) {
+  if (props.host.connection.kind === "duplicate") {
+    return <StatusBadge tone="warning">Duplicate connection</StatusBadge>;
+  }
+  if (props.host.connection.kind === "plugin") {
+    return <StatusBadge tone="success">Linked via plugin</StatusBadge>;
+  }
+  if (props.host.connection.linked) {
     return <StatusBadge tone="success">Linked</StatusBadge>;
   }
   return <StatusBadge tone="muted">Not linked</StatusBadge>;


### PR DESCRIPTION
## Summary

- Detect Ratel Local connections declared through Claude Code and Codex plugin configuration.
- Prefer plugin installation for linking, with a reviewed and backed-up explicit MCP fallback when installation fails.
- Re-enable a disabled bundled Codex MCP server instead of adding a duplicate gateway.
- Surface plugin-plus-explicit duplicates and provide a safe Agent Setup repair action.
- Offer MCP-only installations a plugin promotion path that preserves the working MCP connection if installation fails.

## Validation

- Full test suite: 660 tests
- Typecheck
- Biome
