### PR TITLE
release: v0.5.0-rc.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this package are documented here. The format is based on 
 
 ## [Unreleased]
 
+## [0.5.0-rc.0] - 2026-07-15
+
 ### Changed
 - Made the Ratel Local plugin the preferred link path in both CLI and UI flows so Codex and Claude Code receive the bundled agent skills; when plugin installation fails, linking reports the failure and applies the reviewed, backed-up explicit MCP gateway fallback.
 - Made Claude Code and Codex linking plugin-aware: enabled `ratel-local` plugins now count as host-level Ratel connections in CLI/UI import and link flows, avoiding a second explicit gateway; linking re-enables a disabled Codex plugin MCP server; explicit-plus-plugin duplicates are reported without automatic cleanup.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,16 @@ All notable changes to this package are documented here. The format is based on 
 
 ## [Unreleased]
 
-## [0.5.0-rc.0] - 2026-07-15
+## [0.5.0-rc.0] - 2026-07-17
 
 ### Changed
 - Made the Ratel Local plugin the preferred link path in both CLI and UI flows so Codex and Claude Code receive the bundled agent skills; when plugin installation fails, linking reports the failure and applies the reviewed, backed-up explicit MCP gateway fallback.
-- Made Claude Code and Codex linking plugin-aware: enabled `ratel-local` plugins now count as host-level Ratel connections in CLI/UI import and link flows, avoiding a second explicit gateway; linking re-enables a disabled Codex plugin MCP server; explicit-plus-plugin duplicates are reported without automatic cleanup.
+- Made Claude Code and Codex linking plugin-aware: enabled `ratel-local` plugins now count as host-level Ratel connections in CLI/UI import and link flows, avoiding a second explicit gateway; linking re-enables a disabled Codex plugin MCP server; explicit-plus-plugin duplicates are detected without silently deleting user configuration.
+- Strengthened the MCP server instructions so agents search Ratel capabilities before answering substantive requests or concluding that a workflow is unavailable, while exempting casual conversation and pure writing or reasoning.
 - Renamed Ratel MCP to Ratel Local: the repository moved from `ratel-ai/ratel-mcp` to `ratel-ai/ratel-local`, the npm package changed from `@ratel-ai/mcp-server` to `@ratel-ai/ratel-local`, and the CLI changed from `ratel-mcp` to `ratel-local`. This is a breaking package/CLI rename: reinstall the new package and rename `$RATEL_MCP_BIN` to `$RATEL_LOCAL_BIN`. Existing agent gateway entries named `ratel-mcp` remain recognized during import/link migration, while rewritten entries use `ratel-local`.
+
+### Fixed
+- Added Agent Setup actions to fix duplicate plugin-plus-MCP installations and promote MCP-only installations to the plugin for both Claude Code and Codex. Plugin promotion removes the explicit fallback only after installation succeeds, and cleanup preserves unrelated MCP entries.
 
 ## [0.4.0] - 2026-06-30
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Choose the setup that matches where you are starting:
 - **Migrate existing MCP servers:** install the CLI and import the servers already configured in Claude Code or Codex.
 - **Start fresh with the plugin:** let the plugin start Ratel Local, then add upstreams directly to Ratel Local configuration.
 
-The CLI and UI prefer the `ratel-local` plugin when linking because it bundles the gateway and agent skills. If plugin installation fails, Ratel Local reports the failure and applies the reviewed explicit MCP gateway fallback instead. An enabled plugin is recognized as an existing Ratel connection, so importing does not add a second gateway and `link` becomes a no-op. If the Codex plugin is enabled but its bundled Ratel MCP server is disabled, `link` re-enables that server. If both the plugin and an explicit Ratel MCP entry are present, Ratel Local reports the duplicate connection and leaves both installation paths unchanged.
+The CLI and UI prefer the `ratel-local` plugin when linking because it bundles the gateway and agent skills. If plugin installation fails, Ratel Local reports the failure and applies the reviewed explicit MCP gateway fallback instead. An enabled plugin is recognized as an existing Ratel connection, so importing does not add a second gateway and `link` becomes a no-op. If the Codex plugin is enabled but its bundled Ratel MCP server is disabled, `link` re-enables that server. Agent Setup offers **Fix duplicate installation** when both the plugin and an explicit Ratel MCP entry are present, and **Switch to plugin** for MCP-only installations. Both actions preserve the existing MCP connection unless plugin installation succeeds, and only recognized Ratel entries are removed.
 
 ### Migrate an existing MCP setup
 

--- a/apps/ratel-local/package.json
+++ b/apps/ratel-local/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ratel-ai/ratel-local",
-  "version": "0.4.0",
+  "version": "0.5.0-rc.0",
   "description": "Ratel Local package: an MCP server library plus the ratel-local CLI for managing upstream MCP servers, OAuth, and agent imports from one binary.",
   "private": false,
   "type": "module",

--- a/apps/ratel-local/plugin/.claude-plugin/plugin.json
+++ b/apps/ratel-local/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ratel-local",
   "displayName": "Ratel Local",
-  "version": "0.4.0",
+  "version": "0.5.0-rc.0",
   "description": "Ratel Local gateway plugin for exposing curated upstream MCP tools through search_capabilities and invoke_tool.",
   "author": {
     "name": "Agentified",

--- a/apps/ratel-local/plugin/.codex-plugin/plugin.json
+++ b/apps/ratel-local/plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ratel-local",
-  "version": "0.4.0",
+  "version": "0.5.0-rc.0",
   "description": "Ratel Local gateway plugin for exposing curated upstream MCP tools through search_capabilities and invoke_tool.",
   "author": {
     "name": "Agentified",

--- a/apps/ratel-local/plugin/.mcp.json
+++ b/apps/ratel-local/plugin/.mcp.json
@@ -5,7 +5,7 @@
       "command": "npx",
       "args": [
         "-y",
-        "@ratel-ai/ratel-local@latest",
+        "@ratel-ai/ratel-local@0.5.0-rc.0",
         "serve",
         "--auto-config"
       ]

--- a/apps/ratel-local/plugin/README.md
+++ b/apps/ratel-local/plugin/README.md
@@ -24,7 +24,7 @@ shared `assets/icon.svg` remains referenced by the Codex manifest.
 The plugin MCP config starts Ratel over stdio through `npx`:
 
 ```bash
-npx -y @ratel-ai/ratel-local@latest serve --auto-config
+npx -y @ratel-ai/ratel-local@0.5.0-rc.0 serve --auto-config
 ```
 
 `--auto-config` loads `~/.ratel/config.json` plus project and local Ratel configs when a project root is discoverable.

--- a/apps/ratel-local/plugin/skills/ratel-local/SKILL.md
+++ b/apps/ratel-local/plugin/skills/ratel-local/SKILL.md
@@ -17,7 +17,7 @@ Keep the plugin MCP definition limited to starting the Ratel gateway. Put upstre
 
 ## Plugin Runtime
 
-The plugin `.mcp.json` starts Ratel over stdio through `npx` with `@ratel-ai/ratel-local@latest` and `serve --auto-config`. Do not duplicate upstream MCP definitions into the plugin `.mcp.json`.
+The plugin `.mcp.json` starts Ratel over stdio through `npx` with `@ratel-ai/ratel-local@0.5.0-rc.0` and `serve --auto-config`. Do not duplicate upstream MCP definitions into the plugin `.mcp.json`.
 
 For human CLI work, install the package globally and use the `ratel-local` bin:
 
@@ -210,7 +210,7 @@ ratel-local backup list
 ## Debug Checklist
 
 1. Confirm Node and `npx` are available.
-2. Confirm the plugin `.mcp.json` starts `@ratel-ai/ratel-local@latest` with `serve --auto-config`.
+2. Confirm the plugin `.mcp.json` starts `@ratel-ai/ratel-local@0.5.0-rc.0` with `serve --auto-config`.
 3. Run `ratel-local mcp list` to verify Ratel config has upstreams.
 4. Run `ratel-local serve --auto-config` from the relevant project to reproduce startup outside the host.
 5. For HTTP/SSE upstreams, run `ratel-local mcp auth --check` or `ratel-local mcp auth <name>`.

--- a/apps/ratel-local/scripts/check-pack.ts
+++ b/apps/ratel-local/scripts/check-pack.ts
@@ -6,6 +6,19 @@ const appRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const dist = resolve(appRoot, "dist");
 
 const packageJson = await readJson(resolve(appRoot, "package.json"));
+for (const workspacePackagePath of [
+  "../../package.json",
+  "../../packages/core/package.json",
+  "../../packages/ui/package.json",
+]) {
+  const workspacePackage = await readJson(resolve(appRoot, workspacePackagePath));
+  if (workspacePackage.version !== packageJson.version) {
+    throw new Error(
+      `${workspacePackagePath} version ${String(workspacePackage.version)} does not match published package version ${String(packageJson.version)}`,
+    );
+  }
+}
+
 for (const manifestPath of [
   "plugin/.codex-plugin/plugin.json",
   "plugin/.claude-plugin/plugin.json",

--- a/apps/ratel-local/scripts/check-pack.ts
+++ b/apps/ratel-local/scripts/check-pack.ts
@@ -18,6 +18,15 @@ for (const manifestPath of [
   }
 }
 
+const pluginMcp = await readJson<{
+  mcpServers?: Record<string, { args?: unknown }>;
+}>(resolve(appRoot, "plugin/.mcp.json"));
+const pluginArgs = pluginMcp.mcpServers?.["ratel-local"]?.args;
+const expectedRuntime = `@ratel-ai/ratel-local@${String(packageJson.version)}`;
+if (!Array.isArray(pluginArgs) || !pluginArgs.includes(expectedRuntime)) {
+  throw new Error(`plugin/.mcp.json must pin the runtime to ${expectedRuntime}`);
+}
+
 await mustExist(resolve(dist, "bin.js"));
 await mustExist(resolve(dist, "index.js"));
 await mustExist(resolve(dist, "index.d.ts"));
@@ -49,8 +58,8 @@ async function mustExist(path: string): Promise<void> {
   }
 }
 
-async function readJson(path: string): Promise<{ version?: unknown }> {
-  return JSON.parse(await readFile(path, "utf8")) as { version?: unknown };
+async function readJson<T = { version?: unknown }>(path: string): Promise<T> {
+  return JSON.parse(await readFile(path, "utf8")) as T;
 }
 
 async function listFiles(dir: string): Promise<string[]> {

--- a/docs/adr/0005-prefer-agent-plugins-for-linking.md
+++ b/docs/adr/0005-prefer-agent-plugins-for-linking.md
@@ -1,0 +1,31 @@
+# 5. Prefer agent plugins for linking
+
+Date: 2026-07-17
+
+## Status
+
+Accepted
+
+## Context
+
+Ratel Local can connect to Claude Code and Codex either through the Ratel Local plugin or through an explicit MCP server entry in the agent configuration. The plugin is the richer installation because it bundles the gateway, operational skills, and hooks, while the explicit MCP entry remains a useful fallback when plugin installation is unavailable.
+
+Treating these paths independently can register the gateway twice. Duplicate connections waste resources and make ownership unclear, but automatically deleting configuration during detection would mutate user state without review. Migrating an existing explicit connection also needs to avoid leaving the agent disconnected when plugin installation fails.
+
+## Decision
+
+- Prefer installing the `ratel-local` plugin when linking Claude Code or Codex.
+- Fall back to a reviewed, backed-up explicit MCP gateway change only when plugin installation fails.
+- Model the host-level Ratel connection as `none`, `explicit`, `plugin`, or `duplicate`, and surface that state consistently in CLI and UI flows.
+- Treat an enabled plugin as an existing Ratel connection. Do not add another explicit gateway, and re-enable the bundled Codex MCP server when the plugin is enabled but that server is disabled.
+- Detect duplicate plugin-plus-explicit installations without changing either path automatically. Agent Setup may offer an explicit repair action that keeps the plugin and removes only entries positively identified as Ratel gateways.
+- For MCP-only promotion, install the plugin first and remove the explicit gateway only after installation succeeds. If installation fails, preserve the existing MCP connection unchanged.
+- Use the normal agent-config preview, rewrite, and backup machinery for every explicit gateway removal, preserving unrelated MCP entries and scopes.
+
+## Consequences
+
+- Claude Code and Codex receive the bundled plugin capabilities whenever installation is supported.
+- Linking remains usable in environments where the plugin installer is missing or fails.
+- Detection is read-only; users choose when duplicate configuration is removed.
+- Plugin promotion cannot disconnect a working MCP-only installation merely because plugin installation failed.
+- Host adapters remain responsible for format-preserving JSON or TOML rewrites, while connection policy stays shared across hosts.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ratel-local-workspace",
-  "version": "0.3.0",
+  "version": "0.5.0-rc.0",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.33.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ratel-ai/ratel-local-core",
-  "version": "0.3.0",
+  "version": "0.5.0-rc.0",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/core/src/lib/server.test.ts
+++ b/packages/core/src/lib/server.test.ts
@@ -124,7 +124,12 @@ describe("createMcpServer", () => {
     const instructions = client.getInstructions();
     expect(instructions).toBeDefined();
     expect(instructions).toMatch(/search_capabilities/);
-    expect(instructions?.toLowerCase()).toMatch(/before/);
+    expect(instructions).toMatch(/Before responding to a substantive user request/);
+    expect(instructions).toMatch(/even when you could answer from general knowledge/);
+    expect(instructions).toMatch(
+      /Always search before saying information or a workflow is unavailable/,
+    );
+    expect(instructions).toMatch(/Skip the search only for casual conversation/);
 
     await client.close();
     await handle.close();

--- a/packages/core/src/lib/server.ts
+++ b/packages/core/src/lib/server.ts
@@ -121,9 +121,12 @@ function buildServerInstructions(
   hasSkills = false,
 ): string {
   const base =
-    "This is the Ratel context-engineering gateway. Before reaching for any built-in capability " +
-    "(web fetch, shell, search, automation, etc.), call `search_capabilities` first — Ratel may have a " +
-    "purpose-built tool or skill for the task. Run a returned tool via `invoke_tool`.";
+    "This is the Ratel context-engineering gateway. Before responding to a substantive user request, " +
+    "call `search_capabilities` first — even when you could answer from general knowledge or think you " +
+    "lack access. Ratel may have a purpose-built tool or skill. Always search before saying information " +
+    "or a workflow is unavailable. Skip the search only for casual conversation, simple acknowledgments, " +
+    "clarifying questions, or requests that are plainly pure writing or reasoning with no plausible " +
+    "task-specific capability. When in doubt, search. Run a returned tool via `invoke_tool`.";
   const skills = hasSkills
     ? " The search also returns a `skills` bucket (reusable playbooks); load one in full via " +
       "`get_skill_content` and follow it."

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ratel-ai/ratel-local-ui",
   "private": true,
-  "version": "0.3.0",
+  "version": "0.5.0-rc.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary

- Bump the published package and bundled plugin manifests to 0.5.0-rc.0.
- Pin the plugin MCP runtime to @ratel-ai/ratel-local@0.5.0-rc.0 and validate that pin during package checks.
- Strengthen MCP capability-search guidance.
- Complete README and changelog coverage for plugin promotion and duplicate-install repair.
- Record the plugin-first linking policy in ADR 0005.

## Validation

- Full test suite: 660 tests
- Typecheck and production build
- Package integrity check

PR #29 has merged; this branch is rebased onto main. No release tag will be created yet.
