### PR TITLE
feat: add opt-in dense retrieval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this package are documented here. The format is based on 
 
 ## [Unreleased]
 
+### Added
+- Added opt-in `semantic` and `hybrid` retrieval with scoped, atomic configuration; validated local, Hugging Face, Ollama, and OpenAI-compatible embedding sources; fail-closed dense startup; and generation-safe OAuth reconnect behavior. BM25 remains the model-free default.
+
 ### Changed
 - Upgraded `@ratel-ai/sdk` to 0.5.2. Direct SDK consumers must now await `ToolCatalog.register()` and `SkillCatalog.register()`; Ratel Local awaits every registration and batches gateway skills in one call.
 

--- a/apps/ratel-local/src/cli/handlers/daemon.ts
+++ b/apps/ratel-local/src/cli/handlers/daemon.ts
@@ -238,6 +238,9 @@ export async function runDaemonServer(
           logger: log,
           resolvedMcpEntries: scope.resolvedContext.mcpEntries,
           resolvedSkills: scope.resolvedContext.skills.effectiveSkills,
+          ...(scope.resolvedContext.retrieval
+            ? { retrieval: scope.resolvedContext.retrieval }
+            : {}),
         },
       );
     }

--- a/apps/ratel-local/src/cli/handlers/mcp-auth.test.ts
+++ b/apps/ratel-local/src/cli/handlers/mcp-auth.test.ts
@@ -180,6 +180,31 @@ describe("runMcpAuth", () => {
     expect(all).toMatch(/linear.*authorized.*re-authed/);
   });
 
+  it("reports reconnect-required after authorizing a dense scoped context", async () => {
+    const fs = new MemFs();
+    fs.files.set(
+      RATEL_USER_PATH,
+      JSON.stringify({
+        mcpServers: { stripe: { type: "http", url: "https://x" } },
+        retrieval: {
+          method: "semantic",
+          embedding: {
+            url: "https://embeddings.example/v1/embeddings",
+            model: "embed",
+          },
+        },
+      }),
+    );
+    const logs: string[] = [];
+    const ctx = makeCtx(fs, { log: (message) => logs.push(message) });
+
+    await runMcpAuth(ctx, {
+      authRunner: async () => [{ name: "stripe", status: "authorized", mode: "interactive" }],
+    });
+
+    expect(logs.join("\n")).toMatch(/stripe.*authorized.*reconnect.*new retrieval generation/i);
+  });
+
   describe("--check mode", () => {
     it("does not call the runner; reads OAuth stores and prints per-upstream status", async () => {
       const fs = new MemFs();

--- a/apps/ratel-local/src/cli/handlers/mcp-auth.ts
+++ b/apps/ratel-local/src/cli/handlers/mcp-auth.ts
@@ -4,6 +4,8 @@ import {
   type AuthFlowResult,
   buildGatewayFromConfig,
   type McpConfigDocument,
+  markDenseAuthReconnectRequired,
+  mergeConfigs,
   parseConfig,
   projectIdFromCanonicalRoot,
   type ResolvedMcpEntry,
@@ -21,7 +23,8 @@ export interface RunMcpAuthOptions {
 }
 
 export async function runMcpAuth(ctx: HandlerCtx, opts: RunMcpAuthOptions = {}): Promise<void> {
-  const entries = (await loadResolvedEntries(ctx)).filter(({ status }) => status === "effective");
+  const resolved = await loadResolvedContext(ctx);
+  const entries = resolved.entries.filter(({ status }) => status === "effective");
   if (entries.length === 0) {
     ctx.log("[ratel] no Ratel config found in user/project/local scope; nothing to auth");
     return;
@@ -50,6 +53,9 @@ export async function runMcpAuth(ctx: HandlerCtx, opts: RunMcpAuthOptions = {}):
     } finally {
       await gateway.close();
     }
+  }
+  if (resolved.denseRetrieval) {
+    results = markDenseAuthReconnectRequired(results);
   }
   printResults(ctx, results);
 }
@@ -122,7 +128,9 @@ async function checkUpstream(
   return { status: "ok" };
 }
 
-async function loadResolvedEntries(ctx: HandlerCtx): Promise<ResolvedMcpEntry[]> {
+async function loadResolvedContext(
+  ctx: HandlerCtx,
+): Promise<{ entries: ResolvedMcpEntry[]; denseRetrieval: boolean }> {
   const projectRoot = ctx.env.projectRoot
     ? await realpath(ctx.env.projectRoot).catch(() => ctx.env.projectRoot)
     : undefined;
@@ -139,11 +147,15 @@ async function loadResolvedEntries(ctx: HandlerCtx): Promise<ResolvedMcpEntry[]>
       documents.push({ ref: { scope, projectId }, config: parseConfig(document) });
     }
   }
-  return resolveMcpEntries({
-    homeDir: ctx.env.homeDir,
-    ...(projectRoot ? { projectRoot } : {}),
-    documents,
-  });
+  const retrieval = mergeConfigs(documents.map(({ config }) => config)).retrieval;
+  return {
+    entries: resolveMcpEntries({
+      homeDir: ctx.env.homeDir,
+      ...(projectRoot ? { projectRoot } : {}),
+      documents,
+    }),
+    denseRetrieval: retrieval?.method === "semantic" || retrieval?.method === "hybrid",
+  };
 }
 
 function humanizeDuration(ms: number): string {

--- a/apps/ratel-local/src/ui/server.ts
+++ b/apps/ratel-local/src/ui/server.ts
@@ -17,6 +17,7 @@ import {
   type DocumentRevision,
   documentRevision,
   InvalidContextSnapshotError,
+  markDenseAuthReconnectRequired,
   type PreparedChangeCoordinator,
   type ProjectAdmissionLock,
   type ProjectId,
@@ -481,12 +482,16 @@ async function authResolvedServer(
   const gateway = await buildGatewayFromConfig(
     { mcpServers: {} },
     {
-      resolvedMcpEntries: snapshot.mcpEntries,
-      resolvedSkills: snapshot.skills.effectiveSkills,
+      // This route authorizes one server; it does not need to connect or index
+      // the rest of the resolved context.
+      resolvedMcpEntries: [resolved],
     },
   );
   try {
-    const results = await gateway.runAuthFlow({ name });
+    let results = await gateway.runAuthFlow({ name });
+    if (snapshot.retrieval?.method === "semantic" || snapshot.retrieval?.method === "hybrid") {
+      results = markDenseAuthReconnectRequired(results);
+    }
     const failed = results.find(({ status }) => status === "failed" || status === "unsupported");
     if (failed) {
       throw new UiRouteError(

--- a/packages/core/src/context-snapshot.test.ts
+++ b/packages/core/src/context-snapshot.test.ts
@@ -1,6 +1,6 @@
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { createContextSnapshotResolver, InvalidContextSnapshotError } from "./context-snapshot.js";
 import { createProjectRegistry } from "./project-registry.js";
@@ -111,6 +111,82 @@ describe("ContextSnapshotResolver", () => {
     const second = await secondResolver.resolve({ kind: "project", projectId: project.id });
 
     expect(first.runtimeRevision).not.toBe(second.runtimeRevision);
+  });
+
+  it("resolves retrieval atomically by scope and includes it in the runtime revision", async () => {
+    const { homeDir, projectRoot, project, resolver } = await fixture();
+    await writeFile(
+      join(homeDir, ".ratel", "config.json"),
+      JSON.stringify({
+        retrieval: {
+          method: "semantic",
+          embedding: { huggingface: "intfloat/e5-small-v2", download: false },
+        },
+      }),
+    );
+
+    const inherited = await resolver.resolve({ kind: "project", projectId: project.id });
+    expect(inherited.retrieval).toEqual({
+      method: "semantic",
+      embedding: { huggingface: "intfloat/e5-small-v2", download: false },
+    });
+
+    await writeFile(
+      join(projectRoot, ".ratel", "config.json"),
+      JSON.stringify({
+        retrieval: {
+          method: "hybrid",
+          embedding: { ollama: "nomic-embed-text" },
+        },
+      }),
+    );
+    const overridden = await resolver.resolve({ kind: "project", projectId: project.id });
+
+    expect(overridden.retrieval).toEqual({
+      method: "hybrid",
+      embedding: { ollama: "nomic-embed-text" },
+    });
+    expect(overridden.runtimeRevision).not.toBe(inherited.runtimeRevision);
+  });
+
+  it("changes runtime revision when effective OAuth state changes", async () => {
+    const { homeDir, resolver } = await fixture();
+    await writeFile(
+      join(homeDir, ".ratel", "config.json"),
+      JSON.stringify({
+        mcpServers: {
+          remote: { type: "http", url: "https://remote.example/mcp" },
+        },
+      }),
+    );
+
+    const before = await resolver.resolve({ kind: "global" });
+    const remote = before.mcpEntries.find(({ name }) => name === "remote");
+    if (!remote) throw new Error("expected resolved OAuth entry");
+    const { path: oauthPath, fingerprint: resourceFingerprint } = remote.oauthKey;
+    expect(before.watchInputs).toContainEqual({ path: oauthPath, kind: "file" });
+
+    await mkdir(dirname(oauthPath), { recursive: true });
+    await writeFile(
+      oauthPath,
+      JSON.stringify({
+        resource_fingerprint: resourceFingerprint,
+        code_verifier: "authorization-in-progress",
+      }),
+    );
+    const inProgress = await resolver.resolve({ kind: "global" });
+    expect(inProgress.runtimeRevision).toBe(before.runtimeRevision);
+
+    await writeFile(
+      oauthPath,
+      JSON.stringify({
+        resource_fingerprint: resourceFingerprint,
+        tokens: { access_token: "authorized", token_type: "Bearer" },
+      }),
+    );
+
+    const after = await resolver.resolve({ kind: "global" });
+    expect(after.runtimeRevision).not.toBe(before.runtimeRevision);
   });
 
   it("fails a new snapshot explicitly when a scoped config is invalid", async () => {

--- a/packages/core/src/context-snapshot.ts
+++ b/packages/core/src/context-snapshot.ts
@@ -10,7 +10,13 @@ import type {
 } from "./context.js";
 import { ratelConfigPath } from "./hierarchy.js";
 import { isPlainObject } from "./json.js";
-import { parseConfig, type RatelConfig, type RatelConfigDocument } from "./lib/config.js";
+import {
+  mergeConfigs,
+  parseConfig,
+  type RatelConfig,
+  type RatelConfigDocument,
+  type RetrievalConfig,
+} from "./lib/config.js";
 import {
   type ResolvedSkillCatalog,
   resolveConfiguredSkills,
@@ -21,7 +27,7 @@ import { assertSafeProjectControlPath, ProjectPathSafetyError } from "./project-
 import type { ProjectRegistry } from "./project-registry.js";
 import { type ResolvedMcpEntry, resolveMcpEntries } from "./resolved-mcp.js";
 
-export const CONTEXT_SNAPSHOT_RESOLVER_VERSION = 2;
+export const CONTEXT_SNAPSHOT_RESOLVER_VERSION = 4;
 
 export interface Diagnostic {
   code: string;
@@ -50,6 +56,8 @@ export interface ResolvedContextSnapshot {
   runtimeRevision: RuntimeRevision;
   mcpEntries: ResolvedMcpEntry[];
   skills: ResolvedSkillCatalog;
+  /** Atomic right-most retrieval block for this resolved context. */
+  retrieval?: RetrievalConfig;
   diagnostics: Diagnostic[];
   watchInputs: WatchInput[];
 }
@@ -95,6 +103,11 @@ interface ReadResult {
   target: DocumentTarget;
   snapshot?: ScopedDocumentSnapshot;
   revision?: DocumentRevision;
+}
+
+interface OAuthStoreRevision {
+  path: string;
+  revision: string;
 }
 
 export function createContextSnapshotResolver(
@@ -156,6 +169,10 @@ export function createContextSnapshotResolver(
           documents: documents.map(({ ref, config }) => ({ ref, config })),
           ...(options.env ? { env: options.env } : {}),
         });
+        const oauthStoreRevisions = await readOAuthStoreRevisions(mcpEntries);
+        const confirmedOAuthStoreRevisions = await readOAuthStoreRevisions(mcpEntries);
+        if (!sameOAuthStoreRevisions(oauthStoreRevisions, confirmedOAuthStoreRevisions)) continue;
+        const retrieval = mergeConfigs(documents.map(({ config }) => config)).retrieval;
         const diagnostics: Diagnostic[] = [
           ...skills.diagnostics.map(({ code, severity, message, path }) => ({
             code,
@@ -171,7 +188,12 @@ export function createContextSnapshotResolver(
             })),
           ),
         ];
-        const runtimeRevision = digestRuntimeRevision(documents, mcpEntries, skills.fingerprint);
+        const runtimeRevision = digestRuntimeRevision(
+          documents,
+          mcpEntries,
+          skills.fingerprint,
+          oauthStoreRevisions,
+        );
         const skillWatchInputs = await Promise.all(
           skills.watchInputs.map(async (path): Promise<WatchInput> => {
             try {
@@ -189,6 +211,7 @@ export function createContextSnapshotResolver(
         const watchInputs = uniqueWatchInputs([
           ...targets.map(({ path }) => ({ path: dirname(path), kind: "directory" as const })),
           ...skillWatchInputs,
+          ...oauthStoreRevisions.map(({ path }) => ({ path, kind: "file" as const })),
         ]);
 
         return {
@@ -198,6 +221,7 @@ export function createContextSnapshotResolver(
           runtimeRevision,
           mcpEntries,
           skills,
+          ...(retrieval ? { retrieval } : {}),
           diagnostics,
           watchInputs,
         };
@@ -296,6 +320,68 @@ function sameReadSet(before: ReadResult[], after: ReadResult[]): boolean {
   return before.every((read, index) => read.revision === after[index]?.revision);
 }
 
+async function readOAuthStoreRevisions(
+  entries: readonly ResolvedMcpEntry[],
+): Promise<OAuthStoreRevision[]> {
+  const targets = Array.from(
+    new Map(
+      entries
+        .filter(
+          ({ entry, status }) =>
+            status === "effective" && (entry.type === "http" || entry.type === "sse"),
+        )
+        .map(({ oauthKey }) => [oauthKey.path, oauthKey.fingerprint] as const),
+    ),
+  ).sort(([left], [right]) => (left < right ? -1 : left > right ? 1 : 0));
+  return Promise.all(
+    targets.map(async ([path, expectedFingerprint]) => {
+      try {
+        const parsed = JSON.parse((await readFile(path)).toString("utf8")) as unknown;
+        const state = isPlainObject(parsed) ? parsed : {};
+        return {
+          path,
+          revision: oauthActivationRevision(state, expectedFingerprint),
+        };
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+          return { path, revision: oauthActivationRevision({}, expectedFingerprint) };
+        }
+        throw error;
+      }
+    }),
+  );
+}
+
+function oauthActivationRevision(
+  state: Record<string, unknown>,
+  expectedFingerprint: string,
+): string {
+  const storedFingerprint =
+    typeof state.resource_fingerprint === "string" ? state.resource_fingerprint : undefined;
+  return createHash("sha256")
+    .update(
+      stableStringify({
+        fingerprintMismatch:
+          storedFingerprint !== undefined && storedFingerprint !== expectedFingerprint,
+        tokens: state.tokens ?? null,
+      }),
+    )
+    .digest("base64url");
+}
+
+function sameOAuthStoreRevisions(
+  before: readonly OAuthStoreRevision[],
+  after: readonly OAuthStoreRevision[],
+): boolean {
+  return (
+    before.length === after.length &&
+    before.every(
+      (revision, index) =>
+        revision.path === after[index]?.path && revision.revision === after[index]?.revision,
+    )
+  );
+}
+
 function sameScope(a: RatelScopeRef, b: RatelScopeRef): boolean {
   return (
     a.scope === b.scope &&
@@ -307,6 +393,7 @@ function digestRuntimeRevision(
   documents: ScopedDocumentSnapshot[],
   mcpEntries: ResolvedMcpEntry[],
   skillFingerprint: string,
+  oauthStoreRevisions: readonly OAuthStoreRevision[],
 ): RuntimeRevision {
   const normalizedDocuments = documents.map(({ ref, config }) => ({ ref, config }));
   const runtimeMcpEntries = mcpEntries.map(({ name, owner, status, runtimeCwd, oauthKey }) => ({
@@ -323,6 +410,8 @@ function digestRuntimeRevision(
     .update(stableStringify(runtimeMcpEntries))
     .update("\0")
     .update(skillFingerprint)
+    .update("\0")
+    .update(stableStringify(oauthStoreRevisions))
     .digest("base64url") as RuntimeRevision;
 }
 

--- a/packages/core/src/import-plan.test.ts
+++ b/packages/core/src/import-plan.test.ts
@@ -473,4 +473,19 @@ args = ["fs"]
 
     expect(agentHost.input?.installGatewayScopes).toEqual(new Set(["user"]));
   });
+
+  it("links project and local scopes that contain only retrieval overrides", async () => {
+    const agentHost = new RecordingAgentHost();
+
+    await buildAgentLinkPlan({
+      ...emptyInputs({
+        ratelUser: { mcpServers: { user: FS_ENTRY } },
+        ratelProject: { mcpServers: {}, retrieval: { method: "semantic" } },
+        ratelLocal: { mcpServers: {}, retrieval: { method: "bm25" } },
+      }),
+      agentHost,
+    });
+
+    expect(agentHost.input?.installGatewayScopes).toEqual(new Set(["user", "project", "local"]));
+  });
 });

--- a/packages/core/src/import-plan.ts
+++ b/packages/core/src/import-plan.ts
@@ -349,6 +349,7 @@ function hasRuntimeContent(config: RatelConfig | null): boolean {
   if (!config) return false;
   if (Object.keys(config.mcpServers).length > 0) return true;
   if (Object.keys(config.skills?.entries ?? {}).length > 0) return true;
+  if (config.retrieval) return true;
   return (config.skills?.dirs?.length ?? 0) > 0;
 }
 

--- a/packages/core/src/lib/config.test.ts
+++ b/packages/core/src/lib/config.test.ts
@@ -270,6 +270,178 @@ describe("mergeConfigs", () => {
   });
 });
 
+describe("parseConfig retrieval", () => {
+  it.each(["bm25", "semantic", "hybrid"] as const)("accepts the %s retrieval method", (method) => {
+    expect(parseConfig({ retrieval: { method } }).retrieval).toEqual({ method });
+  });
+
+  it("accepts every supported explicit embedding source", () => {
+    const embeddings = [
+      "/opt/models/bge",
+      "~/models/bge",
+      {
+        huggingface: "intfloat/e5-small-v2",
+        revision: "v1",
+        queryPrefix: "query: ",
+        docPrefix: "passage: ",
+        pooling: "mean",
+        download: false,
+      },
+      { local: "/opt/models/bge", pooling: "cls" },
+      { ollama: "nomic-embed-text", queryPrefix: "search_query: " },
+      {
+        url: "https://embeddings.example/v1/embeddings",
+        model: "text-embedding-3-small",
+        apiKeyEnv: "EMBEDDING_API_KEY",
+      },
+    ];
+
+    for (const embedding of embeddings) {
+      expect(parseConfig({ retrieval: { method: "semantic", embedding } }).retrieval).toEqual({
+        method: "semantic",
+        embedding,
+      });
+    }
+  });
+
+  it("rejects malformed, unknown, and incomplete retrieval methods", () => {
+    expect(() => parseConfig({ retrieval: "semantic" })).toThrow(/retrieval.*object/i);
+    expect(() => parseConfig({ retrieval: {} })).toThrow(/retrieval\.method/);
+    expect(() => parseConfig({ retrieval: { method: "dense" } })).toThrow(/bm25\|semantic\|hybrid/);
+    expect(() => parseConfig({ retrieval: { method: "semantic", fallback: "bm25" } })).toThrow(
+      /retrieval\.fallback/,
+    );
+  });
+
+  it("rejects an embedding when BM25 is selected", () => {
+    expect(() =>
+      parseConfig({
+        retrieval: { method: "bm25", embedding: { ollama: "nomic-embed-text" } },
+      }),
+    ).toThrow(/inactive.*bm25/i);
+  });
+
+  it("rejects relative local paths and mixed embedding sources", () => {
+    expect(() =>
+      parseConfig({ retrieval: { method: "semantic", embedding: "./models/bge" } }),
+    ).toThrow(/absolute path/);
+    expect(() =>
+      parseConfig({
+        retrieval: {
+          method: "semantic",
+          embedding: { local: "models/bge" },
+        },
+      }),
+    ).toThrow(/absolute path/);
+    expect(() =>
+      parseConfig({
+        retrieval: {
+          method: "hybrid",
+          embedding: { huggingface: "model/repo", ollama: "model" },
+        },
+      }),
+    ).toThrow(/exactly one source/);
+  });
+
+  it("rejects literal endpoint credentials and invalid apiKeyEnv names", () => {
+    expect(() =>
+      parseConfig({
+        retrieval: {
+          method: "semantic",
+          embedding: {
+            url: "https://secret:literal@example.com/v1/embeddings",
+            model: "embed",
+          },
+        },
+      }),
+    ).toThrow(/credentials/);
+    expect(() =>
+      parseConfig({
+        retrieval: {
+          method: "semantic",
+          embedding: {
+            url: "https://example.com/v1/embeddings",
+            model: "embed",
+            apiKey: "literal-secret",
+          },
+        },
+      }),
+    ).toThrow(/apiKeyEnv/);
+    expect(() =>
+      parseConfig({
+        retrieval: {
+          method: "semantic",
+          embedding: {
+            url: "https://example.com/v1/embeddings",
+            model: "embed",
+            apiKeyEnv: "NOT-AN-ENV-NAME",
+          },
+        },
+      }),
+    ).toThrow(/environment variable name/);
+  });
+
+  it("rejects obvious credential query parameters but permits endpoint options", () => {
+    for (const parameter of ["api_key", "access-token", "authorization", "client_secret"]) {
+      expect(() =>
+        parseConfig({
+          retrieval: {
+            method: "semantic",
+            embedding: {
+              url: `https://example.com/v1/embeddings?${parameter}=literal-secret`,
+              model: "embed",
+            },
+          },
+        }),
+      ).toThrow(/credential query parameter.*apiKeyEnv/);
+    }
+
+    expect(
+      parseConfig({
+        retrieval: {
+          method: "semantic",
+          embedding: {
+            url: "https://example.com/v1/embeddings?api-version=2024-02-01",
+            model: "embed",
+          },
+        },
+      }).retrieval,
+    ).toEqual({
+      method: "semantic",
+      embedding: {
+        url: "https://example.com/v1/embeddings?api-version=2024-02-01",
+        model: "embed",
+      },
+    });
+  });
+});
+
+describe("mergeConfigs retrieval", () => {
+  it("treats each retrieval block atomically and lets the right-most scope win", () => {
+    const inherited: RatelConfig = {
+      mcpServers: {},
+      retrieval: {
+        method: "semantic",
+        embedding: { huggingface: "intfloat/e5-small-v2", download: false },
+      },
+    };
+    const local: RatelConfig = {
+      mcpServers: {},
+      retrieval: { method: "hybrid", embedding: { ollama: "nomic-embed-text" } },
+    };
+
+    expect(mergeConfigs([inherited, local]).retrieval).toEqual(local.retrieval);
+  });
+
+  it("inherits the earlier retrieval block when later scopes omit it", () => {
+    const inherited: RatelConfig = {
+      mcpServers: {},
+      retrieval: { method: "semantic" },
+    };
+    expect(mergeConfigs([inherited, { mcpServers: {} }]).retrieval).toEqual(inherited.retrieval);
+  });
+});
+
 describe("parseConfig skills", () => {
   it("parses explicit reference and managed-copy entries", () => {
     const config = parseConfig({

--- a/packages/core/src/lib/config.ts
+++ b/packages/core/src/lib/config.ts
@@ -1,3 +1,5 @@
+import { isAbsolute } from "node:path";
+import type { EmbeddingSpec, SearchMethod } from "@ratel-ai/sdk";
 import { isPlainObject } from "../json.js";
 import { isSafeSkillId } from "../skill-id.js";
 
@@ -43,16 +45,28 @@ export interface SkillsConfig {
   dirs?: string[];
 }
 
+export interface RetrievalConfig {
+  method: SearchMethod;
+  /**
+   * Omit for the SDK's pinned built-in model. Explicit sources are validated
+   * here so dense retrieval never starts with an ambiguous or unsafe model
+   * selection.
+   */
+  embedding?: EmbeddingSpec;
+}
+
 /** Lossless on-disk shape. Mutations retain unknown top-level fields. */
 export interface RatelConfigDocument {
   mcpServers?: Record<string, ServerEntry>;
   skills?: SkillsConfig;
+  retrieval?: RetrievalConfig;
   [key: string]: unknown;
 }
 
 export interface RatelConfig {
   mcpServers: Record<string, ServerEntry>;
   skills?: SkillsConfig;
+  retrieval?: RetrievalConfig;
 }
 
 export function parseConfig(input: unknown): RatelConfig {
@@ -74,7 +88,217 @@ export function parseConfig(input: unknown): RatelConfig {
   if (skills !== undefined) {
     config.skills = parseSkills(skills);
   }
+  const retrieval = (input as Record<string, unknown>).retrieval;
+  if (retrieval !== undefined) {
+    config.retrieval = parseRetrieval(retrieval);
+  }
   return config;
+}
+
+function parseRetrieval(raw: unknown): RetrievalConfig {
+  if (!isPlainObject(raw)) {
+    throw new ConfigError("`retrieval` must be a JSON object");
+  }
+  assertOnlyKeys("retrieval", raw, ["method", "embedding"]);
+  const method = parseRetrievalMethod(raw.method);
+  if (method === "bm25" && raw.embedding !== undefined) {
+    throw new ConfigError(
+      "`retrieval.embedding` is inactive when `retrieval.method` is bm25; remove it or select semantic|hybrid",
+    );
+  }
+  return {
+    method,
+    ...(raw.embedding !== undefined
+      ? { embedding: parseEmbedding("retrieval.embedding", raw.embedding) }
+      : {}),
+  };
+}
+
+function parseRetrievalMethod(raw: unknown): SearchMethod {
+  if (raw === "bm25" || raw === "semantic" || raw === "hybrid") return raw;
+  throw new ConfigError("`retrieval.method` must be one of bm25|semantic|hybrid");
+}
+
+function parseEmbedding(path: string, raw: unknown): EmbeddingSpec {
+  if (typeof raw === "string") {
+    return parseLocalModelPath(path, raw);
+  }
+  if (!isPlainObject(raw)) {
+    throw new ConfigError(`\`${path}\` must be a local model path or a JSON object`);
+  }
+  if ("apiKey" in raw) {
+    throw new ConfigError(`\`${path}.apiKey\` is not allowed; use apiKeyEnv instead`);
+  }
+
+  const sources = ["huggingface", "local", "ollama", "url"].filter((key) => raw[key] !== undefined);
+  if (sources.length !== 1) {
+    throw new ConfigError(
+      `\`${path}\` must select exactly one source: huggingface|local|ollama|url`,
+    );
+  }
+
+  const source = sources[0];
+  switch (source) {
+    case "huggingface": {
+      assertOnlyKeys(path, raw, [
+        "huggingface",
+        "revision",
+        "queryPrefix",
+        "docPrefix",
+        "pooling",
+        "download",
+      ]);
+      const config: Extract<EmbeddingSpec, { huggingface: string }> = {
+        huggingface: nonEmptyString(`${path}.huggingface`, raw.huggingface),
+      };
+      const revision = optionalNonEmptyString(`${path}.revision`, raw.revision);
+      const queryPrefix = optionalString(`${path}.queryPrefix`, raw.queryPrefix);
+      const docPrefix = optionalString(`${path}.docPrefix`, raw.docPrefix);
+      const pooling = optionalPooling(`${path}.pooling`, raw.pooling);
+      const download = optionalBoolean(`${path}.download`, raw.download);
+      if (revision !== undefined) config.revision = revision;
+      if (queryPrefix !== undefined) config.queryPrefix = queryPrefix;
+      if (docPrefix !== undefined) config.docPrefix = docPrefix;
+      if (pooling !== undefined) config.pooling = pooling;
+      if (download !== undefined) config.download = download;
+      return config;
+    }
+    case "local": {
+      assertOnlyKeys(path, raw, ["local", "queryPrefix", "docPrefix", "pooling"]);
+      const config: Extract<EmbeddingSpec, { local: string }> = {
+        local: parseLocalModelPath(`${path}.local`, raw.local),
+      };
+      const queryPrefix = optionalString(`${path}.queryPrefix`, raw.queryPrefix);
+      const docPrefix = optionalString(`${path}.docPrefix`, raw.docPrefix);
+      const pooling = optionalPooling(`${path}.pooling`, raw.pooling);
+      if (queryPrefix !== undefined) config.queryPrefix = queryPrefix;
+      if (docPrefix !== undefined) config.docPrefix = docPrefix;
+      if (pooling !== undefined) config.pooling = pooling;
+      return config;
+    }
+    case "ollama": {
+      assertOnlyKeys(path, raw, ["ollama", "queryPrefix", "docPrefix"]);
+      const config: Extract<EmbeddingSpec, { ollama: string }> = {
+        ollama: nonEmptyString(`${path}.ollama`, raw.ollama),
+      };
+      const queryPrefix = optionalString(`${path}.queryPrefix`, raw.queryPrefix);
+      const docPrefix = optionalString(`${path}.docPrefix`, raw.docPrefix);
+      if (queryPrefix !== undefined) config.queryPrefix = queryPrefix;
+      if (docPrefix !== undefined) config.docPrefix = docPrefix;
+      return config;
+    }
+    case "url": {
+      assertOnlyKeys(path, raw, ["url", "model", "apiKeyEnv", "queryPrefix", "docPrefix"]);
+      const url = nonEmptyString(`${path}.url`, raw.url);
+      validateEmbeddingEndpoint(`${path}.url`, url);
+      const config: Extract<EmbeddingSpec, { url: string }> = {
+        url,
+        model: nonEmptyString(`${path}.model`, raw.model),
+      };
+      const apiKeyEnv = optionalNonEmptyString(`${path}.apiKeyEnv`, raw.apiKeyEnv);
+      const queryPrefix = optionalString(`${path}.queryPrefix`, raw.queryPrefix);
+      const docPrefix = optionalString(`${path}.docPrefix`, raw.docPrefix);
+      if (apiKeyEnv !== undefined) {
+        if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(apiKeyEnv)) {
+          throw new ConfigError(`\`${path}.apiKeyEnv\` must be an environment variable name`);
+        }
+        config.apiKeyEnv = apiKeyEnv;
+      }
+      if (queryPrefix !== undefined) config.queryPrefix = queryPrefix;
+      if (docPrefix !== undefined) config.docPrefix = docPrefix;
+      return config;
+    }
+    default:
+      throw new ConfigError(`\`${path}\` has an unsupported source`);
+  }
+}
+
+function parseLocalModelPath(path: string, raw: unknown): string {
+  const value = nonEmptyString(path, raw);
+  if (!(isAbsolute(value) || value === "~" || value.startsWith("~/"))) {
+    throw new ConfigError(`\`${path}\` must be an absolute path or start with ~/`);
+  }
+  return value;
+}
+
+function validateEmbeddingEndpoint(path: string, value: string): void {
+  let parsed: URL;
+  try {
+    parsed = new URL(value);
+  } catch {
+    throw new ConfigError(`\`${path}\` must be an absolute http(s) URL`);
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    throw new ConfigError(`\`${path}\` must use http or https`);
+  }
+  if (parsed.username || parsed.password) {
+    throw new ConfigError(`\`${path}\` must not contain credentials`);
+  }
+  for (const key of parsed.searchParams.keys()) {
+    if (isSecretQueryParameter(key)) {
+      throw new ConfigError(
+        `\`${path}\` must not contain credential query parameter \`${key}\`; use apiKeyEnv instead`,
+      );
+    }
+  }
+}
+
+function isSecretQueryParameter(key: string): boolean {
+  const normalized = key.toLowerCase().replaceAll(/[-_.]/g, "");
+  return SECRET_QUERY_PARAMETERS.has(normalized);
+}
+
+const SECRET_QUERY_PARAMETERS = new Set([
+  "apikey",
+  "token",
+  "accesstoken",
+  "authtoken",
+  "auth",
+  "authorization",
+  "password",
+  "secret",
+  "clientsecret",
+]);
+
+function assertOnlyKeys(
+  path: string,
+  raw: Record<string, unknown>,
+  allowed: readonly string[],
+): void {
+  const unexpected = Object.keys(raw).find((key) => !allowed.includes(key));
+  if (unexpected) {
+    throw new ConfigError(`\`${path}.${unexpected}\` is not supported`);
+  }
+}
+
+function nonEmptyString(path: string, raw: unknown): string {
+  if (typeof raw !== "string" || raw.length === 0) {
+    throw new ConfigError(`\`${path}\` must be a non-empty string`);
+  }
+  return raw;
+}
+
+function optionalNonEmptyString(path: string, raw: unknown): string | undefined {
+  if (raw === undefined) return undefined;
+  return nonEmptyString(path, raw);
+}
+
+function optionalString(path: string, raw: unknown): string | undefined {
+  if (raw === undefined) return undefined;
+  if (typeof raw !== "string") throw new ConfigError(`\`${path}\` must be a string`);
+  return raw;
+}
+
+function optionalPooling(path: string, raw: unknown): "cls" | "mean" | undefined {
+  if (raw === undefined) return undefined;
+  if (raw === "cls" || raw === "mean") return raw;
+  throw new ConfigError(`\`${path}\` must be one of cls|mean`);
+}
+
+function optionalBoolean(path: string, raw: unknown): boolean | undefined {
+  if (raw === undefined) return undefined;
+  if (typeof raw !== "boolean") throw new ConfigError(`\`${path}\` must be a boolean`);
+  return raw;
 }
 
 function parseSkills(raw: unknown): SkillsConfig {
@@ -265,13 +489,19 @@ function parseHttpLike(
 export function mergeConfigs(configs: readonly RatelConfig[]): RatelConfig {
   const out: Record<string, ServerEntry> = {};
   let skills: SkillsConfig | undefined;
+  let retrieval: RetrievalConfig | undefined;
   for (const c of configs) {
     for (const [name, entry] of Object.entries(c.mcpServers)) {
       out[name] = entry;
     }
     if (c.skills) skills = c.skills;
+    if (c.retrieval) retrieval = c.retrieval;
   }
-  return skills ? { mcpServers: out, skills } : { mcpServers: out };
+  return {
+    mcpServers: out,
+    ...(skills ? { skills } : {}),
+    ...(retrieval ? { retrieval } : {}),
+  };
 }
 
 export class ConfigError extends Error {

--- a/packages/core/src/lib/gateway.test.ts
+++ b/packages/core/src/lib/gateway.test.ts
@@ -1,4 +1,6 @@
 import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { createServer } from "node:http";
+import type { AddressInfo } from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { UnauthorizedError } from "@modelcontextprotocol/sdk/client/auth.js";
@@ -6,7 +8,7 @@ import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
 import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
-import { type Skill, SkillCatalog } from "@ratel-ai/sdk";
+import { EmbedderError, type Skill, SkillCatalog } from "@ratel-ai/sdk";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   buildGatewayFromConfig,
@@ -47,7 +49,259 @@ async function startUpstream(tools: UpstreamSpec[], instructions?: string) {
   return { server, clientTransport };
 }
 
+async function startEmbeddingEndpoint(
+  vectorForText: (text: string) => number[] = deterministicEmbedding,
+  responseStatus = 200,
+) {
+  const requests: string[][] = [];
+  const server = createServer(async (request, response) => {
+    const chunks: Buffer[] = [];
+    for await (const chunk of request) chunks.push(Buffer.from(chunk));
+    const body = JSON.parse(Buffer.concat(chunks).toString("utf8")) as {
+      input?: string | string[];
+      model?: string;
+    };
+    const input = Array.isArray(body.input) ? body.input : [body.input ?? ""];
+    requests.push(input);
+    if (responseStatus !== 200) {
+      response.writeHead(responseStatus, { "content-type": "application/json" });
+      response.end(JSON.stringify({ error: { message: "deterministic endpoint failure" } }));
+      return;
+    }
+    response.writeHead(200, { "content-type": "application/json" });
+    response.end(
+      JSON.stringify({
+        object: "list",
+        model: body.model ?? "deterministic",
+        data: input.map((text, index) => ({
+          object: "embedding",
+          index,
+          embedding: vectorForText(text),
+        })),
+        usage: { prompt_tokens: input.length, total_tokens: input.length },
+      }),
+    );
+  });
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address() as AddressInfo;
+  return {
+    url: `http://127.0.0.1:${address.port}/v1/embeddings`,
+    requests,
+    close: () => new Promise<void>((resolve) => server.close(() => resolve())),
+  };
+}
+
+function deterministicEmbedding(text: string): number[] {
+  const normalized = text.toLowerCase();
+  if (/(weather|forecast|rain|climate|umbrella)/.test(normalized)) return [1, 0, 0];
+  if (/(deploy|release|production|vercel)/.test(normalized)) return [0, 1, 0];
+  if (/(database|schema|migration)/.test(normalized)) return [0, 0, 1];
+  return [0.1, 0.1, 0.1];
+}
+
 describe("buildGatewayFromConfig", () => {
+  it("uses the same semantic endpoint for tool and skill catalogs and recalls paraphrases", async () => {
+    const endpoint = await startEmbeddingEndpoint();
+    const upstream = await startUpstream([
+      {
+        name: "weather",
+        description: "Get the current weather forecast for a city.",
+      },
+      {
+        name: "deploy",
+        description: "Deploy an application release to production.",
+      },
+    ]);
+    try {
+      const handle = await buildGatewayFromConfig(
+        {
+          mcpServers: {
+            utilities: { type: "stdio", command: "noop" },
+          },
+          retrieval: {
+            method: "semantic",
+            embedding: { url: endpoint.url, model: "deterministic" },
+          },
+        },
+        {
+          transportFactory: () => upstream.clientTransport,
+          resolvedSkills: [
+            {
+              id: "weather-playbook",
+              name: "Weather planning",
+              description: "Decide whether the forecast calls for an umbrella.",
+            },
+            {
+              id: "release-playbook",
+              name: "Release playbook",
+              description: "Safely deploy a production release.",
+            },
+          ],
+        },
+      );
+
+      expect(endpoint.requests).toHaveLength(2);
+      expect((await handle.catalog.searchAsync("should I pack for rain?", 1))[0]?.toolId).toBe(
+        "utilities__weather",
+      );
+      expect(
+        (await handle.skillCatalog.searchAsync("should I bring an umbrella?", 1))[0]?.skillId,
+      ).toBe("weather-playbook");
+      expect(endpoint.requests).toHaveLength(4);
+
+      await handle.close();
+    } finally {
+      await upstream.server.close();
+      await endpoint.close();
+    }
+  });
+
+  it("keeps exact lexical matches in hybrid retrieval", async () => {
+    const endpoint = await startEmbeddingEndpoint(() => [1, 0, 0]);
+    const upstream = await startUpstream([
+      { name: "exact_release", description: "Run the lunar-release-42 deployment." },
+      { name: "other_release", description: "Deploy another production release." },
+    ]);
+    try {
+      const handle = await buildGatewayFromConfig(
+        {
+          mcpServers: { utilities: { type: "stdio", command: "noop" } },
+          retrieval: {
+            method: "hybrid",
+            embedding: { url: endpoint.url, model: "deterministic" },
+          },
+        },
+        { transportFactory: () => upstream.clientTransport },
+      );
+
+      expect((await handle.catalog.searchAsync("lunar-release-42", 1))[0]?.toolId).toBe(
+        "utilities__exact_release",
+      );
+      await handle.close();
+    } finally {
+      await upstream.server.close();
+      await endpoint.close();
+    }
+  });
+
+  it("does not contact an embedding endpoint when BM25 is selected", async () => {
+    const endpoint = await startEmbeddingEndpoint();
+    const upstream = await startUpstream([{ name: "weather", description: "Weather forecast." }]);
+    try {
+      const handle = await buildGatewayFromConfig(
+        {
+          mcpServers: { utilities: { type: "stdio", command: "noop" } },
+          retrieval: {
+            method: "bm25",
+            // parseConfig rejects this inactive combination. Keeping the test
+            // seam here proves the SDK's BM25 path itself remains traffic-free.
+            embedding: { url: endpoint.url, model: "must-not-be-called" },
+          },
+        },
+        { transportFactory: () => upstream.clientTransport },
+      );
+
+      expect(handle.catalog.search("weather", 1)[0]?.toolId).toBe("utilities__weather");
+      expect(endpoint.requests).toEqual([]);
+      await handle.close();
+    } finally {
+      await upstream.server.close();
+      await endpoint.close();
+    }
+  });
+
+  it("fails dense readiness with a typed error when corpus embedding fails", async () => {
+    const endpoint = await startEmbeddingEndpoint(deterministicEmbedding, 503);
+    try {
+      await expect(
+        buildGatewayFromConfig(
+          {
+            mcpServers: {},
+            retrieval: {
+              method: "semantic",
+              embedding: { url: endpoint.url, model: "deterministic" },
+            },
+          },
+          {
+            resolvedSkills: [
+              {
+                id: "weather-playbook",
+                name: "Weather planning",
+                description: "Plan around the weather forecast.",
+              },
+            ],
+          },
+        ),
+      ).rejects.toBeInstanceOf(EmbedderError);
+      expect(endpoint.requests).toHaveLength(1);
+    } finally {
+      await endpoint.close();
+    }
+  });
+
+  it("stores dense OAuth authorization without mutating the active generation", async () => {
+    const endpoint = await startEmbeddingEndpoint();
+    const closeAuthorizedHandle = vi.fn(async () => {});
+    const notify = vi.fn(async () => {});
+    try {
+      const handle = await buildGatewayFromConfig(
+        {
+          mcpServers: {
+            remote: { type: "http", url: "https://remote.example/mcp" },
+          },
+          retrieval: {
+            method: "semantic",
+            embedding: { url: endpoint.url, model: "deterministic" },
+          },
+        },
+        {
+          oauthStorePath: (name) => join(tmpdir(), `ratel-dense-auth-${name}-${Date.now()}.json`),
+          transportFactory: () => ({
+            async start() {
+              throw new UnauthorizedError("missing tokens");
+            },
+            async send() {},
+            async close() {},
+          }),
+          authStep: async () => ({
+            status: "authorized",
+            mode: "interactive",
+            handle: {
+              toolIds: ["remote__weather"],
+              serverInstructions: undefined,
+              close: closeAuthorizedHandle,
+            },
+          }),
+        },
+      );
+      handle.setListChangedNotifier(notify);
+
+      const results = await handle.runAuthFlow({ name: "remote" });
+
+      expect(results).toEqual([
+        expect.objectContaining({
+          name: "remote",
+          status: "authorized",
+          reason: expect.stringMatching(/reconnect.*new retrieval generation/i),
+        }),
+      ]);
+      expect(handle.catalog.has("remote__weather")).toBe(false);
+      expect(handle.upstreamServers).toContainEqual(
+        expect.objectContaining({ name: "remote", needsAuth: true }),
+      );
+      expect(closeAuthorizedHandle).toHaveBeenCalledOnce();
+      expect(notify).not.toHaveBeenCalled();
+      expect(endpoint.requests).toEqual([]);
+
+      await handle.close();
+    } finally {
+      await endpoint.close();
+    }
+  });
+
   it("awaits one batched registration for resolved gateway skills", async () => {
     const skills: Skill[] = [
       {

--- a/packages/core/src/lib/gateway.ts
+++ b/packages/core/src/lib/gateway.ts
@@ -1,20 +1,26 @@
 import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { resolve } from "node:path";
 import { UnauthorizedError } from "@modelcontextprotocol/sdk/client/auth.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
 import {
+  EmbedderError,
+  type EmbeddingSpec,
   type McpServerHandle,
   registerMcpServer,
+  type SearchMethod,
   type Skill,
   SkillCatalog,
   ToolCatalog,
+  type ToolCatalogOptions,
   type TraceSinkConfig,
   type UpstreamServerInfo,
 } from "@ratel-ai/sdk";
 import type { ResolvedMcpEntry } from "../resolved-mcp.js";
 import { recordToolTokenEstimate } from "../telemetry.js";
-import type { RatelConfig, ServerEntry } from "./config.js";
+import type { RatelConfig, RetrievalConfig, ServerEntry } from "./config.js";
 import { expandEnvPlaceholders } from "./env-placeholders.js";
 import {
   type AuthFlowOptions,
@@ -22,6 +28,7 @@ import {
   type AuthStep,
   defaultAuthStep,
   defaultOAuthStorePath,
+  markDenseAuthReconnectRequired,
   runAuthFlow,
 } from "./oauth/flow.js";
 import { RatelOAuthProvider } from "./oauth/provider.js";
@@ -73,6 +80,8 @@ export interface BuildGatewayOptions {
   loadSkills?: (dirs: string[], opts: { logger?: (message: string) => void }) => Promise<Skill[]>;
   /** Pre-resolved effective skills. When supplied, the gateway performs no discovery of its own. */
   resolvedSkills?: Skill[];
+  /** Resolved scoped retrieval block. Overrides config.retrieval when supplied. */
+  retrieval?: RetrievalConfig;
 }
 
 const PLACEHOLDER_REDIRECT_URL = "http://127.0.0.1:0/cb";
@@ -148,8 +157,13 @@ export async function buildGatewayFromConfig(
   const step = options.authStep ?? defaultAuthStep({ logger: log, storePath, storeFingerprint });
   const refreshTokens = options.refreshTokens ?? defaultRefreshTokens;
 
-  const catalog = new ToolCatalog(options.trace ? { trace: options.trace } : {});
-  const skillCatalog = await buildSkillCatalog(config, options, log);
+  const catalogOptions = resolveCatalogOptions(
+    options.retrieval ?? config.retrieval,
+    options.trace,
+  );
+  const denseRetrieval = isDenseMethod(catalogOptions.method);
+  const catalog = new ToolCatalog(catalogOptions);
+  const skillCatalog = await buildSkillCatalog(config, options, catalogOptions, log);
   const handles = new Map<string, McpServerHandle>();
   const upstreamServers: UpstreamServerInfo[] = [];
   const configEntries: Record<string, ServerEntry> = Object.fromEntries(
@@ -198,8 +212,9 @@ export async function buildGatewayFromConfig(
       }
     }
 
+    let transport: Transport | undefined;
     try {
-      const transport = factory(name, entry, runtime);
+      transport = factory(name, entry, runtime);
       if (!transport) {
         log(`[ratel] skipping ${name}: unsupported transport type "${entry.type}"`);
         continue;
@@ -215,6 +230,11 @@ export async function buildGatewayFromConfig(
       if (handle.serverInstructions) info.instructions = handle.serverInstructions;
       upstreamServers.push(info);
     } catch (err) {
+      if (denseRetrieval && err instanceof EmbedderError) {
+        await transport?.close().catch(() => undefined);
+        await closeGatewayHandles(handles, log);
+        throw err;
+      }
       if (isHttpOrSse(entry) && isAuthRequiredError(err)) {
         markNeedsAuth(upstreamServers, name, entry);
         catalog.recordEvent({ type: "auth_needs", upstream: name });
@@ -231,25 +251,43 @@ export async function buildGatewayFromConfig(
     catalog,
     skillCatalog,
     upstreamServers,
-    close: async () => {
-      const results = await Promise.allSettled(Array.from(handles.values()).map((h) => h.close()));
-      for (const r of results) {
-        if (r.status === "rejected") {
-          log(`[ratel] error during shutdown: ${(r.reason as Error)?.message ?? r.reason}`);
-        }
+    close: () => closeGatewayHandles(handles, log),
+    runAuthFlow: async (opts: AuthFlowOptions = {}) => {
+      if (!denseRetrieval) {
+        return runAuthFlow({
+          catalog,
+          upstreams: upstreamServers,
+          handles,
+          configEntries,
+          step,
+          opts,
+          onListChanged: () => listChangedNotifier?.(),
+          logger: log,
+        });
+      }
+
+      // Dense catalogs are immutable for the lifetime of one scoped gateway
+      // generation. Complete OAuth against an isolated BM25 catalog so tokens
+      // are persisted without hot-registering partially embedded tools into the
+      // active generation. Reconnecting acquires a freshly built generation.
+      const authCatalog = new ToolCatalog(options.trace ? { trace: options.trace } : {});
+      const authHandles = new Map<string, McpServerHandle>();
+      const authUpstreams = upstreamServers.map((upstream) => ({ ...upstream }));
+      try {
+        const results = await runAuthFlow({
+          catalog: authCatalog,
+          upstreams: authUpstreams,
+          handles: authHandles,
+          configEntries,
+          step,
+          opts,
+          logger: log,
+        });
+        return markDenseAuthReconnectRequired(results);
+      } finally {
+        await closeGatewayHandles(authHandles, log);
       }
     },
-    runAuthFlow: (opts: AuthFlowOptions = {}) =>
-      runAuthFlow({
-        catalog,
-        upstreams: upstreamServers,
-        handles,
-        configEntries,
-        step,
-        opts,
-        onListChanged: () => listChangedNotifier?.(),
-        logger: log,
-      }),
     setListChangedNotifier: (fn) => {
       listChangedNotifier = fn;
     },
@@ -264,9 +302,10 @@ export async function buildGatewayFromConfig(
 async function buildSkillCatalog(
   config: RatelConfig,
   options: BuildGatewayOptions,
+  catalogOptions: ToolCatalogOptions,
   log: (message: string) => void,
 ): Promise<SkillCatalog> {
-  const skillCatalog = new SkillCatalog(options.trace ? { trace: options.trace } : {});
+  const skillCatalog = new SkillCatalog(catalogOptions);
   if (options.resolvedSkills) {
     if (options.resolvedSkills.length > 0) {
       await skillCatalog.register(options.resolvedSkills);
@@ -275,16 +314,65 @@ async function buildSkillCatalog(
   }
   const dirs = options.skillDirs ?? config.skills?.dirs ?? defaultSkillDirs();
   const load = options.loadSkills ?? loadSkills;
+  let skills: Skill[];
   try {
-    const skills = await load(dirs, { logger: log });
-    if (skills.length > 0) {
-      await skillCatalog.register(skills);
-      log(`[ratel] loaded ${skills.length} skill(s)`);
-    }
+    skills = await load(dirs, { logger: log });
   } catch (err) {
     log(`[ratel] skill loading failed: ${(err as Error).message}`);
+    return skillCatalog;
+  }
+  if (skills.length > 0) {
+    // Dense registration failures deliberately escape and abort readiness.
+    await skillCatalog.register(skills);
+    log(`[ratel] loaded ${skills.length} skill(s)`);
   }
   return skillCatalog;
+}
+
+function resolveCatalogOptions(
+  retrieval: RetrievalConfig | undefined,
+  trace: TraceSinkConfig | undefined,
+): ToolCatalogOptions {
+  const method = retrieval?.method ?? "bm25";
+  const embedding = resolveEmbeddingSpec(retrieval?.embedding);
+  return {
+    ...(trace ? { trace } : {}),
+    ...(method !== "bm25" ? { method } : {}),
+    ...(embedding !== undefined ? { embedding } : {}),
+  };
+}
+
+function resolveEmbeddingSpec(embedding: EmbeddingSpec | undefined): EmbeddingSpec | undefined {
+  if (typeof embedding === "string") return expandHomeModelPath(embedding);
+  if (embedding && typeof embedding.local === "string") {
+    return { ...embedding, local: expandHomeModelPath(embedding.local) } as EmbeddingSpec;
+  }
+  return embedding;
+}
+
+function expandHomeModelPath(path: string): string {
+  if (path === "~") return homedir();
+  if (path.startsWith("~/")) return resolve(homedir(), path.slice(2));
+  return path;
+}
+
+function isDenseMethod(method: SearchMethod | undefined): boolean {
+  return method === "semantic" || method === "hybrid";
+}
+
+async function closeGatewayHandles(
+  handles: Map<string, McpServerHandle>,
+  log: (message: string) => void,
+): Promise<void> {
+  const results = await Promise.allSettled(
+    Array.from(handles.values()).map((handle) => handle.close()),
+  );
+  handles.clear();
+  for (const result of results) {
+    if (result.status === "rejected") {
+      log(`[ratel] error during shutdown: ${(result.reason as Error)?.message ?? result.reason}`);
+    }
+  }
 }
 
 export const defaultTransportFactory: TransportFactory = (name, entry, runtime) => {

--- a/packages/core/src/lib/index.ts
+++ b/packages/core/src/lib/index.ts
@@ -1,6 +1,7 @@
 export type {
   RatelConfig,
   RatelConfigDocument,
+  RetrievalConfig,
   ServerEntry,
   SkillEntry,
   SkillsConfig,
@@ -24,7 +25,13 @@ export type {
   AuthStep,
   AuthStepResult,
 } from "./oauth/flow.js";
-export { defaultAuthStep, defaultOAuthStorePath, runAuthFlow } from "./oauth/flow.js";
+export {
+  DENSE_AUTH_RECONNECT_REASON,
+  defaultAuthStep,
+  defaultOAuthStorePath,
+  markDenseAuthReconnectRequired,
+  runAuthFlow,
+} from "./oauth/flow.js";
 export { RatelOAuthProvider } from "./oauth/provider.js";
 export { RatelOAuthStore } from "./oauth/store.js";
 export type { CreateMcpServerOptions, McpServerHandle } from "./server.js";

--- a/packages/core/src/lib/oauth/flow.ts
+++ b/packages/core/src/lib/oauth/flow.ts
@@ -14,6 +14,9 @@ import { wrapTransportWithSendMutex } from "./transport-mutex.js";
 
 export type AuthMode = "refresh" | "interactive";
 
+export const DENSE_AUTH_RECONNECT_REASON =
+  "authorization stored; reconnect this agent/context to activate the upstream in a new retrieval generation";
+
 export interface AuthFlowOptions {
   /** Restrict the run to a single named upstream. Without it, every upstream marked needsAuth runs. */
   name?: string;
@@ -25,6 +28,14 @@ export interface AuthFlowResult {
   reason?: string;
   /** Which path produced this row (only meaningful when status === "authorized"). */
   mode?: AuthMode;
+}
+
+export function markDenseAuthReconnectRequired(
+  results: readonly AuthFlowResult[],
+): AuthFlowResult[] {
+  return results.map((result) =>
+    result.status === "authorized" ? { ...result, reason: DENSE_AUTH_RECONNECT_REASON } : result,
+  );
 }
 
 export interface AuthStepSuccess {

--- a/packages/core/src/lib/server.test.ts
+++ b/packages/core/src/lib/server.test.ts
@@ -7,6 +7,7 @@ import {
   ToolListChangedNotificationSchema,
 } from "@modelcontextprotocol/sdk/types.js";
 import {
+  EmbedderError,
   GET_SKILL_CONTENT_ID,
   INVOKE_TOOL_ID,
   registerMcpServer,
@@ -176,6 +177,41 @@ describe("createMcpServer", () => {
 
     await client.close();
     await handle.close();
+  });
+
+  it("keeps the advertised capability-tool schemas stable in dense mode", async () => {
+    const bm25 = await buildClientAgainst(new ToolCatalog());
+    const semantic = await buildClientAgainst(
+      new ToolCatalog({
+        method: "semantic",
+        embedding: {
+          url: "http://127.0.0.1:9/v1/embeddings",
+          model: "schema-only",
+        },
+      }),
+    );
+    try {
+      const bm25Tools = (await bm25.client.listTools()).tools;
+      const semanticTools = (await semantic.client.listTools()).tools;
+      expect(
+        semanticTools.map(({ name, inputSchema, outputSchema }) => ({
+          name,
+          inputSchema,
+          outputSchema,
+        })),
+      ).toEqual(
+        bm25Tools.map(({ name, inputSchema, outputSchema }) => ({
+          name,
+          inputSchema,
+          outputSchema,
+        })),
+      );
+    } finally {
+      await bm25.client.close();
+      await bm25.handle.close();
+      await semantic.client.close();
+      await semantic.handle.close();
+    }
   });
 
   it("search_tools (deprecated) still returns the pre-0.2.0 tools-only {groups} shape", async () => {
@@ -691,6 +727,50 @@ describe("createMcpServer skills", () => {
 
     await client.close();
     await handle.close();
+  });
+
+  it("returns typed embedding failures as structured MCP errors", async () => {
+    const catalog = new ToolCatalog();
+    const search = vi
+      .spyOn(catalog, "searchAsync")
+      .mockRejectedValue(new EmbedderError("endpoint unavailable", "Inference"));
+    const { client, handle } = await buildClientAgainst(catalog);
+    try {
+      const result = await client.callTool({
+        name: SEARCH_CAPABILITIES_ID,
+        arguments: { query: "weather forecast" },
+      });
+
+      expect(result.isError).toBe(true);
+      expect(result.structuredContent).toEqual({
+        error: "retrieval_failed",
+        code: "Inference",
+        message: "endpoint unavailable",
+        isError: true,
+      });
+
+      const listed = await client.listTools();
+      for (const name of [SEARCH_CAPABILITIES_ID, SEARCH_TOOLS_ID]) {
+        const outputSchema = listed.tools.find((tool) => tool.name === name)?.outputSchema as {
+          type?: string;
+          oneOf?: Array<{ required?: string[] }>;
+        };
+        expect(outputSchema.type).toBe("object");
+        expect(outputSchema.oneOf).toHaveLength(2);
+        expect(outputSchema.oneOf?.[1]?.required).toEqual(["error", "code", "message", "isError"]);
+      }
+
+      const legacyResult = await client.callTool({
+        name: SEARCH_TOOLS_ID,
+        arguments: { query: "weather forecast" },
+      });
+      expect(legacyResult.isError).toBe(true);
+      expect(legacyResult.structuredContent).toEqual(result.structuredContent);
+    } finally {
+      search.mockRestore();
+      await client.close();
+      await handle.close();
+    }
   });
 
   it("get_skill_content loads the body; instructions mention get_skill_content", async () => {

--- a/packages/core/src/lib/server.ts
+++ b/packages/core/src/lib/server.ts
@@ -2,10 +2,14 @@ import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
 import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
 import {
+  EmbedderError,
   type ExecutableTool,
   formatUpstreamLine,
   getSkillContentTool,
   invokeToolTool,
+  type JSONSchema7,
+  SEARCH_CAPABILITIES_ID,
+  SEARCH_TOOLS_ID,
   type SkillCatalog,
   searchCapabilitiesTool,
   searchToolsTool,
@@ -59,17 +63,17 @@ export async function createMcpServer(
 
   const gateway: Record<string, ExecutableTool> = {};
   const skills = hasSkills ? skillCatalog : undefined;
-  for (const tool of [
+  const searchCapabilities = withRetrievalErrorSchema(
     searchCapabilitiesTool(catalog, skills, { upstreamServers }),
-    invokeToolTool(catalog, { onUnauthorized }),
-  ]) {
+  );
+  for (const tool of [searchCapabilities, invokeToolTool(catalog, { onUnauthorized })]) {
     gateway[tool.name] = tool;
   }
   // Backward-compat: keep advertising the pre-0.2.0 `search_tools` (deprecated
   // alias, tools-only `{ groups }` result) so MCP clients that pinned its name
   // don't break on upgrade. New clients should use `search_capabilities` — which
   // also returns skills — so the description steers them there.
-  const legacySearch = searchToolsTool(catalog, { upstreamServers });
+  const legacySearch = withRetrievalErrorSchema(searchToolsTool(catalog, { upstreamServers }));
   gateway[legacySearch.name] = {
     ...legacySearch,
     description: `[Deprecated: prefer search_capabilities, which also returns skills.] ${legacySearch.description}`,
@@ -100,7 +104,23 @@ export async function createMcpServer(
       throw new Error(`unknown gateway tool: ${req.params.name}`);
     }
     const args = (req.params.arguments ?? {}) as Record<string, unknown>;
-    const out = await tool.execute(args);
+    let out: unknown;
+    try {
+      out = await tool.execute(args);
+    } catch (error) {
+      if (
+        !(error instanceof EmbedderError) ||
+        (req.params.name !== SEARCH_CAPABILITIES_ID && req.params.name !== SEARCH_TOOLS_ID)
+      ) {
+        throw error;
+      }
+      out = {
+        error: "retrieval_failed",
+        code: error.code,
+        message: error.message,
+        isError: true,
+      };
+    }
     return wrapResult(out);
   });
 
@@ -112,6 +132,29 @@ export async function createMcpServer(
     },
     notifyToolListChanged: async () => {
       await server.sendToolListChanged();
+    },
+  };
+}
+
+const RETRIEVAL_ERROR_SCHEMA: JSONSchema7 = {
+  type: "object",
+  properties: {
+    error: { const: "retrieval_failed" },
+    code: { type: "string" },
+    message: { type: "string" },
+    isError: { const: true },
+  },
+  required: ["error", "code", "message", "isError"],
+  additionalProperties: false,
+};
+
+function withRetrievalErrorSchema(tool: ExecutableTool): ExecutableTool {
+  if (!isObjectSchema(tool.outputSchema)) return tool;
+  return {
+    ...tool,
+    outputSchema: {
+      type: "object",
+      oneOf: [tool.outputSchema, RETRIEVAL_ERROR_SCHEMA],
     },
   };
 }

--- a/packages/core/src/operations.ts
+++ b/packages/core/src/operations.ts
@@ -34,6 +34,7 @@ import {
   type AuthFlowOptions,
   type AuthFlowResult,
   buildGatewayFromConfig,
+  markDenseAuthReconnectRequired,
   mergeConfigs,
   parseConfig,
   type RatelConfig,
@@ -710,10 +711,19 @@ export async function prepareAgentRatelMcpFallbackRemoval(
 }
 
 async function defaultAuthRunner(config: RatelConfig, ctx: CoreContext) {
-  const gateway = await buildGatewayFromConfig(config, { logger: ctx.log });
+  // Authorization only needs upstream transports and the OAuth store. Building
+  // the configured dense tool/skill catalogs here would load the embedding
+  // model before the user can authenticate.
+  const gateway = await buildGatewayFromConfig(
+    { mcpServers: config.mcpServers },
+    { logger: ctx.log },
+  );
+  const denseRetrieval =
+    config.retrieval?.method === "semantic" || config.retrieval?.method === "hybrid";
   return async (opts: AuthFlowOptions) => {
     try {
-      return await gateway.runAuthFlow(opts);
+      const results = await gateway.runAuthFlow(opts);
+      return denseRetrieval ? markDenseAuthReconnectRequired(results) : results;
     } finally {
       await gateway.close();
     }


### PR DESCRIPTION
## Summary

- add scoped, atomic `retrieval` configuration with BM25, semantic, and hybrid modes
- support built-in, local, Hugging Face, Ollama, and OpenAI-compatible embedding sources
- apply one retrieval configuration to tool and skill catalogs, with fail-closed dense startup
- preserve MCP output-schema correctness with explicit success/error unions for retrieval failures
- make OAuth authorization generation-safe without initializing dense retrieval in auth-only flows
- include activation-relevant OAuth state in runtime revisions so reconnecting clients receive a fresh dense catalog
- treat retrieval-only scopes as runtime content during agent linking

## Why

Ratel Local previously always used BM25 even though the upgraded SDK supports semantic and hybrid retrieval. This adds opt-in dense retrieval while keeping BM25 as the model-free default and preserving scoped configuration behavior.

## User impact

Users can select semantic or hybrid retrieval per resolved context. Dense startup fails explicitly when embedding cannot complete, credentials remain environment-backed, and newly authorized MCP tools become available through a fresh catalog generation after reconnect.

## Validation

- `pnpm lint`
- `pnpm typecheck`
- `pnpm test` — 922 tests passed
- `pnpm build`
- `pnpm check:pack`
- `git diff --check`
