### PR TITLE
release: v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this package are documented here. The format is based on 
 
 ## [Unreleased]
 
-## [0.5.0-rc.0] - 2026-07-17
+## [0.5.0] - 2026-07-24
 
 ### Changed
 - Made the Ratel Local plugin the preferred link path in both CLI and UI flows so Codex and Claude Code receive the bundled agent skills; when plugin installation fails, linking reports the failure and applies the reviewed, backed-up explicit MCP gateway fallback.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -12,12 +12,18 @@ How a new version is published to npm. Read end-to-end before cutting a release.
 
 ### Per-release flow
 
-1. **Bump `package.json.version`** to the new value (e.g. `0.2.1-rc.1`, then later `0.2.1`).
+1. **Bump every synchronized version and runtime pin** to the new value (e.g. `0.2.1-rc.1`, then later `0.2.1`): the root, app, core, and UI `package.json` files; both plugin manifests; and the plugin `.mcp.json` package pin. `pnpm check:pack` verifies that they match.
 2. **Update `CHANGELOG.md`** — add a `## [<version>] - YYYY-MM-DD` section above the previous one. For GA versions, collapse any matching `## [X.Y.Z-rc.*]` sections into the new `## [X.Y.Z]`.
 3. **Verify locally:**
    - `pnpm install --frozen-lockfile`
    - `pnpm build && pnpm typecheck && pnpm lint && pnpm test`
-   - `pnpm pack --dry-run` — inspect the would-be tarball; `package.json` inside must show real semver ranges (workspace-protocol deps would break installs).
+   - Pack to a temporary directory and inspect the tarball:
+     ```
+     RATEL_PACK_DIR="$(mktemp -d)"
+     pnpm --filter @ratel-ai/ratel-local pack --pack-destination "$RATEL_PACK_DIR"
+     tar -xOf "$RATEL_PACK_DIR"/ratel-ai-ratel-local-*.tgz package/package.json
+     ```
+     The packed `package.json` must show real semver ranges; workspace-protocol dependencies would break installs.
 4. **(Optional dry-run)** `workflow_dispatch` `release.yml` with `dry_run: true` to validate the auth + publish path end-to-end without consuming a version number.
 5. **Commit, tag, push:**
    ```

--- a/apps/ratel-local/package.json
+++ b/apps/ratel-local/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ratel-ai/ratel-local",
-  "version": "0.5.0-rc.0",
+  "version": "0.5.0",
   "description": "Ratel Local package: an MCP server library plus the ratel-local CLI for managing upstream MCP servers, OAuth, and agent imports from one binary.",
   "private": false,
   "type": "module",

--- a/apps/ratel-local/plugin/.claude-plugin/plugin.json
+++ b/apps/ratel-local/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ratel-local",
   "displayName": "Ratel Local",
-  "version": "0.5.0-rc.0",
+  "version": "0.5.0",
   "description": "Ratel Local gateway plugin for exposing curated upstream MCP tools through search_capabilities and invoke_tool.",
   "author": {
     "name": "Agentified",

--- a/apps/ratel-local/plugin/.codex-plugin/plugin.json
+++ b/apps/ratel-local/plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ratel-local",
-  "version": "0.5.0-rc.0",
+  "version": "0.5.0",
   "description": "Ratel Local gateway plugin for exposing curated upstream MCP tools through search_capabilities and invoke_tool.",
   "author": {
     "name": "Agentified",

--- a/apps/ratel-local/plugin/.mcp.json
+++ b/apps/ratel-local/plugin/.mcp.json
@@ -5,7 +5,7 @@
       "command": "npx",
       "args": [
         "-y",
-        "@ratel-ai/ratel-local@0.5.0-rc.0",
+        "@ratel-ai/ratel-local@0.5.0",
         "serve",
         "--auto-config"
       ]

--- a/apps/ratel-local/plugin/README.md
+++ b/apps/ratel-local/plugin/README.md
@@ -24,7 +24,7 @@ shared `assets/icon.svg` remains referenced by the Codex manifest.
 The plugin MCP config starts Ratel over stdio through `npx`:
 
 ```bash
-npx -y @ratel-ai/ratel-local@0.5.0-rc.0 serve --auto-config
+npx -y @ratel-ai/ratel-local@0.5.0 serve --auto-config
 ```
 
 `--auto-config` loads `~/.ratel/config.json` plus project and local Ratel configs when a project root is discoverable.

--- a/apps/ratel-local/plugin/skills/ratel-local/SKILL.md
+++ b/apps/ratel-local/plugin/skills/ratel-local/SKILL.md
@@ -17,7 +17,7 @@ Keep the plugin MCP definition limited to starting the Ratel gateway. Put upstre
 
 ## Plugin Runtime
 
-The plugin `.mcp.json` starts Ratel over stdio through `npx` with `@ratel-ai/ratel-local@0.5.0-rc.0` and `serve --auto-config`. Do not duplicate upstream MCP definitions into the plugin `.mcp.json`.
+The plugin `.mcp.json` starts Ratel over stdio through `npx` with `@ratel-ai/ratel-local@0.5.0` and `serve --auto-config`. Do not duplicate upstream MCP definitions into the plugin `.mcp.json`.
 
 For human CLI work, install the package globally and use the `ratel-local` bin:
 
@@ -210,7 +210,7 @@ ratel-local backup list
 ## Debug Checklist
 
 1. Confirm Node and `npx` are available.
-2. Confirm the plugin `.mcp.json` starts `@ratel-ai/ratel-local@0.5.0-rc.0` with `serve --auto-config`.
+2. Confirm the plugin `.mcp.json` starts `@ratel-ai/ratel-local@0.5.0` with `serve --auto-config`.
 3. Run `ratel-local mcp list` to verify Ratel config has upstreams.
 4. Run `ratel-local serve --auto-config` from the relevant project to reproduce startup outside the host.
 5. For HTTP/SSE upstreams, run `ratel-local mcp auth --check` or `ratel-local mcp auth <name>`.

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -9,7 +9,7 @@ output schema).
 
 | Part | Layer | What it proves |
 |------|-------|----------------|
-| **A** | Gateway (pull) | `ratel-local serve` exposes exactly `search_capabilities` / `invoke_tool` / `get_skill_content` / `auth`; the two reserved buckets mean a matching **skill is never starved by matching tools**; `invoke_tool` round-trips to a real upstream MCP; `get_skill_content` returns the body and a clean `{ error }` (not a protocol crash) for an unknown id. |
+| **A** | Gateway (pull) | `ratel-local serve` exposes `search_capabilities` / `invoke_tool` / `get_skill_content` / `auth` plus the deprecated `search_tools` compatibility shim; the two reserved buckets mean a matching **skill is never starved by matching tools**; `invoke_tool` round-trips to a real upstream MCP; `get_skill_content` returns the body and a clean `{ error }` (not a protocol crash) for an unknown id. |
 | **B** | Lifecycle | `skill activate → list → deactivate` moves skills into the Ratel folder and back, reversibly and non-destructively, with an accurate manifest. |
 | **C** | Push | The `UserPromptSubmit` preload hook + **real** project-signal detection: the *same* prompt surfaces the React skill in a React repo and the Django skill in a Django repo, and the clear-winner gate stays **silent** when nothing clearly fits. |
 
@@ -18,18 +18,12 @@ MCP server; `run.sh` orchestrates all three parts against throwaway `HOME`s.
 
 ## Running it
 
-This is **local/manual**, not a CI job — it needs the unified SDK linked and
-built (the SDK isn't published yet):
+This is **local/manual**, not a CI job:
 
 ```bash
-cd ../ratel/src/sdk/ts && pnpm build
-cd ../../../../ratel-local
-mv node_modules/@ratel-ai/sdk node_modules/@ratel-ai/sdk.orig
-ln -s ../ratel/src/sdk/ts node_modules/@ratel-ai/sdk
+pnpm install --frozen-lockfile
 pnpm build
-bash e2e/run.sh        # → "16 passed, 0 failed"
-# restore when done:
-rm node_modules/@ratel-ai/sdk && mv node_modules/@ratel-ai/sdk.orig node_modules/@ratel-ai/sdk
+bash e2e/run.sh        # → "19 passed, 0 failed"
 ```
 
 The per-bug regressions are also locked into the normal unit suites

--- a/e2e/driver.mjs
+++ b/e2e/driver.mjs
@@ -28,12 +28,14 @@ const transport = new StdioClientTransport({
 const client = new Client({ name: "e2e", version: "0.0.0" });
 await client.connect(transport);
 
-// A1 — the gateway surface is exactly the designed set (3 gateway tools + auth).
+// A1 — the gateway surface includes the designed set plus the deprecated
+// search_tools compatibility shim.
 const { tools } = await client.listTools();
 const names = tools.map((t) => t.name).sort();
 check(
-  "A1  surface is exactly [auth, get_skill_content, invoke_tool, search_capabilities]",
-  JSON.stringify(names) === JSON.stringify(["auth", "get_skill_content", "invoke_tool", "search_capabilities"]),
+  "A1  surface includes capability tools, auth, and the deprecated search_tools shim",
+  JSON.stringify(names) ===
+    JSON.stringify(["auth", "get_skill_content", "invoke_tool", "search_capabilities", "search_tools"]),
   JSON.stringify(names),
 );
 

--- a/e2e/run.sh
+++ b/e2e/run.sh
@@ -9,18 +9,13 @@
 #   C. PUSH path — the preload hook + REAL project-signal detection (same prompt,
 #      different repo → different skill), and the clear-winner gate staying silent.
 #
-# This is a LOCAL/manual check, not a CI job: it needs the unified SDK linked and
-# built (the SDK isn't published yet). Prereqs:
-#   cd ../ratel/src/sdk/ts && pnpm build
-#   cd ../../../../ratel-local
-#   mv node_modules/@ratel-ai/sdk node_modules/@ratel-ai/sdk.orig
-#   ln -s ../ratel/src/sdk/ts node_modules/@ratel-ai/sdk
+# This is a LOCAL/manual check, not a CI job. Prereqs:
+#   pnpm install --frozen-lockfile
 #   pnpm build
 #   bash e2e/run.sh          # → "19 passed, 0 failed"
-#   rm node_modules/@ratel-ai/sdk && mv node_modules/@ratel-ai/sdk.orig node_modules/@ratel-ai/sdk
 set -u
 RMCP="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-BIN="$RMCP/dist/bin.js"
+BIN="$RMCP/apps/ratel-local/dist/bin.js"
 PASS=0; FAIL=0
 ok()   { echo "  ✓ $1"; PASS=$((PASS+1)); }
 no()   { echo "  ✗ $1${2:+ — $2}"; FAIL=$((FAIL+1)); }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ratel-local-workspace",
-  "version": "0.5.0-rc.0",
+  "version": "0.5.0",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.33.0",
@@ -15,6 +15,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.13",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "@types/node": "^24.0.0",
     "@types/proper-lockfile": "^4.1.4",
     "tsup": "^8.5.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ratel-ai/ratel-local-core",
-  "version": "0.5.0-rc.0",
+  "version": "0.5.0",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ratel-ai/ratel-local-ui",
   "private": true,
-  "version": "0.5.0-rc.0",
+  "version": "0.5.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@biomejs/biome':
         specifier: ^2.4.13
         version: 2.4.15
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.29.0
+        version: 1.29.0(zod@4.4.3)
       '@types/node':
         specifier: ^24.0.0
         version: 24.12.4
@@ -81,15 +84,15 @@ importers:
       '@fontsource-variable/inter-tight':
         specifier: ^5.2.7
         version: 5.2.7
-      '@ratel-ai/ratel-local-core':
-        specifier: workspace:*
-        version: link:../core
       '@fontsource/jetbrains-mono':
         specifier: ^5.2.8
         version: 5.2.8
       '@radix-ui/react-slot':
         specifier: ^1.2.4
         version: 1.2.4(@types/react@19.2.15)(react@19.2.6)
+      '@ratel-ai/ratel-local-core':
+        specifier: workspace:*
+        version: link:../core
       '@tanstack/react-form':
         specifier: ^1.33.0
         version: 1.33.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)


### PR DESCRIPTION
## Summary

- promote the package and bundled plugin from `0.5.0-rc.0` to stable `0.5.0`
- update the changelog and every synchronized workspace/plugin runtime version
- repair the local release packaging instructions
- align the real-process E2E harness with the workspace build path and the intentional deprecated `search_tools` compatibility shim

## Why

The RC has completed local and isolated-agent validation and is ready to become the stable npm release. The release-prep checks had also drifted: the documented dry-run pack option is unsupported, and the E2E harness still assumed the old output path and four-tool surface.

## Impact

After this PR is merged and `v0.5.0` is tagged, the release workflow will publish `@ratel-ai/ratel-local@0.5.0` under npm's `latest` tag. No release or tag is created by this PR itself.

## Validation

- independent final review: no blocking findings
- `pnpm build`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test` — 660 tests passed
- `pnpm check:pack`
- `bash e2e/run.sh` — 19/19 passed
- isolated `ratel-agent-sandbox` config-level tests for Claude Code and Codex
- packed tarball inspected with resolved `0.5.0` internal versions
