### PR TITLE
RL2-2: Upgrade Ratel SDK to 0.5.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 node_modules/
 .pnpm-store/
 .ratel/
+.kestral/
 tmp/
 
 # Build output

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this package are documented here. The format is based on [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/), and this package adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+- Upgraded `@ratel-ai/sdk` to 0.5.2. Direct SDK consumers must now await `ToolCatalog.register()` and `SkillCatalog.register()`; Ratel Local awaits every registration and batches gateway skills in one call.
+
 ## [0.6.0-rc.0] - 2026-07-17
 
 ### Added

--- a/apps/ratel-local/package.json
+++ b/apps/ratel-local/package.json
@@ -29,7 +29,7 @@
     "oauth"
   ],
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=20.6.0"
   },
   "packageManager": "pnpm@10.33.0",
   "bin": {
@@ -61,7 +61,7 @@
   "dependencies": {
     "@clack/prompts": "^1.3.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
-    "@ratel-ai/sdk": "^0.2.0",
+    "@ratel-ai/sdk": "^0.5.2",
     "proper-lockfile": "^4.1.2",
     "smol-toml": "^1.6.1"
   }

--- a/apps/ratel-local/src/cli/skills/suggest.ts
+++ b/apps/ratel-local/src/cli/skills/suggest.ts
@@ -77,7 +77,7 @@ export async function suggestSkills(
   if (skills.length === 0) return [];
 
   const catalog = new SkillCatalog();
-  for (const s of skills) catalog.register(s);
+  await catalog.register(skills);
 
   // Project context is a boost set, not a query term.
   const signals = input.cwd

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
-    "@ratel-ai/sdk": "^0.2.0",
+    "@ratel-ai/sdk": "^0.5.2",
     "proper-lockfile": "^4.1.2",
     "smol-toml": "^1.6.1"
   }

--- a/packages/core/src/lib/gateway.test.ts
+++ b/packages/core/src/lib/gateway.test.ts
@@ -6,6 +6,7 @@ import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
 import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
+import { type Skill, SkillCatalog } from "@ratel-ai/sdk";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   buildGatewayFromConfig,
@@ -47,6 +48,55 @@ async function startUpstream(tools: UpstreamSpec[], instructions?: string) {
 }
 
 describe("buildGatewayFromConfig", () => {
+  it("awaits one batched registration for resolved gateway skills", async () => {
+    const skills: Skill[] = [
+      {
+        id: "api-design",
+        name: "API design",
+        description: "Design stable HTTP APIs.",
+      },
+      {
+        id: "database-migrations",
+        name: "Database migrations",
+        description: "Plan safe database schema changes.",
+      },
+    ];
+    const originalRegister = SkillCatalog.prototype.register;
+    let releaseRegistration: (() => void) | undefined;
+    const registrationGate = new Promise<void>((resolve) => {
+      releaseRegistration = resolve;
+    });
+    const register = vi
+      .spyOn(SkillCatalog.prototype, "register")
+      .mockImplementation(async function (registeredSkills) {
+        await registrationGate;
+        await originalRegister.call(this, registeredSkills);
+      });
+    let settled = false;
+    const pending = buildGatewayFromConfig({ mcpServers: {} }, { resolvedSkills: skills }).then(
+      (handle) => {
+        settled = true;
+        return handle;
+      },
+    );
+
+    try {
+      await Promise.resolve();
+      expect(register).toHaveBeenCalledTimes(1);
+      expect(register).toHaveBeenCalledWith(skills);
+      expect(settled).toBe(false);
+
+      releaseRegistration?.();
+      const handle = await pending;
+      expect(handle.skillCatalog.has("api-design")).toBe(true);
+      expect(handle.skillCatalog.has("database-migrations")).toBe(true);
+      await handle.close();
+    } finally {
+      releaseRegistration?.();
+      register.mockRestore();
+    }
+  });
+
   it("registers tools from every upstream the factory wires up, namespaced by entry key", async () => {
     const fs = await startUpstream([
       { name: "read_file", description: "Read a file from local disk." },

--- a/packages/core/src/lib/gateway.ts
+++ b/packages/core/src/lib/gateway.ts
@@ -268,15 +268,17 @@ async function buildSkillCatalog(
 ): Promise<SkillCatalog> {
   const skillCatalog = new SkillCatalog(options.trace ? { trace: options.trace } : {});
   if (options.resolvedSkills) {
-    for (const skill of options.resolvedSkills) skillCatalog.register(skill);
+    if (options.resolvedSkills.length > 0) {
+      await skillCatalog.register(options.resolvedSkills);
+    }
     return skillCatalog;
   }
   const dirs = options.skillDirs ?? config.skills?.dirs ?? defaultSkillDirs();
   const load = options.loadSkills ?? loadSkills;
   try {
     const skills = await load(dirs, { logger: log });
-    for (const skill of skills) skillCatalog.register(skill);
     if (skills.length > 0) {
+      await skillCatalog.register(skills);
       log(`[ratel] loaded ${skills.length} skill(s)`);
     }
   } catch (err) {

--- a/packages/core/src/lib/server.test.ts
+++ b/packages/core/src/lib/server.test.ts
@@ -163,7 +163,7 @@ describe("createMcpServer", () => {
 
   it("exposes search_capabilities, invoke_tool, and the deprecated search_tools alias via tools/list", async () => {
     const catalog = new ToolCatalog();
-    catalog.register(localTool("echo", "Echo a message back to the caller.", (a) => a));
+    await catalog.register(localTool("echo", "Echo a message back to the caller.", (a) => a));
 
     const { client, handle } = await buildClientAgainst(catalog);
     const { tools } = await client.listTools();
@@ -180,7 +180,7 @@ describe("createMcpServer", () => {
 
   it("search_tools (deprecated) still returns the pre-0.2.0 tools-only {groups} shape", async () => {
     const catalog = new ToolCatalog();
-    catalog.register(
+    await catalog.register(
       localTool("wx__weather", "Get the current weather forecast for a city.", () => ({})),
     );
 
@@ -216,10 +216,10 @@ describe("createMcpServer", () => {
 
   it("search_capabilities roundtrips BM25 hits grouped by upstream MCP", async () => {
     const catalog = new ToolCatalog();
-    catalog.register(
+    await catalog.register([
       localTool("wx__weather", "Get the current weather forecast for a city.", () => ({})),
-    );
-    catalog.register(localTool("util__echo", "Echo a message back to the caller.", (a) => a));
+      localTool("util__echo", "Echo a message back to the caller.", (a) => a),
+    ]);
 
     const [serverTransport, clientTransport] = InMemoryTransport.createLinkedPair();
     const handle = await createMcpServer(catalog, {
@@ -264,7 +264,7 @@ describe("createMcpServer", () => {
 
   it("search_capabilities surfaces the upstream's official `instructions` on each group, separately from any user description", async () => {
     const catalog = new ToolCatalog();
-    catalog.register(
+    await catalog.register(
       localTool("wx__weather", "Get the current weather forecast for a city.", () => ({})),
     );
 
@@ -307,7 +307,7 @@ describe("createMcpServer", () => {
 
   it("invoke_tool runs a locally-registered tool and returns its output as structuredContent", async () => {
     const catalog = new ToolCatalog();
-    catalog.register(
+    await catalog.register(
       localTool("upper", "Uppercase a message.", (a) => ({
         upper: ((a as { msg: string }).msg ?? "").toUpperCase(),
       })),
@@ -345,7 +345,7 @@ describe("createMcpServer", () => {
 
   it("invoke_tool surfaces the gateway's wrapped error when the executor throws", async () => {
     const catalog = new ToolCatalog();
-    catalog.register(
+    await catalog.register(
       localTool("boom", "Always throws.", () => {
         throw new Error("kaboom");
       }),
@@ -366,7 +366,7 @@ describe("createMcpServer", () => {
 
   it("close() tears down the connection so subsequent calls reject", async () => {
     const catalog = new ToolCatalog();
-    catalog.register(localTool("echo", "Echo.", (a) => a));
+    await catalog.register(localTool("echo", "Echo.", (a) => a));
 
     const { client, handle } = await buildClientAgainst(catalog);
     await handle.close();
@@ -511,7 +511,7 @@ describe("createMcpServer", () => {
         this.name = "UnauthorizedError";
       }
     }
-    catalog.register({
+    await catalog.register({
       id: "stripe__charges",
       name: "stripe__charges",
       description: "...",
@@ -596,9 +596,11 @@ describe("createMcpServer", () => {
 });
 
 describe("createMcpServer skills", () => {
-  function skillCatalogWith(...skills: Skill[]): SkillCatalog {
+  async function skillCatalogWith(...skills: Skill[]): Promise<SkillCatalog> {
     const catalog = new SkillCatalog();
-    for (const s of skills) catalog.register(s);
+    if (skills.length > 0) {
+      await catalog.register(skills);
+    }
     return catalog;
   }
 
@@ -616,7 +618,7 @@ describe("createMcpServer skills", () => {
       name: "ratel-test",
       version: "0.0.0",
       transport: serverTransport,
-      skillCatalog: skillCatalogWith(apiDesign),
+      skillCatalog: await skillCatalogWith(apiDesign),
     });
     const client = new Client({ name: "test-client", version: "0.0.0" });
     await client.connect(clientTransport);
@@ -636,7 +638,7 @@ describe("createMcpServer skills", () => {
       name: "ratel-test",
       version: "0.0.0",
       transport: serverTransport,
-      skillCatalog: skillCatalogWith(),
+      skillCatalog: await skillCatalogWith(),
     });
     const client = new Client({ name: "test-client", version: "0.0.0" });
     await client.connect(clientTransport);
@@ -652,7 +654,7 @@ describe("createMcpServer skills", () => {
 
   it("search_capabilities returns a skills bucket alongside the tools bucket", async () => {
     const toolCatalog = new ToolCatalog();
-    toolCatalog.register({
+    await toolCatalog.register({
       id: "vercel__deploy",
       name: "deploy",
       description: "Deploy the current project to Vercel.",
@@ -665,7 +667,7 @@ describe("createMcpServer skills", () => {
       name: "ratel-test",
       version: "0.0.0",
       transport: serverTransport,
-      skillCatalog: skillCatalogWith({
+      skillCatalog: await skillCatalogWith({
         id: "vercel-deploy",
         name: "vercel-deploy",
         description: "How to deploy to Vercel: env vars, preview vs production, rollbacks.",
@@ -697,7 +699,7 @@ describe("createMcpServer skills", () => {
       name: "ratel-test",
       version: "0.0.0",
       transport: serverTransport,
-      skillCatalog: skillCatalogWith(apiDesign),
+      skillCatalog: await skillCatalogWith(apiDesign),
     });
     const client = new Client({ name: "test-client", version: "0.0.0" });
     await client.connect(clientTransport);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,7 +28,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.5
-        version: 4.1.6(@types/node@24.12.4)(msw@2.14.6(@types/node@24.12.4)(typescript@5.9.3))(vite@8.0.12(@types/node@24.12.4)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.22.3))
+        version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(msw@2.14.6(@types/node@24.12.4)(typescript@5.9.3))(vite@8.0.12(@types/node@24.12.4)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.22.3))
 
   apps/ratel-local:
     dependencies:
@@ -39,8 +39,8 @@ importers:
         specifier: ^1.29.0
         version: 1.29.0(zod@4.4.3)
       '@ratel-ai/sdk':
-        specifier: ^0.2.0
-        version: 0.2.0(zod@4.4.3)
+        specifier: ^0.5.2
+        version: 0.5.2(zod@4.4.3)
       proper-lockfile:
         specifier: ^4.1.2
         version: 4.1.2
@@ -61,8 +61,8 @@ importers:
         specifier: ^1.29.0
         version: 1.29.0(zod@4.4.3)
       '@ratel-ai/sdk':
-        specifier: ^0.2.0
-        version: 0.2.0(zod@4.4.3)
+        specifier: ^0.5.2
+        version: 0.5.2(zod@4.4.3)
       proper-lockfile:
         specifier: ^4.1.2
         version: 4.1.2
@@ -895,6 +895,10 @@ packages:
   '@open-draft/until@2.1.0':
     resolution: {integrity: sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==}
 
+  '@opentelemetry/api@1.9.1':
+    resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
+    engines: {node: '>=8.0.0'}
+
   '@oxc-project/types@0.129.0':
     resolution: {integrity: sha512-3oz8m3FGdr2nDXVqmFUw7jolKliC4MoyXYIG2c7gpjBnzUWQpUGIYcXYKxTdTi+N2jusvt610ckTMkxdwHkYEg==}
 
@@ -1091,41 +1095,50 @@ packages:
       '@types/react':
         optional: true
 
-  '@ratel-ai/sdk-darwin-arm64@0.2.0':
-    resolution: {integrity: sha512-RIXMLc46GlJqCBgoifVPEw8+NPPtj8VzIDG12n0EW96OOmdKQzzXRAfYr5qZ+sdY3T1zD8FmH0EFYszc1Fu4Yw==}
+  '@ratel-ai/sdk-darwin-arm64@0.5.2':
+    resolution: {integrity: sha512-BgJphJTARgGvHQDuh5KHXYXGauO/DgzWYLI4i8s9cvF6yWHGFHo/7Njc8XpnxIAvoe7WP6cI9mj7YDHWUWFWwg==}
     engines: {node: '>=20.0.0'}
     cpu: [arm64]
     os: [darwin]
 
-  '@ratel-ai/sdk-darwin-x64@0.2.0':
-    resolution: {integrity: sha512-xguey9AT8TmH++gK0Ol4ryghlZtKBb4GhbW+mJHHHZLTThMXbT63dcgxA3jYZnwZ5CadY7UZsXzh+0iowbE5Yg==}
+  '@ratel-ai/sdk-darwin-x64@0.5.2':
+    resolution: {integrity: sha512-Saye9vaTK98uF5yxC+7BOmZMKI6m4ZOi7BwpGIJs6l1TbTQEA0Ne29pExNIxy+gqGB5uIVU34pTrRxNHZbs/hg==}
     engines: {node: '>=20.0.0'}
     cpu: [x64]
     os: [darwin]
 
-  '@ratel-ai/sdk-linux-arm64-gnu@0.2.0':
-    resolution: {integrity: sha512-k2U815Xn/s9ShA9OyaeQl67XBCQz4Tp3HDinuKfW8Xp4mNex0I2ObkZhbYwEzPcdKjBuCxvnBORQQHiYzAvkQg==}
+  '@ratel-ai/sdk-linux-arm64-gnu@0.5.2':
+    resolution: {integrity: sha512-OisEdMJH83lNMiyZ9XtouWNzw0Y3vkKHhQzW9j9z9tVrHfSHo36xJhdFn/J6qqobHnB1p1wHX1TIdaNLNYSqsQ==}
     engines: {node: '>=20.0.0'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@ratel-ai/sdk-linux-x64-gnu@0.2.0':
-    resolution: {integrity: sha512-W6oaCK1a9mcCJjTZkqH8drbSqhKdGOyHsRsz36Bs7RMmWzfWfWKr5nQlv2ym/tT/clGXwReQb9FYOH+VBbm/xw==}
+  '@ratel-ai/sdk-linux-x64-gnu@0.5.2':
+    resolution: {integrity: sha512-RGXDMMjN/IPaxQEzOW3GWs6/SRBf3lUlrejo9nPKOaBf+OlNrrpPp82KqPqGRXoyUUzLFIBlhRi+0zBkPQ9a0A==}
     engines: {node: '>=20.0.0'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@ratel-ai/sdk-win32-x64-msvc@0.2.0':
-    resolution: {integrity: sha512-Uz5jtKNC7t2ki9ThwatNZS+tzi6XPbOrhNcUUj7Hp3Ttw3lZn9LzpoEbhodL3Dl5g2ntIXP01Viyh++rJSZzTg==}
+  '@ratel-ai/sdk-win32-x64-msvc@0.5.2':
+    resolution: {integrity: sha512-7r7QmIVAkYN+1jW4j7ZxPtl2wWhm4AFb7IS8c5GFWYbX3Ci5TcQYiBnWNYekD0wTsENnngY0fY6hZAyN7F9KXw==}
     engines: {node: '>=20.0.0'}
     cpu: [x64]
     os: [win32]
 
-  '@ratel-ai/sdk@0.2.0':
-    resolution: {integrity: sha512-U357euk4lQUUXooHWcGYUCNGmHDFo6myJWrM8sy1YtZaQWGSN7TMFwMn1TfNL6dIUTv0TqShcx6fw7RPXdx3kw==}
+  '@ratel-ai/sdk@0.5.2':
+    resolution: {integrity: sha512-tslEGA8llSNzqkLCaW7PWyz+ScNmzZHN4gKSGEsLRL73pulAc77InqbLrV0yqMEbfhyi4sVWN+yXihxr1GoH6g==}
     engines: {node: '>=20.0.0'}
+    peerDependencies:
+      '@ratel-ai/telemetry-otlp': ^0.1.1
+    peerDependenciesMeta:
+      '@ratel-ai/telemetry-otlp':
+        optional: true
+
+  '@ratel-ai/telemetry@0.1.2':
+    resolution: {integrity: sha512-8P/2E9U74dbjB1WRT5H2K8KDHoRMxDEl77sv53kGKeQCvSxO0WbtnvHLkYXjUDm83zm3p45ww80Jym+g+xsJ7A==}
+    engines: {node: '>=20.6.0'}
 
   '@reduxjs/toolkit@2.12.0':
     resolution: {integrity: sha512-KiT+RzZbp6mQET+Mg+h2c97+9j1sNflUxQkIHI7Yuzf6Peu+OYpmkn6nbHWmLLWj+1ZODUJFwGZ7gx3L9R9EOw==}
@@ -4443,6 +4456,8 @@ snapshots:
 
   '@open-draft/until@2.1.0': {}
 
+  '@opentelemetry/api@1.9.1': {}
+
   '@oxc-project/types@0.129.0': {}
 
   '@radix-ui/primitive@1.1.3': {}
@@ -4604,35 +4619,39 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.15
 
-  '@ratel-ai/sdk-darwin-arm64@0.2.0':
+  '@ratel-ai/sdk-darwin-arm64@0.5.2':
     optional: true
 
-  '@ratel-ai/sdk-darwin-x64@0.2.0':
+  '@ratel-ai/sdk-darwin-x64@0.5.2':
     optional: true
 
-  '@ratel-ai/sdk-linux-arm64-gnu@0.2.0':
+  '@ratel-ai/sdk-linux-arm64-gnu@0.5.2':
     optional: true
 
-  '@ratel-ai/sdk-linux-x64-gnu@0.2.0':
+  '@ratel-ai/sdk-linux-x64-gnu@0.5.2':
     optional: true
 
-  '@ratel-ai/sdk-win32-x64-msvc@0.2.0':
+  '@ratel-ai/sdk-win32-x64-msvc@0.5.2':
     optional: true
 
-  '@ratel-ai/sdk@0.2.0(zod@4.4.3)':
+  '@ratel-ai/sdk@0.5.2(zod@4.4.3)':
     dependencies:
       '@modelcontextprotocol/sdk': 1.29.0(zod@4.4.3)
+      '@opentelemetry/api': 1.9.1
+      '@ratel-ai/telemetry': 0.1.2
       '@types/json-schema': 7.0.15
     optionalDependencies:
-      '@ratel-ai/sdk-darwin-arm64': 0.2.0
-      '@ratel-ai/sdk-darwin-x64': 0.2.0
-      '@ratel-ai/sdk-linux-arm64-gnu': 0.2.0
-      '@ratel-ai/sdk-linux-x64-gnu': 0.2.0
-      '@ratel-ai/sdk-win32-x64-msvc': 0.2.0
+      '@ratel-ai/sdk-darwin-arm64': 0.5.2
+      '@ratel-ai/sdk-darwin-x64': 0.5.2
+      '@ratel-ai/sdk-linux-arm64-gnu': 0.5.2
+      '@ratel-ai/sdk-linux-x64-gnu': 0.5.2
+      '@ratel-ai/sdk-win32-x64-msvc': 0.5.2
     transitivePeerDependencies:
       - '@cfworker/json-schema'
       - supports-color
       - zod
+
+  '@ratel-ai/telemetry@0.1.2': {}
 
   '@reduxjs/toolkit@2.12.0(react-redux@9.3.0(@types/react@19.2.15)(react@19.2.6)(redux@5.0.1))(react@19.2.6)':
     dependencies:
@@ -7294,7 +7313,7 @@ snapshots:
       jiti: 2.7.0
       tsx: 4.22.3
 
-  vitest@4.1.6(@types/node@24.12.4)(msw@2.14.6(@types/node@24.12.4)(typescript@5.9.3))(vite@8.0.12(@types/node@24.12.4)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.22.3)):
+  vitest@4.1.6(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(msw@2.14.6(@types/node@24.12.4)(typescript@5.9.3))(vite@8.0.12(@types/node@24.12.4)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.22.3)):
     dependencies:
       '@vitest/expect': 4.1.6
       '@vitest/mocker': 4.1.6(msw@2.14.6(@types/node@24.12.4)(typescript@5.9.3))(vite@8.0.12(@types/node@24.12.4)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.22.3))
@@ -7317,6 +7336,7 @@ snapshots:
       vite: 8.0.12(@types/node@24.12.4)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.22.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
+      '@opentelemetry/api': 1.9.1
       '@types/node': 24.12.4
     transitivePeerDependencies:
       - msw


### PR DESCRIPTION
## Summary

- upgrade both Ratel Local dependency declarations and the lockfile to `@ratel-ai/sdk@^0.5.2`
- await every `ToolCatalog` and `SkillCatalog` registration and batch gateway/CLI skill registration
- add a regression test proving gateway startup waits for one batched registration
- document the async registration contract, align the published Node engine with the new `>=20.6.0` transitive requirement, and ignore local `.kestral/` state

## Why

SDK 0.5 makes catalog registration asynchronous and uses registration as the boundary for indexing and embedding failures. Ignoring those promises can expose a catalog before registration finishes. This migration establishes the correct SDK baseline while preserving the default BM25 experience and existing capability-tool wire behavior.

## Impact

Ratel Local remains on `0.6.0-rc.0`. BM25 stays the default with no embedding configuration or model download. Direct SDK consumers now wait for registration completion, and gateway skills are registered in a single batch for the later dense-retrieval phases.

## Validation

- `pnpm test` — 900 tests passed
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build`
- `pnpm check:pack`
- `git diff --check`

Kestral: RL2-2
