### PR TITLE
feat: add scoped retrieval controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this package are documented here. The format is based on 
 
 ### Added
 - Added opt-in `semantic` and `hybrid` retrieval with scoped, atomic configuration; validated local, Hugging Face, Ollama, and OpenAI-compatible embedding sources; fail-closed dense startup; and generation-safe OAuth reconnect behavior. BM25 remains the model-free default.
+- Added `ratel-local retrieval status|configure|reset|prepare` and a Retrieval settings page, with transactional scoped writes, model/source preflight, and explicit cache, memory, multilingual, privacy, trace, and reconnect guidance.
 
 ### Changed
 - Upgraded `@ratel-ai/sdk` to 0.5.2. Direct SDK consumers must now await `ToolCatalog.register()` and `SkillCatalog.register()`; Ratel Local awaits every registration and batches gateway skills in one call.

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ The result should contain a `tools` bucket with matching upstream tools and a `s
 
 For troubleshooting and the complete setup guide, see the [Ratel Local quickstart](https://docs.ratel.sh/docs/local/quickstart).
 
-For configuration scopes, OAuth, skills, the local UI, telemetry, and library usage, see the [Ratel Local Docs](https://docs.ratel.sh/docs/local).
+For configuration scopes, OAuth, skills, the local UI, telemetry, and library usage, see the [Ratel Local Docs](https://docs.ratel.sh/docs/local). Repository contributors can also read the [retrieval configuration and preflight guide](docs/retrieval.md).
 
 ## How it works
 

--- a/apps/ratel-local/src/cli/args.test.ts
+++ b/apps/ratel-local/src/cli/args.test.ts
@@ -35,6 +35,24 @@ describe("parseArgs — group/verb routing", () => {
     expect(r.verb).toBeUndefined();
   });
 
+  it.each([
+    "status",
+    "configure",
+    "reset",
+    "prepare",
+  ] as const)("recognizes retrieval %s", (verb) => {
+    const result = parseArgs(["retrieval", verb, "--scope", "project"]);
+    expect(result).toMatchObject({
+      group: "retrieval",
+      verb,
+      flags: { scope: "project" },
+    });
+  });
+
+  it("rejects an unknown retrieval verb", () => {
+    expect(() => parseArgs(["retrieval", "download"])).toThrow(/unknown retrieval verb: download/);
+  });
+
   it.each(["list", "add", "remove"] as const)("recognizes project %s", (verb) => {
     const result = parseArgs(["project", verb, "/repo"]);
 

--- a/apps/ratel-local/src/cli/args.ts
+++ b/apps/ratel-local/src/cli/args.ts
@@ -1,6 +1,7 @@
 export type Group =
   | "mcp"
   | "backup"
+  | "retrieval"
   | "project"
   | "skill"
   | "doctor"
@@ -18,6 +19,8 @@ export type Group =
 export type McpVerb = "add" | "remove" | "list" | "get" | "edit" | "auth";
 
 export type BackupVerb = "list";
+
+export type RetrievalVerb = "status" | "configure" | "reset" | "prepare";
 
 export type ProjectVerb = "list" | "add" | "remove";
 
@@ -47,6 +50,8 @@ export type SkillVerb =
 const MCP_VERBS: ReadonlySet<string> = new Set(["add", "remove", "list", "get", "edit", "auth"]);
 
 const BACKUP_VERBS: ReadonlySet<string> = new Set(["list"]);
+
+const RETRIEVAL_VERBS: ReadonlySet<string> = new Set(["status", "configure", "reset", "prepare"]);
 
 const PROJECT_VERBS: ReadonlySet<string> = new Set(["list", "add", "remove"]);
 
@@ -154,6 +159,17 @@ export function parseArgs(argv: string[]): ParsedArgs {
       const candidate = argv[1];
       if (!BACKUP_VERBS.has(candidate)) {
         throw new ArgError(`unknown backup verb: ${candidate}`);
+      }
+      verb = candidate;
+      i = 2;
+    }
+  } else if (first === "retrieval") {
+    group = "retrieval";
+    i = 1;
+    if (argv.length > 1 && !argv[1].startsWith("-")) {
+      const candidate = argv[1];
+      if (!RETRIEVAL_VERBS.has(candidate)) {
+        throw new ArgError(`unknown retrieval verb: ${candidate}`);
       }
       verb = candidate;
       i = 2;

--- a/apps/ratel-local/src/cli/cli.test.ts
+++ b/apps/ratel-local/src/cli/cli.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
@@ -6,7 +6,7 @@ import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
 import type { BackupFs, JsonFs, ProjectRegistry } from "@ratel-ai/ratel-local-core";
-import { AUTH_TOOL_ID } from "@ratel-ai/ratel-local-core";
+import { AUTH_TOOL_ID, nodeFs } from "@ratel-ai/ratel-local-core";
 import { INVOKE_TOOL_ID, SEARCH_CAPABILITIES_ID, SEARCH_TOOLS_ID } from "@ratel-ai/sdk";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { runCli } from "./cli.js";
@@ -63,6 +63,65 @@ beforeEach(() => {
 afterEach(() => {
   if (previousTelemetry === undefined) delete process.env.RATEL_TELEMETRY;
   else process.env.RATEL_TELEMETRY = previousTelemetry;
+});
+
+describe("runCli — retrieval", () => {
+  it("configures, reports, prepares, and resets through the production scoped control plane", async () => {
+    const root = await mkdtemp(join(tmpdir(), "ratel-retrieval-cli-"));
+    const homeDir = join(root, "home");
+    await mkdir(join(homeDir, ".ratel"), { recursive: true });
+    const logs: string[] = [];
+    const preflighted: unknown[] = [];
+
+    try {
+      await runCli(["retrieval", "configure", "--method", "semantic", "--source", "built-in"], {
+        env: { homeDir },
+        fs: nodeFs,
+        logger: (message) => logs.push(message),
+      });
+      const configPath = join(homeDir, ".ratel", "config.json");
+      expect(JSON.parse(await readFile(configPath, "utf8")).retrieval).toEqual({
+        method: "semantic",
+      });
+
+      await runCli(["retrieval", "status"], {
+        env: { homeDir },
+        fs: nodeFs,
+        logger: (message) => logs.push(message),
+      });
+      expect(logs.join("\n")).toContain("effective semantic");
+
+      await runCli(["retrieval", "prepare"], {
+        env: { homeDir },
+        fs: nodeFs,
+        logger: (message) => logs.push(message),
+        retrievalPreflight: async (retrieval) => {
+          preflighted.push(retrieval);
+          return {
+            status: "ready",
+            method: retrieval.method,
+            source: "built-in",
+            model: "BAAI/bge-small-en-v1.5",
+            downloadedIfMissing: true,
+            runtimeMemoryMb: 130,
+            remoteDataTransfer: false,
+            reconnectRequired: true,
+            message: "built-in model ready",
+          };
+        },
+      });
+      expect(preflighted).toEqual([{ method: "semantic" }]);
+
+      await runCli(["retrieval", "reset"], {
+        env: { homeDir },
+        fs: nodeFs,
+        logger: (message) => logs.push(message),
+      });
+      expect(JSON.parse(await readFile(configPath, "utf8")).retrieval).toBeUndefined();
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
 });
 
 async function fakeUpstream() {

--- a/apps/ratel-local/src/cli/cli.ts
+++ b/apps/ratel-local/src/cli/cli.ts
@@ -19,6 +19,7 @@ import {
   nodeFs,
   type PreparedChangeCoordinator,
   type ProjectRegistry,
+  preflightRetrieval,
   type RatelScopeRef,
   ratelConfigPath,
   type SupportedAgentHostKind,
@@ -26,6 +27,7 @@ import {
 } from "@ratel-ai/ratel-local-core";
 import { type AgentPluginInstaller, installRatelAgentPlugin } from "../agent-plugin.js";
 import { ArgError, type ParsedArgs, parseArgs } from "./args.js";
+import { requestRunningDaemon, requireDaemonJson } from "./daemon-api.js";
 import { BACKUP_USAGE, runBackup } from "./handlers/backup.js";
 import { runConnect } from "./handlers/connect.js";
 import { daemonPaths, runDaemon } from "./handlers/daemon.js";
@@ -34,6 +36,7 @@ import { IMPORT_USAGE, runImport } from "./handlers/import.js";
 import { LINK_USAGE, runLink } from "./handlers/link.js";
 import { MCP_USAGE, runMcp } from "./handlers/mcp.js";
 import { PROJECT_USAGE, runProject } from "./handlers/project.js";
+import { type CliRetrievalMutator, RETRIEVAL_USAGE, runRetrieval } from "./handlers/retrieval.js";
 import { runServe } from "./handlers/serve.js";
 import { runSetup, SETUP_USAGE } from "./handlers/setup.js";
 import { runSkill, SKILL_USAGE } from "./handlers/skill.js";
@@ -59,6 +62,7 @@ export interface RunCliOptions {
   stdout?: (message: string) => void;
   projectRegistryFactory?: (homeDir: string) => ProjectRegistry;
   preparedChanges?: PreparedChangeCoordinator;
+  retrievalPreflight?: typeof preflightRetrieval;
 }
 
 export interface RunCliResult {
@@ -77,6 +81,7 @@ Commands:
   link     install the agent plugin, falling back to MCP config when needed
   mcp      manage MCP servers (add, remove, list, get, edit, auth)
   backup   manage backup snapshots (list)
+  retrieval manage scoped BM25, semantic, and hybrid retrieval
   project  manage registered project roots (list, add, remove)
   skill    manage scoped skills (skill import/list, add-scope, remove-scope, remove)
   doctor   recover interrupted mutations and diagnose scoped configuration/OAuth state
@@ -114,6 +119,11 @@ export async function runCli(argv: string[], options: RunCliOptions = {}): Promi
 
   if (parsed.group === "backup" && parsed.verb === undefined) {
     log(BACKUP_USAGE);
+    return {};
+  }
+
+  if (parsed.group === "retrieval" && parsed.verb === undefined) {
+    log(RETRIEVAL_USAGE);
     return {};
   }
 
@@ -227,6 +237,17 @@ export async function runCli(argv: string[], options: RunCliOptions = {}): Promi
     return {};
   }
 
+  if (parsed.group === "retrieval") {
+    const registry = options.projectRegistryFactory
+      ? options.projectRegistryFactory(ctx.env.homeDir)
+      : createProjectRegistry({ homeDir: ctx.env.homeDir });
+    await runRetrieval(ctx, {
+      mutateRetrieval: createCliRetrievalMutator(ctx, registry),
+      preflight: options.retrievalPreflight ?? preflightRetrieval,
+    });
+    return {};
+  }
+
   if (parsed.group === "project") {
     const registry = options.projectRegistryFactory
       ? options.projectRegistryFactory(ctx.env.homeDir)
@@ -268,6 +289,9 @@ function commandUsesPreparedChanges(parsed: ParsedArgs): boolean {
   if (parsed.group === "mcp") {
     return parsed.verb === "add" || parsed.verb === "edit" || parsed.verb === "remove";
   }
+  if (parsed.group === "retrieval") {
+    return parsed.verb === "configure" || parsed.verb === "reset";
+  }
   if (parsed.group === "skill") {
     return [
       "import",
@@ -279,6 +303,62 @@ function commandUsesPreparedChanges(parsed: ParsedArgs): boolean {
     ].includes(parsed.verb ?? "");
   }
   return false;
+}
+
+function createCliRetrievalMutator(
+  ctx: HandlerCtx,
+  registry: ProjectRegistry,
+): CliRetrievalMutator {
+  return async (request) => {
+    const { target, projectRoot } = await cliMutationTarget(ctx, registry, request.scope);
+    const path = ratelConfigPath(request.scope, {
+      homeDir: ctx.env.homeDir,
+      ...(projectRoot ? { projectRoot } : {}),
+    });
+    if (await mutateRetrievalThroughRunningDaemon(ctx, request, target)) {
+      return { path };
+    }
+    const preparedChanges =
+      ctx.preparedChanges ??
+      createPreparedChangeCoordinator({
+        mutationEngine: await createMutationEngine({
+          controlDir: join(ctx.env.homeDir, ".ratel"),
+        }),
+      });
+    const control = await createConfigControlPlane({
+      homeDir: ctx.env.homeDir,
+      projectRegistry: registry,
+      preparedChanges,
+      localGitExcludeManager: createLocalGitExcludeManager(),
+    });
+    await control.mutateRetrieval({
+      target,
+      action: request.action,
+      ...(request.retrieval ? { retrieval: request.retrieval } : {}),
+      ...(request.expectedRevision ? { expectedRevision: request.expectedRevision } : {}),
+    });
+    return { path };
+  };
+}
+
+async function mutateRetrievalThroughRunningDaemon(
+  ctx: HandlerCtx,
+  request: Parameters<CliRetrievalMutator>[0],
+  target: RatelScopeRef,
+): Promise<boolean> {
+  const projectQuery =
+    target.scope === "user" ? "" : `?projectId=${encodeURIComponent(target.projectId)}`;
+  const response = await requestRunningDaemon(ctx, `/api/retrieval${projectQuery}`, {
+    method: request.action === "reset" ? "DELETE" : "PATCH",
+    body: {
+      target,
+      ...(request.retrieval ? { retrieval: request.retrieval } : {}),
+      ...(request.expectedRevision ? { expectedRevision: request.expectedRevision } : {}),
+    },
+  });
+  if (!response) return false;
+  await requireDaemonJson(response, `retrieval ${request.action}`);
+  return true;
 }
 
 function createCliServerMutator(ctx: HandlerCtx, registry: ProjectRegistry): CliServerMutator {

--- a/apps/ratel-local/src/cli/handlers/retrieval.test.ts
+++ b/apps/ratel-local/src/cli/handlers/retrieval.test.ts
@@ -132,6 +132,53 @@ describe("retrieval CLI", () => {
     );
   });
 
+  it.each([
+    {
+      source: "huggingface",
+      sourceArgs: ["--model", "intfloat/e5-small-v2"],
+      unsupportedArgs: ["--url", "https://embed.example.test/v1/embeddings"],
+      flag: "url",
+    },
+    {
+      source: "local",
+      sourceArgs: ["--model", "/models/bge"],
+      unsupportedArgs: ["--revision", "main"],
+      flag: "revision",
+    },
+    {
+      source: "ollama",
+      sourceArgs: ["--model", "nomic-embed-text"],
+      unsupportedArgs: ["--url", "https://ollama.example.test"],
+      flag: "url",
+    },
+    {
+      source: "endpoint",
+      sourceArgs: [
+        "--model",
+        "text-embedding-3-small",
+        "--url",
+        "https://embed.example.test/v1/embeddings",
+      ],
+      unsupportedArgs: ["--pooling", "mean"],
+      flag: "pooling",
+    },
+  ])("rejects --$flag for the $source source", async ({ flag, source, sourceArgs, unsupportedArgs }) => {
+    const { ctx } = context([
+      "retrieval",
+      "configure",
+      "--method",
+      "semantic",
+      "--source",
+      source,
+      ...sourceArgs,
+      ...unsupportedArgs,
+    ]);
+
+    await expect(runRetrieval(ctx, { mutateRetrieval: vi.fn() })).rejects.toThrow(
+      `--${flag} is not valid with --source ${source}`,
+    );
+  });
+
   it("resets only the selected scope", async () => {
     const { ctx, log } = context(["retrieval", "reset", "--scope", "project"]);
     const mutateRetrieval = vi.fn<CliRetrievalMutator>().mockResolvedValue({

--- a/apps/ratel-local/src/cli/handlers/retrieval.test.ts
+++ b/apps/ratel-local/src/cli/handlers/retrieval.test.ts
@@ -1,0 +1,212 @@
+import type {
+  BackupFs,
+  JsonFs,
+  RetrievalConfig,
+  RetrievalPreflightResult,
+} from "@ratel-ai/ratel-local-core";
+import { describe, expect, it, vi } from "vitest";
+import { parseArgs } from "../args.js";
+import { type CliRetrievalMutator, runRetrieval } from "./retrieval.js";
+import type { HandlerCtx } from "./types.js";
+
+const HOME = "/home/u";
+const ROOT = "/repo";
+
+class MemFs implements BackupFs, JsonFs {
+  files = new Map<string, string>();
+
+  async read(path: string) {
+    return this.files.get(path) ?? null;
+  }
+  async write(path: string, contents: string) {
+    this.files.set(path, contents);
+  }
+  async writeAtomic(path: string, contents: string) {
+    this.files.set(path, contents);
+  }
+  async remove(path: string) {
+    this.files.delete(path);
+  }
+  async mkdirp() {}
+  async exists(path: string) {
+    return this.files.has(path);
+  }
+  async list() {
+    return [];
+  }
+}
+
+function context(argv: string[], fs = new MemFs()) {
+  const log: string[] = [];
+  const ctx: HandlerCtx = {
+    argv: parseArgs(argv),
+    env: { homeDir: HOME, projectRoot: ROOT },
+    fs,
+    log: (message) => log.push(message),
+    prompts: {
+      isCancel: () => false,
+      text: async () => "",
+      select: async () => "",
+      confirm: async () => true,
+      multiselect: async () => [],
+    },
+  };
+  return { ctx, fs, log };
+}
+
+describe("retrieval CLI", () => {
+  it("reports each scoped override and the effective rightmost configuration", async () => {
+    const { ctx, fs, log } = context(["retrieval", "status"]);
+    fs.files.set(
+      `${HOME}/.ratel/config.json`,
+      JSON.stringify({ retrieval: { method: "semantic" } }),
+    );
+    fs.files.set(
+      `${ROOT}/.ratel/config.json`,
+      JSON.stringify({
+        retrieval: { method: "hybrid", embedding: { ollama: "nomic-embed-text" } },
+      }),
+    );
+
+    await runRetrieval(ctx);
+
+    expect(log.join("\n")).toContain("user     semantic  built-in");
+    expect(log.join("\n")).toContain("project  hybrid    ollama:nomic-embed-text");
+    expect(log.join("\n")).toContain("local    inherited");
+    expect(log.join("\n")).toContain("effective hybrid    ollama:nomic-embed-text");
+    expect(log.join("\n")).toMatch(/reconnect.*agent\/context/i);
+  });
+
+  it("configures an endpoint source through the scoped mutation seam", async () => {
+    const { ctx, log } = context([
+      "retrieval",
+      "configure",
+      "--scope",
+      "local",
+      "--method",
+      "hybrid",
+      "--source",
+      "endpoint",
+      "--url",
+      "https://embed.example.test/v1/embeddings",
+      "--model",
+      "text-embedding-3-small",
+      "--api-key-env",
+      "EMBEDDING_API_KEY",
+    ]);
+    const mutateRetrieval = vi.fn<CliRetrievalMutator>().mockResolvedValue({
+      path: `${ROOT}/.ratel/config.local.json`,
+    });
+
+    await runRetrieval(ctx, { mutateRetrieval });
+
+    expect(mutateRetrieval).toHaveBeenCalledWith({
+      action: "configure",
+      scope: "local",
+      retrieval: {
+        method: "hybrid",
+        embedding: {
+          url: "https://embed.example.test/v1/embeddings",
+          model: "text-embedding-3-small",
+          apiKeyEnv: "EMBEDDING_API_KEY",
+        },
+      },
+    });
+    expect(log.join("\n")).toMatch(/reconnect.*agent\/context/i);
+  });
+
+  it("rejects inactive embedding flags under BM25", async () => {
+    const { ctx } = context([
+      "retrieval",
+      "configure",
+      "--method",
+      "bm25",
+      "--source",
+      "ollama",
+      "--model",
+      "nomic-embed-text",
+    ]);
+
+    await expect(runRetrieval(ctx, { mutateRetrieval: vi.fn() })).rejects.toThrow(
+      /BM25.*model-free/i,
+    );
+  });
+
+  it("resets only the selected scope", async () => {
+    const { ctx, log } = context(["retrieval", "reset", "--scope", "project"]);
+    const mutateRetrieval = vi.fn<CliRetrievalMutator>().mockResolvedValue({
+      path: `${ROOT}/.ratel/config.json`,
+    });
+
+    await runRetrieval(ctx, { mutateRetrieval });
+
+    expect(mutateRetrieval).toHaveBeenCalledWith({
+      action: "reset",
+      scope: "project",
+    });
+    expect(log.join("\n")).toContain("reset project retrieval override");
+  });
+
+  it("prepares the effective model and prints resource and privacy disclosures", async () => {
+    const { ctx, fs, log } = context(["retrieval", "prepare"]);
+    fs.files.set(
+      `${HOME}/.ratel/config.json`,
+      JSON.stringify({ retrieval: { method: "semantic" } }),
+    );
+    const result: RetrievalPreflightResult = {
+      status: "ready",
+      method: "semantic",
+      source: "built-in",
+      model: "BAAI/bge-small-en-v1.5",
+      downloadedIfMissing: true,
+      runtimeMemoryMb: 130,
+      remoteDataTransfer: false,
+      reconnectRequired: true,
+      message: "model ready",
+    };
+    const preflight = vi.fn().mockResolvedValue(result);
+
+    await runRetrieval(ctx, { preflight });
+
+    expect(preflight).toHaveBeenCalledWith({ method: "semantic" }, { homeDir: HOME });
+    expect(log.join("\n")).toContain("model ready");
+    expect(log.join("\n")).toContain("~130 MB");
+    expect(log.join("\n")).toContain("metadata and queries stay local");
+    expect(log.join("\n")).toMatch(/reconnect.*agent\/context/i);
+  });
+
+  it("prepares one explicit scope instead of the merged effective value", async () => {
+    const { ctx, fs } = context(["retrieval", "prepare", "--scope", "project"]);
+    fs.files.set(
+      `${HOME}/.ratel/config.json`,
+      JSON.stringify({ retrieval: { method: "semantic" } }),
+    );
+    fs.files.set(
+      `${ROOT}/.ratel/config.json`,
+      JSON.stringify({
+        retrieval: { method: "hybrid", embedding: { ollama: "nomic-embed-text" } },
+      }),
+    );
+    const preflight = vi.fn().mockResolvedValue({
+      status: "ready",
+      method: "hybrid",
+      source: "ollama",
+      model: "nomic-embed-text",
+      downloadedIfMissing: false,
+      runtimeMemoryMb: null,
+      remoteDataTransfer: false,
+      reconnectRequired: true,
+      message: "ollama ready",
+    } satisfies RetrievalPreflightResult);
+
+    await runRetrieval(ctx, { preflight });
+
+    expect(preflight).toHaveBeenCalledWith(
+      {
+        method: "hybrid",
+        embedding: { ollama: "nomic-embed-text" },
+      } satisfies RetrievalConfig,
+      { homeDir: HOME },
+    );
+  });
+});

--- a/apps/ratel-local/src/cli/handlers/retrieval.test.ts
+++ b/apps/ratel-local/src/cli/handlers/retrieval.test.ts
@@ -256,4 +256,18 @@ describe("retrieval CLI", () => {
       { homeDir: HOME },
     );
   });
+
+  it.each(["project", "local"])(
+    "rejects an explicit %s preflight outside a project context",
+    async (scope) => {
+      const { ctx } = context(["retrieval", "prepare", "--scope", scope]);
+      ctx.env = { homeDir: HOME };
+      const preflight = vi.fn();
+
+      await expect(runRetrieval(ctx, { preflight })).rejects.toThrow(
+        `scope "${scope}" requires a project root`,
+      );
+      expect(preflight).not.toHaveBeenCalled();
+    },
+  );
 });

--- a/apps/ratel-local/src/cli/handlers/retrieval.test.ts
+++ b/apps/ratel-local/src/cli/handlers/retrieval.test.ts
@@ -162,7 +162,12 @@ describe("retrieval CLI", () => {
       unsupportedArgs: ["--pooling", "mean"],
       flag: "pooling",
     },
-  ])("rejects --$flag for the $source source", async ({ flag, source, sourceArgs, unsupportedArgs }) => {
+  ])("rejects --$flag for the $source source", async ({
+    flag,
+    source,
+    sourceArgs,
+    unsupportedArgs,
+  }) => {
     const { ctx } = context([
       "retrieval",
       "configure",
@@ -257,17 +262,17 @@ describe("retrieval CLI", () => {
     );
   });
 
-  it.each(["project", "local"])(
-    "rejects an explicit %s preflight outside a project context",
-    async (scope) => {
-      const { ctx } = context(["retrieval", "prepare", "--scope", scope]);
-      ctx.env = { homeDir: HOME };
-      const preflight = vi.fn();
+  it.each([
+    "project",
+    "local",
+  ])("rejects an explicit %s preflight outside a project context", async (scope) => {
+    const { ctx } = context(["retrieval", "prepare", "--scope", scope]);
+    ctx.env = { homeDir: HOME };
+    const preflight = vi.fn();
 
-      await expect(runRetrieval(ctx, { preflight })).rejects.toThrow(
-        `scope "${scope}" requires a project root`,
-      );
-      expect(preflight).not.toHaveBeenCalled();
-    },
-  );
+    await expect(runRetrieval(ctx, { preflight })).rejects.toThrow(
+      `scope "${scope}" requires a project root`,
+    );
+    expect(preflight).not.toHaveBeenCalled();
+  });
 });

--- a/apps/ratel-local/src/cli/handlers/retrieval.ts
+++ b/apps/ratel-local/src/cli/handlers/retrieval.ts
@@ -1,0 +1,353 @@
+import {
+  documentRevision,
+  loadMergedConfig,
+  parseConfig,
+  type RatelScope,
+  type RetrievalConfig,
+  type RetrievalPreflightOptions,
+  type RetrievalPreflightResult,
+  ratelConfigPath,
+  readJson,
+  resolveScope,
+} from "@ratel-ai/ratel-local-core";
+import type { EmbeddingSpec } from "@ratel-ai/sdk";
+import { ArgError } from "../args.js";
+import type { HandlerCtx } from "./types.js";
+
+export const RETRIEVAL_USAGE = `usage: ratel-local retrieval <verb> [flags]
+
+Verbs:
+  status      show user/project/local overrides and the effective retrieval mode
+  configure   write one atomic retrieval override
+  reset       remove one scoped override and inherit the earlier scope
+  prepare     download/verify a model or check Ollama/endpoint availability
+
+Scopes:
+  --scope user|project|local   selected write/preflight scope (writes default to user)
+
+Configure:
+  --method bm25|semantic|hybrid
+  --source built-in|huggingface|local|ollama|endpoint
+  --model <id-or-path>         required except for built-in
+  --url <embeddings-url>       required for endpoint
+  --api-key-env <ENV_NAME>     endpoint bearer key environment variable
+  --revision <git-revision>    optional Hugging Face revision
+  --download / --no-download   Hugging Face startup download policy
+  --query-prefix <text>        optional query prefix
+  --doc-prefix <text>          optional document prefix
+  --pooling cls|mean           optional local/Hugging Face pooling`;
+
+export interface CliRetrievalMutationRequest {
+  action: "configure" | "reset";
+  scope: RatelScope;
+  retrieval?: RetrievalConfig;
+  expectedRevision?: ReturnType<typeof documentRevision>;
+}
+
+export type CliRetrievalMutator = (
+  request: CliRetrievalMutationRequest,
+) => Promise<{ path: string }>;
+
+export interface RetrievalHandlerDependencies {
+  mutateRetrieval?: CliRetrievalMutator;
+  preflight?: (
+    retrieval: RetrievalConfig,
+    options: RetrievalPreflightOptions,
+  ) => Promise<RetrievalPreflightResult>;
+}
+
+export async function runRetrieval(
+  ctx: HandlerCtx,
+  dependencies: RetrievalHandlerDependencies = {},
+): Promise<void> {
+  switch (ctx.argv.verb) {
+    case "status":
+      await showStatus(ctx);
+      return;
+    case "configure":
+      await configureRetrieval(ctx, dependencies);
+      return;
+    case "reset":
+      await resetRetrieval(ctx, dependencies);
+      return;
+    case "prepare":
+      await prepareRetrieval(ctx, dependencies);
+      return;
+    default:
+      throw new ArgError(`unknown retrieval verb: ${ctx.argv.verb}`);
+  }
+}
+
+async function showStatus(ctx: HandlerCtx): Promise<void> {
+  const scopes: RatelScope[] = ["user", "project", "local"];
+  for (const scope of scopes) {
+    const retrieval = await readScopedRetrieval(ctx, scope);
+    ctx.log(
+      `${scope.padEnd(9)}${retrieval ? `${retrieval.method.padEnd(10)}${sourceLabel(retrieval)}` : "inherited"}`,
+    );
+  }
+  const effective = (await loadMergedConfig(ctx))?.retrieval ?? { method: "bm25" as const };
+  ctx.log(`effective ${effective.method.padEnd(10)}${sourceLabel(effective)}`);
+  logLifecycleDisclosure(ctx, effective);
+}
+
+async function configureRetrieval(
+  ctx: HandlerCtx,
+  dependencies: RetrievalHandlerDependencies,
+): Promise<void> {
+  if (!dependencies.mutateRetrieval) {
+    throw new Error("retrieval mutation control plane is unavailable");
+  }
+  const scope = resolveScope(ctx.argv.flags.scope);
+  const retrieval = configuredRetrieval(ctx);
+  const expectedRevision = await scopedRevision(ctx, scope);
+  const result = await dependencies.mutateRetrieval({
+    action: "configure",
+    scope,
+    retrieval,
+    ...(expectedRevision ? { expectedRevision } : {}),
+  });
+  ctx.log(`configured ${scope} retrieval at ${result.path}`);
+  logLifecycleDisclosure(ctx, retrieval);
+}
+
+async function resetRetrieval(
+  ctx: HandlerCtx,
+  dependencies: RetrievalHandlerDependencies,
+): Promise<void> {
+  if (!dependencies.mutateRetrieval) {
+    throw new Error("retrieval mutation control plane is unavailable");
+  }
+  const scope = resolveScope(ctx.argv.flags.scope);
+  const expectedRevision = await scopedRevision(ctx, scope);
+  const result = await dependencies.mutateRetrieval({
+    action: "reset",
+    scope,
+    ...(expectedRevision ? { expectedRevision } : {}),
+  });
+  ctx.log(`reset ${scope} retrieval override at ${result.path}`);
+  ctx.log(
+    "Reconnect the affected agent/context to acquire the inherited retrieval generation; restart the daemon only if reconnecting is unavailable.",
+  );
+}
+
+async function prepareRetrieval(
+  ctx: HandlerCtx,
+  dependencies: RetrievalHandlerDependencies,
+): Promise<void> {
+  if (!dependencies.preflight) throw new Error("retrieval preflight is unavailable");
+  const scopeFlag = ctx.argv.flags.scope;
+  const retrieval =
+    scopeFlag === undefined
+      ? ((await loadMergedConfig(ctx))?.retrieval ?? { method: "bm25" as const })
+      : ((await readScopedRetrieval(ctx, resolveScope(scopeFlag))) ?? {
+          method: "bm25" as const,
+        });
+  const result = await dependencies.preflight(retrieval, { homeDir: ctx.env.homeDir });
+  ctx.log(result.message);
+  if (result.runtimeMemoryMb !== null) {
+    ctx.log(
+      `The loaded in-process model uses approximately ~${result.runtimeMemoryMb} MB of process memory and is shared by tool and skill catalogs.`,
+    );
+  }
+  ctx.log(
+    result.remoteDataTransfer
+      ? "Tool/skill metadata and retrieval queries are sent to the configured embedding endpoint."
+      : "Embedding metadata and queries stay local to this machine.",
+  );
+  if (result.source === "built-in") {
+    ctx.log(
+      "The pinned BAAI/bge-small-en-v1.5 model uses the Hugging Face cache and is English-focused; choose a multilingual Hugging Face model when needed.",
+    );
+  } else if (result.source === "huggingface") {
+    ctx.log("The prepared model uses the Hugging Face cache.");
+  }
+  ctx.log("Local retrieval traces remain under ~/.ratel/telemetry.");
+  if (result.reconnectRequired) {
+    ctx.log(
+      "Reconnect the affected agent/context to acquire the prepared retrieval generation; restart the daemon only as a fallback.",
+    );
+  }
+}
+
+function configuredRetrieval(ctx: HandlerCtx): RetrievalConfig {
+  const method = requiredFlag(ctx, "method");
+  if (method !== "bm25" && method !== "semantic" && method !== "hybrid") {
+    throw new ArgError("--method must be one of bm25|semantic|hybrid");
+  }
+  const source = optionalFlag(ctx, "source");
+  if (method === "bm25") {
+    if (source !== undefined || hasEmbeddingFlags(ctx)) {
+      throw new ArgError("BM25 is model-free; remove embedding source/model flags");
+    }
+    return { method };
+  }
+
+  const embedding = embeddingFromFlags(ctx, source ?? "built-in");
+  return parseConfig({
+    mcpServers: {},
+    retrieval: {
+      method,
+      ...(embedding !== undefined ? { embedding } : {}),
+    },
+  }).retrieval as RetrievalConfig;
+}
+
+function embeddingFromFlags(ctx: HandlerCtx, source: string): EmbeddingSpec | undefined {
+  const queryPrefix = optionalFlag(ctx, "query-prefix");
+  const docPrefix = optionalFlag(ctx, "doc-prefix");
+  const prefixes = {
+    ...(queryPrefix !== undefined ? { queryPrefix } : {}),
+    ...(docPrefix !== undefined ? { docPrefix } : {}),
+  };
+  if (source === "built-in") {
+    if (hasEmbeddingFlags(ctx)) {
+      throw new ArgError("built-in source does not accept model, URL, revision, or pooling flags");
+    }
+    return undefined;
+  }
+  if (source === "huggingface") {
+    const pooling = optionalPooling(ctx);
+    const revision = optionalFlag(ctx, "revision");
+    const download = optionalBooleanFlag(ctx, "download");
+    return {
+      huggingface: requiredFlag(ctx, "model"),
+      ...prefixes,
+      ...(revision !== undefined ? { revision } : {}),
+      ...(pooling !== undefined ? { pooling } : {}),
+      ...(download !== undefined ? { download } : {}),
+    };
+  }
+  if (source === "local") {
+    const pooling = optionalPooling(ctx);
+    return {
+      local: requiredFlag(ctx, "model"),
+      ...prefixes,
+      ...(pooling !== undefined ? { pooling } : {}),
+    };
+  }
+  if (source === "ollama") {
+    return { ollama: requiredFlag(ctx, "model"), ...prefixes };
+  }
+  if (source === "endpoint") {
+    const apiKeyEnv = optionalFlag(ctx, "api-key-env");
+    return {
+      url: requiredFlag(ctx, "url"),
+      model: requiredFlag(ctx, "model"),
+      ...prefixes,
+      ...(apiKeyEnv !== undefined ? { apiKeyEnv } : {}),
+    };
+  }
+  throw new ArgError("--source must be one of built-in|huggingface|local|ollama|endpoint");
+}
+
+async function readScopedRetrieval(
+  ctx: HandlerCtx,
+  scope: RatelScope,
+): Promise<RetrievalConfig | undefined> {
+  let path: string;
+  try {
+    path = ratelConfigPath(scope, ctx.env);
+  } catch {
+    return undefined;
+  }
+  const document = await readJson<unknown>(ctx.fs, path);
+  return document === null ? undefined : parseConfig(document).retrieval;
+}
+
+async function scopedRevision(
+  ctx: HandlerCtx,
+  scope: RatelScope,
+): Promise<ReturnType<typeof documentRevision> | undefined> {
+  const path = ratelConfigPath(scope, ctx.env);
+  const raw = await ctx.fs.read(path);
+  return raw === null ? undefined : documentRevision(Buffer.from(raw, "utf8"));
+}
+
+function sourceLabel(retrieval: RetrievalConfig): string {
+  const embedding = retrieval.embedding;
+  if (retrieval.method === "bm25") return "model-free";
+  if (embedding === undefined) return "built-in";
+  if (typeof embedding === "string") return `local:${embedding}`;
+  if (typeof embedding.huggingface === "string") return `huggingface:${embedding.huggingface}`;
+  if (typeof embedding.local === "string") return `local:${embedding.local}`;
+  if (typeof embedding.ollama === "string") return `ollama:${embedding.ollama}`;
+  return `endpoint:${embedding.model}`;
+}
+
+function logLifecycleDisclosure(ctx: HandlerCtx, retrieval: RetrievalConfig): void {
+  if (retrieval.method === "bm25") {
+    ctx.log("BM25 is model-free and performs no embedding downloads or requests.");
+    return;
+  }
+  const embedding = retrieval.embedding;
+  if (embedding === undefined) {
+    ctx.log(
+      "The pinned BAAI/bge-small-en-v1.5 model uses the Hugging Face cache, adds roughly 130 MB while loaded, and is English-focused; choose a multilingual Hugging Face model when needed.",
+    );
+  } else if (typeof embedding === "string" || typeof embedding.local === "string") {
+    ctx.log(
+      "The local in-process model keeps metadata and queries on this machine; memory varies.",
+    );
+  } else if (typeof embedding.huggingface === "string") {
+    ctx.log(
+      "The in-process model uses the Hugging Face cache; memory and multilingual coverage vary by model.",
+    );
+  } else if (typeof embedding.ollama === "string") {
+    ctx.log(
+      "Tool/skill metadata and retrieval queries are sent to the configured local Ollama service.",
+    );
+  } else {
+    ctx.log(
+      "Tool/skill metadata and retrieval queries are sent to the configured embedding endpoint.",
+    );
+  }
+  ctx.log("Local retrieval traces remain under ~/.ratel/telemetry.");
+  ctx.log(
+    "Dense retrieval changes apply to new gateway generations. Reconnect the affected agent/context; restart the daemon only as a fallback.",
+  );
+}
+
+const EMBEDDING_FLAGS = [
+  "model",
+  "url",
+  "api-key-env",
+  "revision",
+  "download",
+  "query-prefix",
+  "doc-prefix",
+  "pooling",
+] as const;
+
+function hasEmbeddingFlags(ctx: HandlerCtx, except: readonly string[] = []): boolean {
+  return EMBEDDING_FLAGS.some(
+    (flag) => !except.includes(flag) && ctx.argv.flags[flag] !== undefined,
+  );
+}
+
+function requiredFlag(ctx: HandlerCtx, name: string): string {
+  const value = optionalFlag(ctx, name);
+  if (value === undefined || value.length === 0) throw new ArgError(`--${name} is required`);
+  return value;
+}
+
+function optionalFlag(ctx: HandlerCtx, name: string): string | undefined {
+  const value = ctx.argv.flags[name];
+  if (value === undefined) return undefined;
+  if (typeof value !== "string") throw new ArgError(`--${name} requires one value`);
+  return value;
+}
+
+function optionalBooleanFlag(ctx: HandlerCtx, name: string): boolean | undefined {
+  const value = ctx.argv.flags[name];
+  if (value === undefined) return undefined;
+  if (typeof value !== "boolean") throw new ArgError(`--${name} does not accept a value`);
+  return value;
+}
+
+function optionalPooling(ctx: HandlerCtx): "cls" | "mean" | undefined {
+  const pooling = optionalFlag(ctx, "pooling");
+  if (pooling === undefined) return undefined;
+  if (pooling === "cls" || pooling === "mean") return pooling;
+  throw new ArgError("--pooling must be cls or mean");
+}

--- a/apps/ratel-local/src/cli/handlers/retrieval.ts
+++ b/apps/ratel-local/src/cli/handlers/retrieval.ts
@@ -231,12 +231,7 @@ function embeddingFromFlags(ctx: HandlerCtx, source: string): EmbeddingSpec | un
     };
   }
   if (source === "local") {
-    assertEmbeddingFlagsForSource(ctx, source, [
-      "model",
-      "query-prefix",
-      "doc-prefix",
-      "pooling",
-    ]);
+    assertEmbeddingFlagsForSource(ctx, source, ["model", "query-prefix", "doc-prefix", "pooling"]);
     const pooling = optionalPooling(ctx);
     return {
       local: requiredFlag(ctx, "model"),

--- a/apps/ratel-local/src/cli/handlers/retrieval.ts
+++ b/apps/ratel-local/src/cli/handlers/retrieval.ts
@@ -137,10 +137,14 @@ async function prepareRetrieval(
 ): Promise<void> {
   if (!dependencies.preflight) throw new Error("retrieval preflight is unavailable");
   const scopeFlag = ctx.argv.flags.scope;
+  const scope = scopeFlag === undefined ? undefined : resolveScope(scopeFlag);
+  if (scope !== undefined && scope !== "user" && !ctx.env.projectRoot) {
+    throw new ArgError(`scope "${scope}" requires a project root`);
+  }
   const retrieval =
-    scopeFlag === undefined
+    scope === undefined
       ? ((await loadMergedConfig(ctx))?.retrieval ?? { method: "bm25" as const })
-      : ((await readScopedRetrieval(ctx, resolveScope(scopeFlag))) ?? {
+      : ((await readScopedRetrieval(ctx, scope)) ?? {
           method: "bm25" as const,
         });
   const result = await dependencies.preflight(retrieval, { homeDir: ctx.env.homeDir });

--- a/apps/ratel-local/src/cli/handlers/retrieval.ts
+++ b/apps/ratel-local/src/cli/handlers/retrieval.ts
@@ -177,7 +177,7 @@ function configuredRetrieval(ctx: HandlerCtx): RetrievalConfig {
   }
   const source = optionalFlag(ctx, "source");
   if (method === "bm25") {
-    if (source !== undefined || hasEmbeddingFlags(ctx)) {
+    if (source !== undefined || unsupportedEmbeddingFlag(ctx, [])) {
       throw new ArgError("BM25 is model-free; remove embedding source/model flags");
     }
     return { method };
@@ -201,12 +201,20 @@ function embeddingFromFlags(ctx: HandlerCtx, source: string): EmbeddingSpec | un
     ...(docPrefix !== undefined ? { docPrefix } : {}),
   };
   if (source === "built-in") {
-    if (hasEmbeddingFlags(ctx)) {
+    if (unsupportedEmbeddingFlag(ctx, [])) {
       throw new ArgError("built-in source does not accept model, URL, revision, or pooling flags");
     }
     return undefined;
   }
   if (source === "huggingface") {
+    assertEmbeddingFlagsForSource(ctx, source, [
+      "model",
+      "revision",
+      "download",
+      "query-prefix",
+      "doc-prefix",
+      "pooling",
+    ]);
     const pooling = optionalPooling(ctx);
     const revision = optionalFlag(ctx, "revision");
     const download = optionalBooleanFlag(ctx, "download");
@@ -219,6 +227,12 @@ function embeddingFromFlags(ctx: HandlerCtx, source: string): EmbeddingSpec | un
     };
   }
   if (source === "local") {
+    assertEmbeddingFlagsForSource(ctx, source, [
+      "model",
+      "query-prefix",
+      "doc-prefix",
+      "pooling",
+    ]);
     const pooling = optionalPooling(ctx);
     return {
       local: requiredFlag(ctx, "model"),
@@ -227,9 +241,17 @@ function embeddingFromFlags(ctx: HandlerCtx, source: string): EmbeddingSpec | un
     };
   }
   if (source === "ollama") {
+    assertEmbeddingFlagsForSource(ctx, source, ["model", "query-prefix", "doc-prefix"]);
     return { ollama: requiredFlag(ctx, "model"), ...prefixes };
   }
   if (source === "endpoint") {
+    assertEmbeddingFlagsForSource(ctx, source, [
+      "model",
+      "url",
+      "api-key-env",
+      "query-prefix",
+      "doc-prefix",
+    ]);
     const apiKeyEnv = optionalFlag(ctx, "api-key-env");
     return {
       url: requiredFlag(ctx, "url"),
@@ -319,9 +341,23 @@ const EMBEDDING_FLAGS = [
   "pooling",
 ] as const;
 
-function hasEmbeddingFlags(ctx: HandlerCtx, except: readonly string[] = []): boolean {
-  return EMBEDDING_FLAGS.some(
-    (flag) => !except.includes(flag) && ctx.argv.flags[flag] !== undefined,
+function assertEmbeddingFlagsForSource(
+  ctx: HandlerCtx,
+  source: string,
+  allowed: readonly (typeof EMBEDDING_FLAGS)[number][],
+): void {
+  const unsupported = unsupportedEmbeddingFlag(ctx, allowed);
+  if (unsupported) {
+    throw new ArgError(`--${unsupported} is not valid with --source ${source}`);
+  }
+}
+
+function unsupportedEmbeddingFlag(
+  ctx: HandlerCtx,
+  allowed: readonly (typeof EMBEDDING_FLAGS)[number][],
+): (typeof EMBEDDING_FLAGS)[number] | undefined {
+  return EMBEDDING_FLAGS.find(
+    (flag) => !allowed.includes(flag) && ctx.argv.flags[flag] !== undefined,
   );
 }
 

--- a/apps/ratel-local/src/ui/server.test.ts
+++ b/apps/ratel-local/src/ui/server.test.ts
@@ -99,6 +99,7 @@ async function spin(
     | "skillDiscovery"
     | "skillImportControlPlane"
     | "skillRegistrationControlPlane"
+    | "retrievalPreflight"
     | "daemonToken"
     | "projectAdmissionLock"
   > = {},
@@ -992,6 +993,7 @@ describe("UI server — add / edit / remove", () => {
     const skillDiscovery = createSkillDiscovery({ homeDir });
     const mutationEngine = await createMutationEngine({ controlDir: join(homeDir, ".ratel") });
     const committedContexts: unknown[] = [];
+    const preflightedRetrieval: unknown[] = [];
     const preparedChanges = createPreparedChangeCoordinator({
       mutationEngine,
       publish: (contexts) => {
@@ -1030,6 +1032,20 @@ describe("UI server — add / edit / remove", () => {
       skillImportControlPlane,
       skillRegistrationControlPlane,
       preparedChanges,
+      retrievalPreflight: async (retrieval) => {
+        preflightedRetrieval.push(retrieval);
+        return {
+          status: "ready",
+          method: retrieval.method,
+          source: "ollama",
+          model: "nomic-embed-text",
+          downloadedIfMissing: false,
+          runtimeMemoryMb: null,
+          remoteDataTransfer: false,
+          reconnectRequired: true,
+          message: "Ollama model is ready.",
+        };
+      },
     });
 
     try {
@@ -1066,6 +1082,78 @@ describe("UI server — add / edit / remove", () => {
       expect(config.resolvedMcpEntries).toContainEqual(
         expect.objectContaining({ name: "filesystem", status: "effective" }),
       );
+
+      const configuredRetrieval = await fetch(`${base}/api/retrieval?projectId=${project.id}`, {
+        method: "PATCH",
+        headers,
+        body: JSON.stringify({
+          target: { scope: "local", projectId: project.id },
+          retrieval: {
+            method: "hybrid",
+            embedding: { ollama: "nomic-embed-text" },
+          },
+        }),
+      });
+      expect(configuredRetrieval.status).toBe(200);
+      expect(await configuredRetrieval.json()).toMatchObject({
+        action: "configure",
+        target: { scope: "local", projectId: project.id },
+        reconnectRequired: true,
+      });
+      expect(JSON.parse(await readFile(localPath, "utf8"))).toMatchObject({
+        custom: { keep: true },
+        skills: { dirs: [] },
+        mcpServers: { filesystem: { type: "stdio", command: "node" } },
+        retrieval: {
+          method: "hybrid",
+          embedding: { ollama: "nomic-embed-text" },
+        },
+      });
+      const retrievalConfig = (await (
+        await fetch(`${base}/api/config?projectId=${project.id}`, { headers })
+      ).json()) as {
+        effectiveRetrieval: { method: string; embedding?: { ollama?: string } };
+      };
+      expect(retrievalConfig.effectiveRetrieval).toEqual({
+        method: "hybrid",
+        embedding: { ollama: "nomic-embed-text" },
+      });
+
+      const preparedRetrieval = await fetch(
+        `${base}/api/retrieval/prepare?projectId=${project.id}`,
+        {
+          method: "POST",
+          headers,
+          body: JSON.stringify({
+            retrieval: {
+              method: "hybrid",
+              embedding: { ollama: "nomic-embed-text" },
+            },
+          }),
+        },
+      );
+      expect(preparedRetrieval.status).toBe(200);
+      expect(await preparedRetrieval.json()).toMatchObject({
+        status: "ready",
+        source: "ollama",
+        reconnectRequired: true,
+      });
+      expect(preflightedRetrieval).toEqual([
+        {
+          method: "hybrid",
+          embedding: { ollama: "nomic-embed-text" },
+        },
+      ]);
+
+      const resetRetrieval = await fetch(`${base}/api/retrieval?projectId=${project.id}`, {
+        method: "DELETE",
+        headers,
+        body: JSON.stringify({
+          target: { scope: "local", projectId: project.id },
+        }),
+      });
+      expect(resetRetrieval.status).toBe(200);
+      expect(JSON.parse(await readFile(localPath, "utf8")).retrieval).toBeUndefined();
 
       const createdSkill = await fetch(`${base}/api/skills?projectId=${project.id}`, {
         method: "POST",

--- a/apps/ratel-local/src/ui/server.ts
+++ b/apps/ratel-local/src/ui/server.ts
@@ -17,13 +17,19 @@ import {
   type DocumentRevision,
   documentRevision,
   InvalidContextSnapshotError,
+  loadMergedConfig,
   markDenseAuthReconnectRequired,
   type PreparedChangeCoordinator,
   type ProjectAdmissionLock,
   type ProjectId,
   type ProjectRegistry,
+  parseConfig,
   parseSkillMd,
+  preflightRetrieval,
   type RatelScopeRef,
+  type RetrievalConfig,
+  type RetrievalPreflightOptions,
+  type RetrievalPreflightResult,
   type RuntimeContextRef,
   readJson,
   type ServerEntry,
@@ -82,6 +88,10 @@ export interface StartUiServerOptions {
   /** Long-lived local daemon credential used by CLI API clients. */
   daemonToken?: string;
   canForgetProject?: CanForgetProject;
+  retrievalPreflight?: (
+    retrieval: RetrievalConfig,
+    options: RetrievalPreflightOptions,
+  ) => Promise<RetrievalPreflightResult>;
   publicRoute?: (req: IncomingMessage, res: ServerResponse, path: string) => Promise<boolean>;
 }
 
@@ -200,6 +210,7 @@ async function handleRequest(
       opts.skillImportControlPlane,
       opts.skillRegistrationControlPlane,
       opts.preparedChanges,
+      opts.retrievalPreflight ?? preflightRetrieval,
     );
     if (!response) {
       writeJson(res, 404, { error: "not found" });
@@ -231,6 +242,10 @@ async function route(
   skillImportControlPlane?: SkillImportControlPlane,
   skillRegistrationControlPlane?: SkillRegistrationControlPlane,
   preparedChanges?: PreparedChangeCoordinator,
+  retrievalPreflight: (
+    retrieval: RetrievalConfig,
+    options: RetrievalPreflightOptions,
+  ) => Promise<RetrievalPreflightResult> = preflightRetrieval,
 ): Promise<ApiResponse | null> {
   const method = req.method ?? "GET";
 
@@ -249,6 +264,45 @@ async function route(
 
   if (method === "GET" && path === "/api/config") {
     return getConfigWithSnapshot(ctx, runtimeContext, snapshotResolver);
+  }
+  if ((method === "PATCH" || method === "DELETE") && path === "/api/retrieval") {
+    if (!configControlPlane) return null;
+    const body = await readJsonBody(req);
+    const target = parseRatelScopeRef(body.target);
+    const expectedRevision = optionalDocumentRevision(body.expectedRevision);
+    const action = method === "DELETE" ? "reset" : "configure";
+    const retrieval = action === "configure" ? parseRetrievalBody(body.retrieval) : undefined;
+    const commit = await configControlPlane.mutateRetrieval({
+      target,
+      action,
+      ...(retrieval ? { retrieval } : {}),
+      ...(expectedRevision ? { expectedRevision } : {}),
+    });
+    return {
+      status: 200,
+      body: {
+        action,
+        target,
+        ...(retrieval ? { retrieval } : {}),
+        transactionId: commit.transactionId,
+        changedPaths: commit.changedPaths,
+        revisions: commit.revisions,
+        reconnectRequired: true,
+        reconnectMessage:
+          "Reconnect the affected agent/context to acquire the new retrieval generation; restart the daemon only as a fallback.",
+      },
+    };
+  }
+  if (method === "POST" && path === "/api/retrieval/prepare") {
+    const body = await readJsonBody(req);
+    const retrieval =
+      body.retrieval === undefined
+        ? ((await loadMergedConfig(ctx))?.retrieval ?? { method: "bm25" as const })
+        : parseRetrievalBody(body.retrieval);
+    return {
+      status: 200,
+      body: await retrievalPreflight(retrieval, { homeDir: ctx.env.homeDir }),
+    };
   }
   if (method === "GET" && path === "/api/projects" && projects) {
     return getProjectsRoute(projects);
@@ -633,8 +687,13 @@ async function getConfigWithSnapshot(
       documents: snapshot.documents,
       resolvedMcpEntries: snapshot.mcpEntries,
       diagnostics: snapshot.diagnostics,
+      effectiveRetrieval: snapshot.retrieval ?? { method: "bm25" },
     },
   };
+}
+
+function parseRetrievalBody(value: unknown): RetrievalConfig {
+  return parseConfig({ mcpServers: {}, retrieval: value }).retrieval as RetrievalConfig;
 }
 
 async function scopedAuthStatus(

--- a/docs/retrieval.md
+++ b/docs/retrieval.md
@@ -1,0 +1,142 @@
+# Retrieval configuration
+
+Ratel Local uses model-free BM25 retrieval unless a user, project, or local scope explicitly
+selects `semantic` or `hybrid`. The retrieval block is atomic: the rightmost scope that defines
+`retrieval` replaces the complete earlier block rather than merging individual fields.
+
+## Inspect and change retrieval
+
+```bash
+# Show user/project/local overrides and the effective value.
+ratel-local retrieval status
+
+# Keep the user scope model-free.
+ratel-local retrieval configure --scope user --method bm25
+
+# Use the pinned built-in model for one project.
+ratel-local retrieval configure \
+  --scope project \
+  --method hybrid \
+  --source built-in
+
+# Remove the project override and inherit the user scope again.
+ratel-local retrieval reset --scope project
+```
+
+`configure` and `reset` use the same revision checks, transaction journal, backup, and local
+Git-exclude safeguards as the rest of Ratel Local's scoped control plane.
+
+After a dense retrieval or OAuth change, reconnect the affected agent/context so it acquires a new
+gateway generation. Existing leases drain on their old immutable generation. Restart the whole
+daemon only when reconnecting the client is unavailable.
+
+## Embedding sources
+
+### Built-in
+
+Omitting `embedding`, or selecting `--source built-in`, uses the SDK 0.5.2 pinned
+`BAAI/bge-small-en-v1.5` model.
+
+```json
+{
+  "retrieval": {
+    "method": "semantic"
+  }
+}
+```
+
+The built-in model downloads into the Hugging Face cache when first prepared and adds roughly
+130 MB of resident process memory while loaded. It is shared by the tool and skill catalogs. It is
+English-focused; choose an appropriate multilingual Hugging Face model when non-English recall is
+important.
+
+### Hugging Face
+
+```bash
+ratel-local retrieval configure \
+  --scope project \
+  --method hybrid \
+  --source huggingface \
+  --model intfloat/multilingual-e5-small \
+  --revision main \
+  --download
+```
+
+`--download` controls whether dense startup may fetch a missing explicit Hugging Face model.
+`retrieval prepare` always opts the preflight into downloading a missing Hugging Face model without
+changing the persisted startup policy.
+
+### Local model directory
+
+```bash
+ratel-local retrieval configure \
+  --scope local \
+  --method semantic \
+  --source local \
+  --model ~/.cache/models/bge-small
+```
+
+Local paths must be absolute or start with `~/`. Model metadata and retrieval queries stay on the
+machine.
+
+### Ollama
+
+```bash
+ratel-local retrieval configure \
+  --scope project \
+  --method semantic \
+  --source ollama \
+  --model nomic-embed-text
+```
+
+Ollama runs outside the Ratel Local process. Preflight sends a representative embedding request to
+confirm that the configured local service and model are available.
+
+### OpenAI-compatible endpoint
+
+```bash
+export EMBEDDING_API_KEY=...
+
+ratel-local retrieval configure \
+  --scope project \
+  --method hybrid \
+  --source endpoint \
+  --url https://api.example.com/v1/embeddings \
+  --model text-embedding-3-small \
+  --api-key-env EMBEDDING_API_KEY
+```
+
+Literal API keys are rejected. `apiKeyEnv` names an environment variable that the daemon must
+receive. Tool and skill metadata are sent to the endpoint while indexing, and retrieval queries are
+sent during search. Choose an endpoint only when that transfer matches the data policy for the
+selected scope.
+
+## Preflight
+
+```bash
+# Prepare the effective merged configuration.
+ratel-local retrieval prepare
+
+# Prepare/check only the project override.
+ratel-local retrieval prepare --scope project
+```
+
+Preflight does not start the gateway:
+
+- BM25 returns immediately without a model or network request.
+- Built-in and Hugging Face sources download when missing, load, and embed a representative tool.
+- Local sources load and embed a representative tool.
+- Ollama and endpoint sources send one representative embedding request.
+- Endpoint preflight fails before the request when its `apiKeyEnv` is absent.
+
+The browser UI exposes the same source choices and preflight action under **Retrieval**.
+
+## Storage and lifecycle
+
+- Hugging Face models use the normal Hugging Face cache.
+- In-process built-in, Hugging Face, and local models use roughly 130 MB while loaded; actual
+  consumption varies with the selected model.
+- Tool and skill vectors remain in memory and rebuild for each new scoped gateway generation,
+  including process startup or a retrieval revision.
+- Local retrieval traces remain under `~/.ratel/telemetry`.
+- BM25 is always the zero-download, zero-embedding-request path.

--- a/packages/core/src/config-control-plane.test.ts
+++ b/packages/core/src/config-control-plane.test.ts
@@ -49,6 +49,129 @@ describe("ConfigControlPlane", () => {
     });
   });
 
+  it("configures retrieval without disturbing unrelated scoped settings", async () => {
+    const configPath = join(homeDir, ".ratel", "config.json");
+    await writeFile(
+      configPath,
+      `${JSON.stringify(
+        {
+          custom: { keep: true },
+          mcpServers: { filesystem: { type: "stdio", command: "node" } },
+        },
+        null,
+        2,
+      )}\n`,
+    );
+    const control = await createConfigControlPlane({
+      homeDir,
+      projectRegistry: createProjectRegistry({ homeDir }),
+    });
+
+    const preview = await control.prepareRetrievalMutation({
+      target: { scope: "user" },
+      action: "configure",
+      retrieval: {
+        method: "hybrid",
+        embedding: { huggingface: "intfloat/e5-small-v2", download: false },
+      },
+    });
+    expect(preview.preview).toMatchObject({
+      action: "configure",
+      target: { scope: "user" },
+      retrieval: {
+        method: "hybrid",
+        embedding: { huggingface: "intfloat/e5-small-v2", download: false },
+      },
+    });
+    await control.commit(preview.changeId);
+
+    expect(JSON.parse(await readFile(configPath, "utf8"))).toEqual({
+      custom: { keep: true },
+      mcpServers: { filesystem: { type: "stdio", command: "node" } },
+      retrieval: {
+        method: "hybrid",
+        embedding: { huggingface: "intfloat/e5-small-v2", download: false },
+      },
+    });
+  });
+
+  it("resets only the retrieval override and keeps the selected scope document", async () => {
+    const configPath = join(homeDir, ".ratel", "config.json");
+    await writeFile(
+      configPath,
+      `${JSON.stringify(
+        {
+          mcpServers: { filesystem: { type: "stdio", command: "node" } },
+          retrieval: { method: "semantic" },
+        },
+        null,
+        2,
+      )}\n`,
+    );
+    const control = await createConfigControlPlane({
+      homeDir,
+      projectRegistry: createProjectRegistry({ homeDir }),
+    });
+
+    await control.mutateRetrieval({
+      target: { scope: "user" },
+      action: "reset",
+    });
+
+    expect(JSON.parse(await readFile(configPath, "utf8"))).toEqual({
+      mcpServers: { filesystem: { type: "stdio", command: "node" } },
+    });
+  });
+
+  it("applies retrieval revision safeguards and local Git-exclude preparation", async () => {
+    const registry = createProjectRegistry({ homeDir });
+    const project = await registry.registerRoot(projectRoot);
+    const excludePath = join(projectRoot, ".git", "info", "exclude");
+    await mkdir(join(projectRoot, ".git", "info"), { recursive: true });
+    const ensuredRoots: string[] = [];
+    const control = await createConfigControlPlane({
+      homeDir,
+      projectRegistry: registry,
+      localGitExcludeManager: {
+        async preview(root) {
+          ensuredRoots.push(root);
+          return {
+            projectRoot: root,
+            excludePath,
+            changed: true,
+            currentContents: null,
+            contents: "# ratel local\n",
+            documentRevision: MISSING_DOCUMENT_REVISION,
+          };
+        },
+        async ensure(root) {
+          return { projectRoot: root, excludePath, changed: true };
+        },
+      },
+    });
+    const current = await control.read({ scope: "local", projectId: project.id });
+
+    const commit = await control.mutateRetrieval({
+      target: { scope: "local", projectId: project.id },
+      expectedRevision: current.documentRevision,
+      action: "configure",
+      retrieval: { method: "semantic" },
+    });
+
+    expect(commit.changedPaths).toEqual([
+      join(project.canonicalRoot, ".ratel", "config.local.json"),
+      excludePath,
+    ]);
+    expect(ensuredRoots).toEqual([project.canonicalRoot]);
+    await expect(
+      control.prepareRetrievalMutation({
+        target: { scope: "local", projectId: project.id },
+        expectedRevision: current.documentRevision,
+        action: "reset",
+      }),
+    ).rejects.toMatchObject({ statusCode: 409, reason: "revision_conflict" });
+  });
+
   it("targets project/local files only through a registered ProjectId", async () => {
     const registry = createProjectRegistry({ homeDir });
     const project = await registry.registerRoot(projectRoot);

--- a/packages/core/src/config-control-plane.ts
+++ b/packages/core/src/config-control-plane.ts
@@ -8,6 +8,7 @@ import {
   ConfigError,
   parseConfig,
   type RatelConfigDocument,
+  type RetrievalConfig,
   type ServerEntry,
 } from "./lib/config.js";
 import type { LocalGitExcludeManager } from "./local-git-exclude.js";
@@ -49,16 +50,33 @@ export interface ScopedConfigRead {
   documentRevision: DocumentRevision;
 }
 
+export type RetrievalMutationAction = "configure" | "reset";
+
+export interface ScopedRetrievalMutationRequest {
+  target: RatelScopeRef;
+  expectedRevision?: DocumentRevision;
+  action: RetrievalMutationAction;
+  retrieval?: RetrievalConfig;
+}
+
 export interface ConfigControlPlane {
   read(target: RatelScopeRef): Promise<ScopedConfigRead>;
   prepareServerMutation(
     request: ScopedServerMutationRequest,
   ): Promise<PreparedChange<ServerMutationReview>>;
-  commit(changeId: string): Promise<PreparedChangeCommit<ServerMutationResult>>;
+  prepareRetrievalMutation(
+    request: ScopedRetrievalMutationRequest,
+  ): Promise<PreparedChange<RetrievalMutationReview>>;
+  commit<DomainResult = ServerMutationResult>(
+    changeId: string,
+  ): Promise<PreparedChangeCommit<DomainResult>>;
   cancel(changeId: string): void;
   mutateServer(
     request: ScopedServerMutationRequest,
   ): Promise<PreparedChangeCommit<ServerMutationResult>>;
+  mutateRetrieval(
+    request: ScopedRetrievalMutationRequest,
+  ): Promise<PreparedChangeCommit<RetrievalMutationResult>>;
 }
 
 export interface ServerMutationReview {
@@ -72,6 +90,19 @@ export interface ServerMutationResult {
   action: ServerMutationAction;
   target: RatelScopeRef;
   name: string;
+}
+
+export interface RetrievalMutationReview {
+  action: RetrievalMutationAction;
+  target: RatelScopeRef;
+  retrieval?: RetrievalConfig;
+  files: MutationPreview["files"];
+}
+
+export interface RetrievalMutationResult {
+  action: RetrievalMutationAction;
+  target: RatelScopeRef;
+  retrieval?: RetrievalConfig;
 }
 
 export interface ConfigControlPlaneOptions {
@@ -321,7 +352,144 @@ class FilesystemConfigControlPlane implements ConfigControlPlane {
     return this.preparedChanges.commit(change.changeId);
   }
 
-  commit(changeId: string): Promise<PreparedChangeCommit<ServerMutationResult>> {
+  async prepareRetrievalMutation(
+    request: ScopedRetrievalMutationRequest,
+  ): Promise<PreparedChange<RetrievalMutationReview>> {
+    if (request.action === "configure" && request.retrieval === undefined) {
+      throw new MutationValidationError("configure requires a retrieval configuration");
+    }
+    let localGitOperation: { kind: "replace-file"; path: string; contents: string } | undefined;
+    let localGitRevision: DocumentRevision | undefined;
+    if (request.target.scope === "local" && this.options.localGitExcludeManager) {
+      const project = await this.resolveAvailableProject(request.target.projectId);
+      const preview = await this.options.localGitExcludeManager.preview(project.canonicalRoot);
+      if (preview.changed) {
+        localGitOperation = {
+          kind: "replace-file",
+          path: preview.excludePath,
+          contents: preview.contents,
+        };
+        localGitRevision = preview.documentRevision;
+      }
+    }
+
+    const current = await this.read(request.target);
+    if (
+      request.expectedRevision !== undefined &&
+      request.expectedRevision !== current.documentRevision
+    ) {
+      throw new MutationConflictError(
+        "revision_conflict",
+        `document changed before preview: ${current.path}`,
+        current.path,
+        request.expectedRevision,
+        current.documentRevision,
+      );
+    }
+
+    const document: RatelConfigDocument = { ...current.document };
+    if (request.action === "reset") {
+      delete document.retrieval;
+    } else {
+      document.retrieval = request.retrieval;
+    }
+    try {
+      parseConfig(document);
+    } catch (error) {
+      if (error instanceof ConfigError) {
+        throw new MutationValidationError(error.message);
+      }
+      throw error;
+    }
+
+    const operations = [
+      {
+        kind: "replace-file" as const,
+        path: current.path,
+        contents: `${JSON.stringify(document, null, 2)}\n`,
+      },
+      ...(localGitOperation ? [localGitOperation] : []),
+    ];
+    const projectRootsByPath = new Map<string, string>();
+    if (request.target.scope !== "user") {
+      const project = await this.resolveAvailableProject(request.target.projectId);
+      projectRootsByPath.set(current.path, project.canonicalRoot);
+    }
+    const allowedPaths = new Set(operations.map(({ path }) => path));
+    const result: RetrievalMutationResult = {
+      action: request.action,
+      target: request.target,
+      ...(request.retrieval ? { retrieval: request.retrieval } : {}),
+    };
+    return this.preparedChanges.prepare({
+      kind: `retrieval.${request.action}`,
+      operations,
+      affectedContexts: [contextForTarget(request.target)],
+      buildPreview: (mutation) => {
+        const previewRevision = mutation.baseRevisions[current.path];
+        if (previewRevision !== current.documentRevision) {
+          throw new MutationConflictError(
+            "revision_conflict",
+            `document changed while creating preview: ${current.path}`,
+            current.path,
+            current.documentRevision,
+            previewRevision,
+          );
+        }
+        if (
+          localGitOperation &&
+          localGitRevision !== undefined &&
+          mutation.baseRevisions[localGitOperation.path] !== localGitRevision
+        ) {
+          throw new MutationConflictError(
+            "revision_conflict",
+            `Git exclude changed while creating preview: ${localGitOperation.path}`,
+            localGitOperation.path,
+            localGitRevision,
+            mutation.baseRevisions[localGitOperation.path],
+          );
+        }
+        return {
+          ...result,
+          files: mutation.preview.files,
+        };
+      },
+      invariants: {
+        precondition: async () => {
+          for (const [path, projectRoot] of projectRootsByPath) {
+            await assertSafeProjectControlPath(projectRoot, path);
+          }
+        },
+        operationPrecondition: async (operation) => {
+          if (!allowedPaths.has(operation.path)) {
+            throw new MutationConflictError(
+              "digest_mismatch",
+              `retrieval mutation contains an unexpected path: ${operation.path}`,
+            );
+          }
+          const projectRoot = projectRootsByPath.get(operation.path);
+          if (projectRoot) await assertSafeProjectControlPath(projectRoot, operation.path);
+        },
+      },
+      captureBackup: async () => {
+        const backup = startBackup({ homeDir: this.options.homeDir }, nodeFs);
+        for (const { path } of operations) await backup.capture(path);
+        return backup.finalize(request.action === "reset" ? "remove" : "edit");
+      },
+      result,
+    });
+  }
+
+  async mutateRetrieval(
+    request: ScopedRetrievalMutationRequest,
+  ): Promise<PreparedChangeCommit<RetrievalMutationResult>> {
+    const change = await this.prepareRetrievalMutation(request);
+    return this.preparedChanges.commit(change.changeId);
+  }
+
+  commit<DomainResult = ServerMutationResult>(
+    changeId: string,
+  ): Promise<PreparedChangeCommit<DomainResult>> {
     return this.preparedChanges.commit(changeId);
   }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -22,6 +22,7 @@ export * from "./project-admission.js";
 export * from "./project-path-safety.js";
 export * from "./project-registry.js";
 export * from "./resolved-mcp.js";
+export * from "./retrieval-preflight.js";
 export * from "./skill-copy-adoption.js";
 export * from "./skill-discovery.js";
 export * from "./skill-document.js";

--- a/packages/core/src/retrieval-preflight.test.ts
+++ b/packages/core/src/retrieval-preflight.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it, vi } from "vitest";
+import { preflightRetrieval } from "./retrieval-preflight.js";
+
+describe("retrieval preflight", () => {
+  it("keeps BM25 model-free and does not invoke the dense probe", async () => {
+    const probe = vi.fn();
+
+    await expect(
+      preflightRetrieval({ method: "bm25" }, { homeDir: "/home/u", env: {}, probe }),
+    ).resolves.toMatchObject({
+      status: "not-required",
+      method: "bm25",
+      source: "none",
+    });
+    expect(probe).not.toHaveBeenCalled();
+  });
+
+  it("prepares the pinned built-in model and reports its runtime disclosures", async () => {
+    const probe = vi.fn().mockResolvedValue(undefined);
+
+    const result = await preflightRetrieval(
+      { method: "semantic" },
+      { homeDir: "/home/u", env: {}, probe },
+    );
+
+    expect(probe).toHaveBeenCalledWith({
+      method: "semantic",
+      embedding: undefined,
+    });
+    expect(result).toMatchObject({
+      status: "ready",
+      method: "semantic",
+      source: "built-in",
+      model: "BAAI/bge-small-en-v1.5",
+      runtimeMemoryMb: 130,
+      remoteDataTransfer: false,
+    });
+  });
+
+  it("opts Hugging Face preparation into download without changing persisted config", async () => {
+    const probe = vi.fn().mockResolvedValue(undefined);
+    const retrieval = {
+      method: "hybrid" as const,
+      embedding: {
+        huggingface: "intfloat/multilingual-e5-small",
+        revision: "main",
+        download: false,
+      },
+    };
+
+    const result = await preflightRetrieval(retrieval, {
+      homeDir: "/home/u",
+      env: {},
+      probe,
+    });
+
+    expect(probe).toHaveBeenCalledWith({
+      method: "hybrid",
+      embedding: {
+        huggingface: "intfloat/multilingual-e5-small",
+        revision: "main",
+        download: true,
+      },
+    });
+    expect(retrieval.embedding.download).toBe(false);
+    expect(result).toMatchObject({
+      status: "ready",
+      source: "huggingface",
+      model: "intfloat/multilingual-e5-small",
+      downloadedIfMissing: true,
+    });
+  });
+
+  it("expands tilde local paths before checking the model", async () => {
+    const probe = vi.fn().mockResolvedValue(undefined);
+
+    await preflightRetrieval(
+      {
+        method: "semantic",
+        embedding: { local: "~/.cache/models/bge" },
+      },
+      { homeDir: "/home/u", env: {}, probe },
+    );
+
+    expect(probe).toHaveBeenCalledWith({
+      method: "semantic",
+      embedding: { local: "/home/u/.cache/models/bge" },
+    });
+  });
+
+  it("fails before a remote request when apiKeyEnv is not available", async () => {
+    const probe = vi.fn();
+
+    await expect(
+      preflightRetrieval(
+        {
+          method: "semantic",
+          embedding: {
+            url: "https://embeddings.example.test/v1/embeddings",
+            model: "text-embedding-3-small",
+            apiKeyEnv: "EMBEDDING_API_KEY",
+          },
+        },
+        { homeDir: "/home/u", env: {}, probe },
+      ),
+    ).rejects.toMatchObject({
+      code: "RETRIEVAL_PREFLIGHT_FAILED",
+      reason: "missing_api_key_env",
+    });
+    expect(probe).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    {
+      embedding: { ollama: "nomic-embed-text" },
+      source: "ollama",
+      model: "nomic-embed-text",
+      remoteDataTransfer: false,
+    },
+    {
+      embedding: {
+        url: "http://127.0.0.1:8080/v1/embeddings",
+        model: "bge-small",
+      },
+      source: "endpoint",
+      model: "bge-small",
+      remoteDataTransfer: true,
+    },
+  ] as const)("checks $source availability with a real embedding probe", async (testCase) => {
+    const probe = vi.fn().mockResolvedValue(undefined);
+
+    const result = await preflightRetrieval(
+      { method: "semantic", embedding: testCase.embedding },
+      { homeDir: "/home/u", env: {}, probe },
+    );
+
+    expect(probe).toHaveBeenCalledOnce();
+    expect(result).toMatchObject({
+      status: "ready",
+      source: testCase.source,
+      model: testCase.model,
+      remoteDataTransfer: testCase.remoteDataTransfer,
+    });
+  });
+});

--- a/packages/core/src/retrieval-preflight.ts
+++ b/packages/core/src/retrieval-preflight.ts
@@ -1,0 +1,191 @@
+import { join } from "node:path";
+import { type EmbeddingSpec, ToolCatalog } from "@ratel-ai/sdk";
+import type { RetrievalConfig } from "./lib/config.js";
+
+export const BUILT_IN_RETRIEVAL_MODEL = "BAAI/bge-small-en-v1.5";
+export const BUILT_IN_RETRIEVAL_RUNTIME_MEMORY_MB = 130;
+
+export type RetrievalPreflightSource =
+  | "none"
+  | "built-in"
+  | "huggingface"
+  | "local"
+  | "ollama"
+  | "endpoint";
+
+export interface RetrievalPreflightResult {
+  status: "ready" | "not-required";
+  method: RetrievalConfig["method"];
+  source: RetrievalPreflightSource;
+  model?: string;
+  downloadedIfMissing: boolean;
+  runtimeMemoryMb: number | null;
+  remoteDataTransfer: boolean;
+  reconnectRequired: boolean;
+  message: string;
+}
+
+export type RetrievalProbe = (retrieval: RetrievalConfig) => Promise<void>;
+
+export interface RetrievalPreflightOptions {
+  homeDir: string;
+  env?: Readonly<Record<string, string | undefined>>;
+  probe?: RetrievalProbe;
+}
+
+export class RetrievalPreflightError extends Error {
+  readonly code = "RETRIEVAL_PREFLIGHT_FAILED";
+
+  constructor(
+    readonly reason: "missing_api_key_env" | "probe_failed",
+    message: string,
+    options?: ErrorOptions,
+  ) {
+    super(message, options);
+    this.name = "RetrievalPreflightError";
+  }
+}
+
+export async function preflightRetrieval(
+  retrieval: RetrievalConfig,
+  options: RetrievalPreflightOptions,
+): Promise<RetrievalPreflightResult> {
+  if (retrieval.method === "bm25") {
+    return {
+      status: "not-required",
+      method: retrieval.method,
+      source: "none",
+      downloadedIfMissing: false,
+      runtimeMemoryMb: null,
+      remoteDataTransfer: false,
+      reconnectRequired: false,
+      message: "BM25 is model-free; no model download or embedding service is required.",
+    };
+  }
+
+  const source = describeSource(retrieval.embedding);
+  const env = options.env ?? process.env;
+  if (
+    source.source === "endpoint" &&
+    source.apiKeyEnv &&
+    !nonEmptyEnvironmentValue(env[source.apiKeyEnv])
+  ) {
+    throw new RetrievalPreflightError(
+      "missing_api_key_env",
+      `embedding endpoint requires environment variable ${source.apiKeyEnv}`,
+    );
+  }
+
+  const preparedRetrieval: RetrievalConfig = {
+    method: retrieval.method,
+    embedding: prepareEmbedding(retrieval.embedding, options.homeDir),
+  };
+  try {
+    await (options.probe ?? defaultRetrievalProbe)(preparedRetrieval);
+  } catch (error) {
+    if (error instanceof RetrievalPreflightError) throw error;
+    throw new RetrievalPreflightError(
+      "probe_failed",
+      `embedding preflight failed: ${errorMessage(error)}`,
+      { cause: error },
+    );
+  }
+
+  return {
+    status: "ready",
+    method: retrieval.method,
+    source: source.source,
+    model: source.model,
+    downloadedIfMissing: source.source === "built-in" || source.source === "huggingface",
+    runtimeMemoryMb: source.source === "built-in" ? BUILT_IN_RETRIEVAL_RUNTIME_MEMORY_MB : null,
+    remoteDataTransfer: source.source === "endpoint",
+    reconnectRequired: true,
+    message: preflightMessage(source.source, source.model),
+  };
+}
+
+function prepareEmbedding(
+  embedding: EmbeddingSpec | undefined,
+  homeDir: string,
+): EmbeddingSpec | undefined {
+  if (embedding === undefined) return undefined;
+  if (typeof embedding === "string") return expandHomePath(embedding, homeDir);
+  if (typeof embedding.huggingface === "string") {
+    return { ...embedding, huggingface: embedding.huggingface, download: true };
+  }
+  if (typeof embedding.local === "string") {
+    return { ...embedding, local: expandHomePath(embedding.local, homeDir) };
+  }
+  return { ...embedding };
+}
+
+function describeSource(embedding: EmbeddingSpec | undefined): {
+  source: Exclude<RetrievalPreflightSource, "none">;
+  model: string;
+  apiKeyEnv?: string;
+} {
+  if (embedding === undefined) {
+    return { source: "built-in", model: BUILT_IN_RETRIEVAL_MODEL };
+  }
+  if (typeof embedding === "string") return { source: "local", model: embedding };
+  if (typeof embedding.huggingface === "string") {
+    return { source: "huggingface", model: embedding.huggingface };
+  }
+  if (typeof embedding.local === "string") return { source: "local", model: embedding.local };
+  if (typeof embedding.ollama === "string") return { source: "ollama", model: embedding.ollama };
+  return {
+    source: "endpoint",
+    model: embedding.model as string,
+    ...(embedding.apiKeyEnv ? { apiKeyEnv: embedding.apiKeyEnv } : {}),
+  };
+}
+
+async function defaultRetrievalProbe(retrieval: RetrievalConfig): Promise<void> {
+  const catalog = new ToolCatalog({
+    method: retrieval.method,
+    ...(retrieval.embedding !== undefined ? { embedding: retrieval.embedding } : {}),
+  });
+  await catalog.register({
+    id: "ratel_retrieval_preflight",
+    name: "ratel_retrieval_preflight",
+    description: "Verify that the configured embedding model can index a representative tool.",
+    inputSchema: {
+      type: "object",
+      properties: {},
+      additionalProperties: false,
+    },
+    outputSchema: {
+      type: "object",
+      properties: { ok: { type: "boolean" } },
+      required: ["ok"],
+      additionalProperties: false,
+    },
+    execute: () => ({ ok: true }),
+  });
+}
+
+function expandHomePath(path: string, homeDir: string): string {
+  if (path === "~") return homeDir;
+  if (path.startsWith("~/")) return join(homeDir, path.slice(2));
+  return path;
+}
+
+function nonEmptyEnvironmentValue(value: string | undefined): boolean {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function preflightMessage(
+  source: Exclude<RetrievalPreflightSource, "none">,
+  model: string,
+): string {
+  if (source === "built-in" || source === "huggingface") {
+    return `${model} is available in the Hugging Face cache and passed an embedding probe.`;
+  }
+  if (source === "local") return `${model} loaded and passed an embedding probe.`;
+  if (source === "ollama") return `Ollama model ${model} responded to an embedding probe.`;
+  return `Embedding endpoint model ${model} responded to an embedding probe.`;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -11,6 +11,7 @@ import {
   Search,
   Server,
   Settings2,
+  SlidersHorizontal,
   Sparkles,
   UserCircle,
 } from "lucide-react";
@@ -88,7 +89,40 @@ export interface ServerEntry {
 
 export interface RatelConfig {
   mcpServers: Record<string, ServerEntry>;
+  retrieval?: RetrievalConfig;
 }
+
+export type RetrievalConfig = {
+  method: "bm25" | "semantic" | "hybrid";
+  embedding?:
+    | string
+    | {
+        huggingface: string;
+        revision?: string;
+        queryPrefix?: string;
+        docPrefix?: string;
+        pooling?: "cls" | "mean";
+        download?: boolean;
+      }
+    | {
+        local: string;
+        queryPrefix?: string;
+        docPrefix?: string;
+        pooling?: "cls" | "mean";
+      }
+    | {
+        ollama: string;
+        queryPrefix?: string;
+        docPrefix?: string;
+      }
+    | {
+        url: string;
+        model: string;
+        apiKeyEnv?: string;
+        queryPrefix?: string;
+        docPrefix?: string;
+      };
+};
 
 export interface BackupManifest {
   createdAt: string;
@@ -117,6 +151,7 @@ export interface ConfigResponse {
     path: string;
   }>;
   runtimeRevision?: string;
+  effectiveRetrieval?: RetrievalConfig;
 }
 
 export interface ServerToolTokenEstimate {
@@ -403,7 +438,7 @@ export function AppShell() {
   );
 
   const goTo = useCallback(
-    (to: "/" | "/agent-setup" | "/skills" | "/clients") => {
+    (to: "/" | "/agent-setup" | "/skills" | "/clients" | "/retrieval") => {
       void navigate({ to: pagePath(to) } as never);
     },
     [navigate, pagePath],
@@ -583,6 +618,12 @@ function ProductSidebar({
               label="Skills"
               to={pagePath("/skills")}
             />
+            <ProductSidebarItem
+              active={pageSuffix === "/retrieval"}
+              icon={<SlidersHorizontal />}
+              label="Retrieval"
+              to={pagePath("/retrieval")}
+            />
           </>
         )}
       </nav>
@@ -737,7 +778,7 @@ function CommandMenu(props: {
   onAddToolSource: () => void;
   onImport: () => void;
   onLink: () => void;
-  onNavigate: (to: "/" | "/agent-setup" | "/skills" | "/clients") => void;
+  onNavigate: (to: "/" | "/agent-setup" | "/skills" | "/clients" | "/retrieval") => void;
   onSelectAgent: (kind: AgentHostKind) => void;
   onSelectToolSource: (scope: RatelScope, name: string) => void;
   open: boolean;
@@ -776,6 +817,10 @@ function CommandMenu(props: {
               <CommandItem onSelect={() => props.onNavigate("/skills")}>
                 <Sparkles />
                 Skills
+              </CommandItem>
+              <CommandItem onSelect={() => props.onNavigate("/retrieval")}>
+                <SlidersHorizontal />
+                Retrieval
               </CommandItem>
             </CommandGroup>
             {agentItems.length > 0 && (

--- a/packages/ui/src/components/context-route-page.tsx
+++ b/packages/ui/src/components/context-route-page.tsx
@@ -9,6 +9,7 @@ import {
   agentHostsFromResponse,
 } from "@/pages/AgentSetupPage";
 import { McpClientsPage } from "@/pages/McpClientsPage";
+import { RetrievalSettingsPage } from "@/pages/RetrievalSettingsPage";
 import { SkillDetailPage } from "@/pages/SkillDetailPage";
 import { SkillsPage } from "@/pages/SkillsPage";
 import { ToolSourceCreatePage, ToolSourceDetailPage, ToolsPage } from "@/pages/ToolsPage";
@@ -30,6 +31,9 @@ export function ContextRoutePage({ routeData, subpath = "" }: ContextRoutePagePr
   if (segments.length === 0) return <ToolsPage />;
   if (segments[0] === "clients" && segments.length === 1) return <McpClientsPage />;
   if (segments[0] === "skills" && segments.length === 1) return <SkillsPage />;
+  if (segments[0] === "retrieval" && segments.length === 1) {
+    return <RetrievalSettingsPage />;
+  }
   if (segments[0] === "skills" && segments.length === 2) {
     return <SkillDetailPage id={segments[1]} />;
   }

--- a/packages/ui/src/pages/RetrievalSettingsPage.test.ts
+++ b/packages/ui/src/pages/RetrievalSettingsPage.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   availableRetrievalScopes,
   retrievalConfigFromDraft,
+  retrievalDraftKey,
   retrievalDraftFromConfig,
   retrievalTarget,
 } from "./RetrievalSettingsPage";
@@ -72,6 +73,26 @@ describe("retrieval settings model", () => {
     });
     expect(() => retrievalConfigFromDraft({ ...draft, url: "" })).toThrow(/URL is required/);
     expect(() => retrievalConfigFromDraft({ ...draft, model: "" })).toThrow(/model is required/);
+  });
+
+  it.each([
+    ["method", "hybrid"],
+    ["source", "endpoint"],
+    ["model", "other-model"],
+    ["url", "https://other.example.test/v1/embeddings"],
+    ["apiKeyEnv", "OTHER_KEY"],
+    ["revision", "v2"],
+    ["download", true],
+    ["queryPrefix", "query: "],
+    ["docPrefix", "passage: "],
+    ["pooling", "mean"],
+  ] as const)("changes the preflight identity when %s changes", (field, value) => {
+    const draft = retrievalDraftFromConfig({
+      method: "semantic",
+      embedding: { ollama: "nomic-embed-text" },
+    });
+
+    expect(retrievalDraftKey({ ...draft, [field]: value })).not.toBe(retrievalDraftKey(draft));
   });
 
   it("allows all scopes only inside a project runtime context", () => {

--- a/packages/ui/src/pages/RetrievalSettingsPage.test.ts
+++ b/packages/ui/src/pages/RetrievalSettingsPage.test.ts
@@ -2,9 +2,10 @@ import { describe, expect, it } from "vitest";
 import {
   availableRetrievalScopes,
   retrievalConfigFromDraft,
-  retrievalDraftKey,
   retrievalDraftFromConfig,
+  retrievalDraftKey,
   retrievalTarget,
+  showsEmbeddingFields,
 } from "./RetrievalSettingsPage";
 
 describe("retrieval settings model", () => {
@@ -24,6 +25,14 @@ describe("retrieval settings model", () => {
     expect(retrievalConfigFromDraft(retrievalDraftFromConfig(undefined))).toEqual({
       method: "bm25",
     });
+  });
+
+  it("shows configurable embedding fields only for explicit dense sources", () => {
+    const builtIn = retrievalDraftFromConfig({ method: "semantic" });
+
+    expect(showsEmbeddingFields(builtIn)).toBe(false);
+    expect(showsEmbeddingFields({ ...builtIn, source: "huggingface" })).toBe(true);
+    expect(showsEmbeddingFields({ ...builtIn, method: "bm25", source: "huggingface" })).toBe(false);
   });
 
   it.each([

--- a/packages/ui/src/pages/RetrievalSettingsPage.test.ts
+++ b/packages/ui/src/pages/RetrievalSettingsPage.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+import {
+  availableRetrievalScopes,
+  retrievalConfigFromDraft,
+  retrievalDraftFromConfig,
+  retrievalTarget,
+} from "./RetrievalSettingsPage";
+
+describe("retrieval settings model", () => {
+  it("maps the inherited BM25 default to a model-free draft", () => {
+    expect(retrievalDraftFromConfig(undefined)).toEqual({
+      method: "bm25",
+      source: "built-in",
+      model: "",
+      url: "",
+      apiKeyEnv: "",
+      revision: "",
+      download: false,
+      queryPrefix: "",
+      docPrefix: "",
+      pooling: "",
+    });
+    expect(retrievalConfigFromDraft(retrievalDraftFromConfig(undefined))).toEqual({
+      method: "bm25",
+    });
+  });
+
+  it.each([
+    {
+      config: { method: "semantic", embedding: undefined },
+      source: "built-in",
+    },
+    {
+      config: {
+        method: "hybrid",
+        embedding: { huggingface: "intfloat/e5-small-v2", download: true },
+      },
+      source: "huggingface",
+    },
+    {
+      config: { method: "semantic", embedding: { local: "/models/bge" } },
+      source: "local",
+    },
+    {
+      config: { method: "semantic", embedding: { ollama: "nomic-embed-text" } },
+      source: "ollama",
+    },
+    {
+      config: {
+        method: "hybrid",
+        embedding: {
+          url: "https://embed.example.test/v1/embeddings",
+          model: "text-embedding-3-small",
+          apiKeyEnv: "EMBEDDING_API_KEY",
+        },
+      },
+      source: "endpoint",
+    },
+  ] as const)("round-trips the $source source progressively", ({ config, source }) => {
+    const draft = retrievalDraftFromConfig(config);
+    expect(draft.source).toBe(source);
+    expect(retrievalConfigFromDraft(draft)).toEqual(config);
+  });
+
+  it("rejects endpoint drafts that omit URL or model", () => {
+    const draft = retrievalDraftFromConfig({
+      method: "semantic",
+      embedding: {
+        url: "https://embed.example.test/v1/embeddings",
+        model: "text-embedding-3-small",
+      },
+    });
+    expect(() => retrievalConfigFromDraft({ ...draft, url: "" })).toThrow(/URL is required/);
+    expect(() => retrievalConfigFromDraft({ ...draft, model: "" })).toThrow(/model is required/);
+  });
+
+  it("allows all scopes only inside a project runtime context", () => {
+    expect(availableRetrievalScopes({ kind: "global" })).toEqual(["user"]);
+    expect(availableRetrievalScopes({ kind: "project", projectId: "project/a" })).toEqual([
+      "user",
+      "project",
+      "local",
+    ]);
+    expect(retrievalTarget("user", { kind: "global" })).toEqual({ scope: "user" });
+    expect(retrievalTarget("local", { kind: "project", projectId: "project/a" })).toEqual({
+      scope: "local",
+      projectId: "project/a",
+    });
+  });
+});

--- a/packages/ui/src/pages/RetrievalSettingsPage.tsx
+++ b/packages/ui/src/pages/RetrievalSettingsPage.tsx
@@ -41,6 +41,11 @@ interface RetrievalPreflightView {
   reconnectRequired: boolean;
 }
 
+interface RetrievalPreflightState {
+  draftKey: string;
+  result: RetrievalPreflightView;
+}
+
 export function RetrievalSettingsPage() {
   const { config, configError, configLoading, context } = useRatelApp();
   const scopes = availableRetrievalScopes(context);
@@ -121,7 +126,9 @@ function RetrievalEditor({
 }) {
   const { busy, context, request, runAction } = useRatelApp();
   const [draft, setDraft] = useState(() => retrievalDraftFromConfig(initial));
-  const [preflight, setPreflight] = useState<RetrievalPreflightView | null>(null);
+  const [preflight, setPreflight] = useState<RetrievalPreflightState | null>(null);
+  const draftKey = retrievalDraftKey(draft);
+  const visiblePreflight = preflight?.draftKey === draftKey ? preflight.result : null;
   const target = retrievalTarget(scope, context);
   const hasOverride = config?.scopes[scope]?.available
     ? config.scopes[scope].config.retrieval !== undefined
@@ -159,12 +166,13 @@ function RetrievalEditor({
 
   const prepare = async () => {
     await runAction("Retrieval preflight complete", async () => {
+      const preparedDraftKey = retrievalDraftKey(draft);
       const retrieval = retrievalConfigFromDraft(draft);
       const result = await request<RetrievalPreflightView>("/api/retrieval/prepare", {
         method: "POST",
         body: { retrieval },
       });
-      setPreflight(result);
+      setPreflight({ draftKey: preparedDraftKey, result });
       return { log: [result.message] };
     });
   };
@@ -199,10 +207,9 @@ function RetrievalEditor({
             id="retrieval-method"
             label="Method"
             value={draft.method}
-            onChange={(method) => {
-              setDraft((current) => ({ ...current, method: method as RetrievalMethod }));
-              setPreflight(null);
-            }}
+            onChange={(method) =>
+              setDraft((current) => ({ ...current, method: method as RetrievalMethod }))
+            }
             options={[
               ["bm25", "BM25"],
               ["semantic", "Semantic"],
@@ -214,10 +221,9 @@ function RetrievalEditor({
               id="retrieval-source"
               label="Embedding source"
               value={draft.source}
-              onChange={(source) => {
-                setDraft((current) => ({ ...current, source: source as RetrievalSource }));
-                setPreflight(null);
-              }}
+              onChange={(source) =>
+                setDraft((current) => ({ ...current, source: source as RetrievalSource }))
+              }
               options={[
                 ["built-in", "Built-in"],
                 ["huggingface", "Hugging Face"],
@@ -233,11 +239,11 @@ function RetrievalEditor({
 
         <RetrievalDisclosures draft={draft} />
 
-        {preflight ? (
+        {visiblePreflight ? (
           <Alert>
             <CheckCircle2 />
-            <AlertTitle>Preflight {preflight.status}</AlertTitle>
-            <AlertDescription>{preflight.message}</AlertDescription>
+            <AlertTitle>Preflight {visiblePreflight.status}</AlertTitle>
+            <AlertDescription>{visiblePreflight.message}</AlertDescription>
           </Alert>
         ) : null}
 
@@ -522,6 +528,10 @@ export function retrievalDraftFromConfig(config: RetrievalConfig | undefined): R
     url: embedding.url ?? "",
     apiKeyEnv: embedding.apiKeyEnv ?? "",
   };
+}
+
+export function retrievalDraftKey(draft: RetrievalDraft): string {
+  return JSON.stringify(draft);
 }
 
 export function retrievalConfigFromDraft(draft: RetrievalDraft): RetrievalConfig {

--- a/packages/ui/src/pages/RetrievalSettingsPage.tsx
+++ b/packages/ui/src/pages/RetrievalSettingsPage.tsx
@@ -235,7 +235,7 @@ function RetrievalEditor({
           ) : null}
         </div>
 
-        {draft.method !== "bm25" ? <EmbeddingFields draft={draft} setDraft={setDraft} /> : null}
+        {showsEmbeddingFields(draft) ? <EmbeddingFields draft={draft} setDraft={setDraft} /> : null}
 
         <RetrievalDisclosures draft={draft} />
 
@@ -532,6 +532,10 @@ export function retrievalDraftFromConfig(config: RetrievalConfig | undefined): R
 
 export function retrievalDraftKey(draft: RetrievalDraft): string {
   return JSON.stringify(draft);
+}
+
+export function showsEmbeddingFields(draft: RetrievalDraft): boolean {
+  return draft.method !== "bm25" && draft.source !== "built-in";
 }
 
 export function retrievalConfigFromDraft(draft: RetrievalDraft): RetrievalConfig {

--- a/packages/ui/src/pages/RetrievalSettingsPage.tsx
+++ b/packages/ui/src/pages/RetrievalSettingsPage.tsx
@@ -1,0 +1,609 @@
+import { CheckCircle2, DatabaseZap, RefreshCw, Save } from "lucide-react";
+import { useState } from "react";
+import { type ConfigResponse, type RatelScope, type RetrievalConfig, useRatelApp } from "@/App";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import type { RuntimeUiContext } from "@/lib/runtime-context";
+
+type RetrievalMethod = RetrievalConfig["method"];
+type RetrievalSource = "built-in" | "huggingface" | "local" | "ollama" | "endpoint";
+
+export interface RetrievalDraft {
+  method: RetrievalMethod;
+  source: RetrievalSource;
+  model: string;
+  url: string;
+  apiKeyEnv: string;
+  revision: string;
+  download: boolean;
+  queryPrefix: string;
+  docPrefix: string;
+  pooling: "" | "cls" | "mean";
+}
+
+interface RetrievalPreflightView {
+  status: "ready" | "not-required";
+  message: string;
+  source: string;
+  model?: string;
+  runtimeMemoryMb: number | null;
+  remoteDataTransfer: boolean;
+  reconnectRequired: boolean;
+}
+
+export function RetrievalSettingsPage() {
+  const { config, configError, configLoading, context } = useRatelApp();
+  const scopes = availableRetrievalScopes(context);
+  const [requestedScope, setRequestedScope] = useState<RatelScope>(scopes[0] ?? "user");
+  const scope = scopes.includes(requestedScope) ? requestedScope : (scopes[0] ?? "user");
+  const scopeState = config?.scopes[scope];
+  const override = scopeState?.available ? scopeState.config.retrieval : undefined;
+  const revision = documentRevisionForScope(config, scope);
+  const editorKey = `${scope}:${revision ?? "missing"}:${JSON.stringify(override ?? null)}`;
+  const effective = effectiveRetrieval(config);
+
+  return (
+    <main className="grid w-full gap-6">
+      <header className="grid gap-2">
+        <div className="flex items-center gap-2 text-ctx-skills">
+          <DatabaseZap className="size-5" />
+          <span className="font-mono text-xs uppercase tracking-[0.18em]">Retrieval</span>
+        </div>
+        <h1 className="font-semibold text-3xl tracking-tight">Retrieval settings</h1>
+        <p className="max-w-3xl text-muted-foreground">
+          Keep BM25 model-free, or opt this runtime context into semantic or hybrid retrieval. Each
+          scope replaces the complete earlier retrieval block.
+        </p>
+      </header>
+
+      {configError ? (
+        <Alert variant="destructive">
+          <AlertTitle>Configuration unavailable</AlertTitle>
+          <AlertDescription>{configError}</AlertDescription>
+        </Alert>
+      ) : null}
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Effective retrieval</CardTitle>
+          <CardDescription>
+            The rightmost configured scope wins for newly connected clients.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="grid gap-1">
+          <p className="font-medium capitalize">{effective.method}</p>
+          <p className="font-mono text-muted-foreground text-sm">
+            {retrievalSourceLabel(effective)}
+          </p>
+        </CardContent>
+      </Card>
+
+      <RetrievalEditor
+        key={editorKey}
+        config={config}
+        initial={override}
+        loading={configLoading}
+        onScopeChange={setRequestedScope}
+        revision={revision}
+        scope={scope}
+        scopes={scopes}
+      />
+    </main>
+  );
+}
+
+function RetrievalEditor({
+  config,
+  initial,
+  loading,
+  onScopeChange,
+  revision,
+  scope,
+  scopes,
+}: {
+  config: ConfigResponse | null;
+  initial?: RetrievalConfig;
+  loading: boolean;
+  onScopeChange: (scope: RatelScope) => void;
+  revision?: string;
+  scope: RatelScope;
+  scopes: RatelScope[];
+}) {
+  const { busy, context, request, runAction } = useRatelApp();
+  const [draft, setDraft] = useState(() => retrievalDraftFromConfig(initial));
+  const [preflight, setPreflight] = useState<RetrievalPreflightView | null>(null);
+  const target = retrievalTarget(scope, context);
+  const hasOverride = config?.scopes[scope]?.available
+    ? config.scopes[scope].config.retrieval !== undefined
+    : false;
+  const disabled = busy || loading;
+
+  const configure = async () => {
+    await runAction(`Saved ${scope} retrieval override`, async () => {
+      const retrieval = retrievalConfigFromDraft(draft);
+      const result = await request<{ reconnectMessage?: string }>("/api/retrieval", {
+        method: "PATCH",
+        body: {
+          target,
+          retrieval,
+          ...(revision ? { expectedRevision: revision } : {}),
+        },
+      });
+      return { log: result.reconnectMessage ? [result.reconnectMessage] : [] };
+    });
+  };
+
+  const reset = async () => {
+    await runAction(`Reset ${scope} retrieval override`, async () =>
+      request<{ reconnectMessage?: string }>("/api/retrieval", {
+        method: "DELETE",
+        body: {
+          target,
+          ...(revision ? { expectedRevision: revision } : {}),
+        },
+      }).then((result) => ({
+        log: result.reconnectMessage ? [result.reconnectMessage] : [],
+      })),
+    );
+  };
+
+  const prepare = async () => {
+    await runAction("Retrieval preflight complete", async () => {
+      const retrieval = retrievalConfigFromDraft(draft);
+      const result = await request<RetrievalPreflightView>("/api/retrieval/prepare", {
+        method: "POST",
+        body: { retrieval },
+      });
+      setPreflight(result);
+      return { log: [result.message] };
+    });
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Scoped override</CardTitle>
+        <CardDescription>
+          Configure and prepare one scope. Saving creates a new runtime revision.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="grid gap-6">
+        <div className="grid gap-2 sm:max-w-xs">
+          <Label htmlFor="retrieval-scope">Scope</Label>
+          <Select value={scope} onValueChange={(value) => onScopeChange(value as RatelScope)}>
+            <SelectTrigger id="retrieval-scope" className="w-full">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {scopes.map((value) => (
+                <SelectItem key={value} value={value}>
+                  {value}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        <div className="grid gap-4 sm:grid-cols-2">
+          <SelectField
+            id="retrieval-method"
+            label="Method"
+            value={draft.method}
+            onChange={(method) => {
+              setDraft((current) => ({ ...current, method: method as RetrievalMethod }));
+              setPreflight(null);
+            }}
+            options={[
+              ["bm25", "BM25"],
+              ["semantic", "Semantic"],
+              ["hybrid", "Hybrid"],
+            ]}
+          />
+          {draft.method !== "bm25" ? (
+            <SelectField
+              id="retrieval-source"
+              label="Embedding source"
+              value={draft.source}
+              onChange={(source) => {
+                setDraft((current) => ({ ...current, source: source as RetrievalSource }));
+                setPreflight(null);
+              }}
+              options={[
+                ["built-in", "Built-in"],
+                ["huggingface", "Hugging Face"],
+                ["local", "Local path"],
+                ["ollama", "Ollama"],
+                ["endpoint", "OpenAI-compatible endpoint"],
+              ]}
+            />
+          ) : null}
+        </div>
+
+        {draft.method !== "bm25" ? <EmbeddingFields draft={draft} setDraft={setDraft} /> : null}
+
+        <RetrievalDisclosures draft={draft} />
+
+        {preflight ? (
+          <Alert>
+            <CheckCircle2 />
+            <AlertTitle>Preflight {preflight.status}</AlertTitle>
+            <AlertDescription>{preflight.message}</AlertDescription>
+          </Alert>
+        ) : null}
+
+        <div className="flex flex-wrap gap-2">
+          <Button
+            disabled={disabled}
+            onClick={() => void prepare()}
+            type="button"
+            variant="outline"
+          >
+            <RefreshCw />
+            Prepare
+          </Button>
+          <Button disabled={disabled} onClick={() => void configure()} type="button">
+            <Save />
+            Save override
+          </Button>
+          <Button
+            disabled={disabled || !hasOverride}
+            onClick={() => void reset()}
+            type="button"
+            variant="ghost"
+          >
+            Reset override
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function EmbeddingFields({
+  draft,
+  setDraft,
+}: {
+  draft: RetrievalDraft;
+  setDraft: React.Dispatch<React.SetStateAction<RetrievalDraft>>;
+}) {
+  const update = (patch: Partial<RetrievalDraft>) => {
+    setDraft((current) => ({ ...current, ...patch }));
+  };
+  return (
+    <div className="grid gap-4 rounded-xl border border-border bg-muted/20 p-4 sm:grid-cols-2">
+      {draft.source !== "built-in" ? (
+        <TextField
+          id="retrieval-model"
+          label={draft.source === "local" ? "Model directory" : "Model"}
+          placeholder={
+            draft.source === "huggingface"
+              ? "intfloat/multilingual-e5-small"
+              : draft.source === "local"
+                ? "~/.cache/models/bge"
+                : "nomic-embed-text"
+          }
+          value={draft.model}
+          onChange={(model) => update({ model })}
+        />
+      ) : null}
+      {draft.source === "endpoint" ? (
+        <>
+          <TextField
+            id="retrieval-url"
+            label="Embeddings URL"
+            placeholder="https://api.example.com/v1/embeddings"
+            value={draft.url}
+            onChange={(url) => update({ url })}
+          />
+          <TextField
+            id="retrieval-api-key-env"
+            label="API key environment variable"
+            placeholder="EMBEDDING_API_KEY"
+            value={draft.apiKeyEnv}
+            onChange={(apiKeyEnv) => update({ apiKeyEnv })}
+          />
+        </>
+      ) : null}
+      {draft.source === "huggingface" ? (
+        <>
+          <TextField
+            id="retrieval-revision"
+            label="Revision"
+            placeholder="main"
+            value={draft.revision}
+            onChange={(revision) => update({ revision })}
+          />
+          <label className="flex items-center gap-2 self-end pb-3 text-sm">
+            <input
+              checked={draft.download}
+              onChange={(event) => update({ download: event.currentTarget.checked })}
+              type="checkbox"
+            />
+            Download at dense startup if not cached
+          </label>
+        </>
+      ) : null}
+      {draft.source === "huggingface" || draft.source === "local" ? (
+        <SelectField
+          id="retrieval-pooling"
+          label="Pooling"
+          value={draft.pooling || "auto"}
+          onChange={(pooling) =>
+            update({ pooling: pooling === "auto" ? "" : (pooling as "cls" | "mean") })
+          }
+          options={[
+            ["auto", "Auto"],
+            ["cls", "CLS"],
+            ["mean", "Mean"],
+          ]}
+        />
+      ) : null}
+      <TextField
+        id="retrieval-query-prefix"
+        label="Query prefix"
+        placeholder="Optional"
+        value={draft.queryPrefix}
+        onChange={(queryPrefix) => update({ queryPrefix })}
+      />
+      <TextField
+        id="retrieval-doc-prefix"
+        label="Document prefix"
+        placeholder="Optional"
+        value={draft.docPrefix}
+        onChange={(docPrefix) => update({ docPrefix })}
+      />
+    </div>
+  );
+}
+
+function RetrievalDisclosures({ draft }: { draft: RetrievalDraft }) {
+  if (draft.method === "bm25") {
+    return (
+      <Alert>
+        <AlertTitle>Zero-download path</AlertTitle>
+        <AlertDescription>
+          BM25 loads no embedding model and sends no embedding requests.
+        </AlertDescription>
+      </Alert>
+    );
+  }
+  const remote = draft.source === "endpoint";
+  return (
+    <Alert>
+      <AlertTitle>Dense retrieval lifecycle</AlertTitle>
+      <AlertDescription className="grid gap-1">
+        {draft.source === "built-in" ? (
+          <span>
+            The pinned built-in model adds roughly 130 MB while loaded and is English-focused.
+            Choose a multilingual Hugging Face model when needed.
+          </span>
+        ) : null}
+        {draft.source === "huggingface" || draft.source === "local" ? (
+          <span>
+            This in-process model&apos;s memory and multilingual coverage vary by model. Hugging
+            Face sources use the normal model cache.
+          </span>
+        ) : null}
+        {draft.source === "ollama" || draft.source === "endpoint" ? (
+          <span>Model memory is owned by the configured embedding service.</span>
+        ) : null}
+        <span>
+          {remote
+            ? "Tool/skill metadata and retrieval queries are sent to the configured endpoint."
+            : "Embedding metadata and queries stay on this machine."}
+        </span>
+        <span>
+          Retrieval traces remain under ~/.ratel/telemetry. Reconnect the affected agent/context
+          after saving; restart the daemon only as a fallback.
+        </span>
+      </AlertDescription>
+    </Alert>
+  );
+}
+
+function SelectField({
+  id,
+  label,
+  onChange,
+  options,
+  value,
+}: {
+  id: string;
+  label: string;
+  onChange: (value: string) => void;
+  options: ReadonlyArray<readonly [string, string]>;
+  value: string;
+}) {
+  return (
+    <div className="grid gap-2">
+      <Label htmlFor={id}>{label}</Label>
+      <Select value={value} onValueChange={onChange}>
+        <SelectTrigger id={id} className="w-full">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          {options.map(([optionValue, optionLabel]) => (
+            <SelectItem key={optionValue} value={optionValue}>
+              {optionLabel}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </div>
+  );
+}
+
+function TextField({
+  id,
+  label,
+  onChange,
+  placeholder,
+  value,
+}: {
+  id: string;
+  label: string;
+  onChange: (value: string) => void;
+  placeholder?: string;
+  value: string;
+}) {
+  return (
+    <div className="grid gap-2">
+      <Label htmlFor={id}>{label}</Label>
+      <Input
+        id={id}
+        onChange={(event) => onChange(event.currentTarget.value)}
+        placeholder={placeholder}
+        value={value}
+      />
+    </div>
+  );
+}
+
+export function retrievalDraftFromConfig(config: RetrievalConfig | undefined): RetrievalDraft {
+  const embedding = config?.embedding;
+  const draft: RetrievalDraft = {
+    method: config?.method ?? "bm25",
+    source: "built-in",
+    model: "",
+    url: "",
+    apiKeyEnv: "",
+    revision: "",
+    download: false,
+    queryPrefix: "",
+    docPrefix: "",
+    pooling: "",
+  };
+  if (embedding === undefined) return draft;
+  if (typeof embedding === "string") {
+    return { ...draft, source: "local", model: embedding };
+  }
+  const shared = {
+    queryPrefix: embedding.queryPrefix ?? "",
+    docPrefix: embedding.docPrefix ?? "",
+  };
+  if ("huggingface" in embedding) {
+    return {
+      ...draft,
+      ...shared,
+      source: "huggingface",
+      model: embedding.huggingface,
+      revision: embedding.revision ?? "",
+      download: embedding.download ?? false,
+      pooling: embedding.pooling ?? "",
+    };
+  }
+  if ("local" in embedding) {
+    return {
+      ...draft,
+      ...shared,
+      source: "local",
+      model: embedding.local,
+      pooling: embedding.pooling ?? "",
+    };
+  }
+  if ("ollama" in embedding) {
+    return { ...draft, ...shared, source: "ollama", model: embedding.ollama };
+  }
+  return {
+    ...draft,
+    ...shared,
+    source: "endpoint",
+    model: embedding.model ?? "",
+    url: embedding.url ?? "",
+    apiKeyEnv: embedding.apiKeyEnv ?? "",
+  };
+}
+
+export function retrievalConfigFromDraft(draft: RetrievalDraft): RetrievalConfig {
+  if (draft.method === "bm25") return { method: "bm25" };
+  const shared = {
+    ...(draft.queryPrefix ? { queryPrefix: draft.queryPrefix } : {}),
+    ...(draft.docPrefix ? { docPrefix: draft.docPrefix } : {}),
+  };
+  let embedding: RetrievalConfig["embedding"];
+  if (draft.source === "huggingface") {
+    embedding = {
+      huggingface: requiredDraftValue(draft.model, "Hugging Face model"),
+      ...shared,
+      ...(draft.revision ? { revision: draft.revision } : {}),
+      ...(draft.pooling ? { pooling: draft.pooling } : {}),
+      download: draft.download,
+    };
+  } else if (draft.source === "local") {
+    embedding = {
+      local: requiredDraftValue(draft.model, "Local model directory"),
+      ...shared,
+      ...(draft.pooling ? { pooling: draft.pooling } : {}),
+    };
+  } else if (draft.source === "ollama") {
+    embedding = {
+      ollama: requiredDraftValue(draft.model, "Ollama model"),
+      ...shared,
+    };
+  } else if (draft.source === "endpoint") {
+    embedding = {
+      url: requiredDraftValue(draft.url, "Endpoint URL"),
+      model: requiredDraftValue(draft.model, "Endpoint model"),
+      ...shared,
+      ...(draft.apiKeyEnv ? { apiKeyEnv: draft.apiKeyEnv } : {}),
+    };
+  }
+  return {
+    method: draft.method,
+    ...(embedding !== undefined ? { embedding } : {}),
+  };
+}
+
+export function availableRetrievalScopes(context: RuntimeUiContext): RatelScope[] {
+  return context.kind === "project" ? ["user", "project", "local"] : ["user"];
+}
+
+export function retrievalTarget(scope: RatelScope, context: RuntimeUiContext) {
+  if (scope === "user") return { scope: "user" as const };
+  if (context.kind !== "project") throw new Error(`${scope} retrieval requires a project context`);
+  return { scope, projectId: context.projectId };
+}
+
+function effectiveRetrieval(config: ConfigResponse | null): RetrievalConfig {
+  if (config?.effectiveRetrieval) return config.effectiveRetrieval;
+  let effective: RetrievalConfig = { method: "bm25" };
+  for (const scope of ["user", "project", "local"] as const) {
+    const state = config?.scopes[scope];
+    if (state?.available && state.config.retrieval) effective = state.config.retrieval;
+  }
+  return effective;
+}
+
+function documentRevisionForScope(
+  config: ConfigResponse | null,
+  scope: RatelScope,
+): string | undefined {
+  return config?.documents?.find(({ ref }) => ref.scope === scope)?.documentRevision;
+}
+
+function retrievalSourceLabel(retrieval: RetrievalConfig): string {
+  if (retrieval.method === "bm25") return "model-free";
+  const embedding = retrieval.embedding;
+  if (embedding === undefined) return "BAAI/bge-small-en-v1.5 (built-in)";
+  if (typeof embedding === "string") return embedding;
+  if ("huggingface" in embedding) return embedding.huggingface;
+  if ("local" in embedding) return embedding.local;
+  if ("ollama" in embedding) return `Ollama · ${embedding.ollama}`;
+  return `${embedding.model} · ${embedding.url}`;
+}
+
+function requiredDraftValue(value: string, label: string): string {
+  const normalized = value.trim();
+  if (!normalized) throw new Error(`${label} is required`);
+  return normalized;
+}


### PR DESCRIPTION
## Summary

- add scoped `retrieval status|configure|reset|prepare` CLI controls for user, project, and local configuration
- add transactional retrieval mutations with backups, revision safeguards, local Git exclusion handling, and scoped generation publication
- add model/source preflight for built-in, Hugging Face, local, Ollama, and OpenAI-compatible endpoints
- add the Retrieval settings UI with progressive source controls and cache, memory, multilingual, privacy, trace, and reconnect disclosures
- document retrieval configuration, preparation, storage, and lifecycle behavior

## Review follow-ups included

- reject incompatible source-specific CLI flags instead of silently dropping them
- require a project context for explicit project/local preflight
- invalidate stale UI preflight results after any draft change, including in-flight edits
- hide unsupported embedding fields for the built-in source

## Validation

- `pnpm test` — 969 tests passed
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- `pnpm check:pack`
- `git diff --check`
