### PR TITLE
docs: add AGENTS.md and CLAUDE.md with ways-of-working rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,41 @@
+# AGENTS.md
+
+Guidance for coding agents working on **Ratel Local** — the MCP gateway that fronts
+Claude Code / Codex / Cursor with capability search. Shipped as `@ratel-ai/ratel-local`.
+
+pnpm workspace: `packages/core`, `packages/ui`, `apps/ratel-local`, `e2e/`.
+
+## Setup
+
+- Node 24+, pnpm 10+.
+- `pnpm install`
+
+## Core commands
+
+```bash
+pnpm build       # tsc → dist/
+pnpm typecheck
+pnpm lint        # biome
+pnpm test        # vitest
+```
+
+CI (`.github/workflows/ts.yml`) runs all four on every PR. **Land green.**
+
+## Rules
+
+- **TDD on library and CLI logic.** Red → green → refactor (vitest).
+- **Conventional-commits-ish prefixes:** `feat:`, `fix:`, `chore:`, `docs:`, `refactor:`, `ci:`. Scopes optional but useful (`fix(cli):`).
+- **No tool-attribution lines in commit messages** (no `Co-Authored-By: Claude`, etc.).
+- **Keep PRs focused** — one logical change per PR. Update `README.md` / `CHANGELOG.md` in the same PR when the change affects them.
+- **ADRs are immutable once Accepted** (`docs/adr/`) — supersede with a new ADR rather than editing.
+
+## Ways of working
+
+- **Avoid breaking changes whenever avoidable.** Prefer additive, backward-compatible changes. When a break is genuinely unavoidable, call it out explicitly (PR description + `CHANGELOG.md`) and provide a migration path.
+- **Develop behind feature flags.** Gate new features — and any change to existing behaviour — behind a flag/config that is **off by default**, so it can ship dark, be rolled out incrementally, and be reverted without a code change. Remove the flag once the behaviour is the stable default.
+
+## More detail
+
+- Contributing & conventions: [`CONTRIBUTING.md`](CONTRIBUTING.md)
+- Release process: [`RELEASING.md`](RELEASING.md)
+- Architecture decisions: [`docs/adr/`](docs/adr/)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,6 +26,11 @@ CI (`.github/workflows/ts.yml`) runs all of these on every PR. Land green.
 - **No tool-attribution lines** in commit messages (no `Co-Authored-By: Claude` etc.).
 - **ADRs are immutable once Accepted** — write a new ADR that supersedes the old one rather than editing.
 
+## Ways of working
+
+- **Avoid breaking changes whenever avoidable.** Prefer additive, backward-compatible changes. When a break is genuinely unavoidable, call it out explicitly (PR description + `CHANGELOG.md`) and provide a migration path.
+- **Develop behind feature flags.** Gate new features — and any change to existing behaviour — behind a flag/config that is off by default, so it can ship dark, be rolled out incrementally, and be reverted without a code change. Remove the flag once the behaviour is the stable default.
+
 ## Pull requests
 
 - Keep PRs focused — one logical change per PR.


### PR DESCRIPTION
Adds a minimal `AGENTS.md` capturing the main contributor rules (setup, core commands, conventions) and a `CLAUDE.md` whose sole content is `@AGENTS.md`, so agent guidance has a single source of truth. Introduces a "Ways of working" section — shared between `AGENTS.md` and `CONTRIBUTING.md` — that codifies avoiding breaking changes whenever avoidable and developing new features (and behaviour changes) behind feature flags that are off by default.