### PR TITLE
release: v0.5.0-rc.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this package are documented here. The format is based on 
 
 ## [Unreleased]
 
+## [0.5.0-rc.0] - 2026-07-15
+
 ### Changed
 - Made the Ratel Local plugin the preferred link path in both CLI and UI flows so Codex and Claude Code receive the bundled agent skills; when plugin installation fails, linking reports the failure and applies the reviewed, backed-up explicit MCP gateway fallback.
 - Made Claude Code and Codex linking plugin-aware: enabled `ratel-local` plugins now count as host-level Ratel connections in CLI/UI import and link flows, avoiding a second explicit gateway; linking re-enables a disabled Codex plugin MCP server; explicit-plus-plugin duplicates are reported without automatic cleanup.

--- a/apps/ratel-local/package.json
+++ b/apps/ratel-local/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ratel-ai/ratel-local",
-  "version": "0.4.0",
+  "version": "0.5.0-rc.0",
   "description": "Ratel Local package: an MCP server library plus the ratel-local CLI for managing upstream MCP servers, OAuth, and agent imports from one binary.",
   "private": false,
   "type": "module",

--- a/apps/ratel-local/plugin/.claude-plugin/plugin.json
+++ b/apps/ratel-local/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ratel-local",
   "displayName": "Ratel Local",
-  "version": "0.4.0",
+  "version": "0.5.0-rc.0",
   "description": "Ratel Local gateway plugin for exposing curated upstream MCP tools through search_capabilities and invoke_tool.",
   "author": {
     "name": "Agentified",

--- a/apps/ratel-local/plugin/.codex-plugin/plugin.json
+++ b/apps/ratel-local/plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ratel-local",
-  "version": "0.4.0",
+  "version": "0.5.0-rc.0",
   "description": "Ratel Local gateway plugin for exposing curated upstream MCP tools through search_capabilities and invoke_tool.",
   "author": {
     "name": "Agentified",

--- a/apps/ratel-local/plugin/.mcp.json
+++ b/apps/ratel-local/plugin/.mcp.json
@@ -5,7 +5,7 @@
       "command": "npx",
       "args": [
         "-y",
-        "@ratel-ai/ratel-local@latest",
+        "@ratel-ai/ratel-local@0.5.0-rc.0",
         "serve",
         "--auto-config"
       ]


### PR DESCRIPTION
Prepares the 0.5.0 release candidate.\n\n- Bumps the published package and bundled plugin manifests to 0.5.0-rc.0.\n- Pins the plugin MCP runtime to @ratel-ai/ratel-local@0.5.0-rc.0.\n- Adds the 0.5.0-rc.0 changelog entry.\n\nValidated with the package-integrity check and JSON version/runtime assertions.\n\nThis is intentionally stacked on #29. After #29 merges, rebase this branch onto main and retarget this PR before merging.