### PR TITLE
chore: finish retrieval production hardening

### DIFF
--- a/.github/workflows/ts.yml
+++ b/.github/workflows/ts.yml
@@ -29,3 +29,60 @@ jobs:
         run: pnpm lint
       - name: Test
         run: pnpm test
+
+  package-smoke:
+    name: Package smoke (${{ matrix.target }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: linux-x64
+            runner: ubuntu-24.04
+            platform: linux
+            arch: x64
+          - target: linux-arm64
+            runner: ubuntu-24.04-arm
+            platform: linux
+            arch: arm64
+          - target: darwin-x64
+            runner: macos-15-intel
+            platform: darwin
+            arch: x64
+          - target: darwin-arm64
+            runner: macos-15
+            platform: darwin
+            arch: arm64
+          - target: win32-x64
+            runner: windows-2025
+            platform: win32
+            arch: x64
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: pnpm
+      - name: Install
+        run: pnpm install --frozen-lockfile
+      - name: Build and validate package
+        run: pnpm build && pnpm check:pack
+      - name: Smoke packed native target
+        shell: bash
+        env:
+          EXPECTED_PLATFORM: ${{ matrix.platform }}
+          EXPECTED_ARCH: ${{ matrix.arch }}
+        run: |
+          set -euo pipefail
+          pack_dir="$RUNNER_TEMP/ratel-pack"
+          smoke_dir="$RUNNER_TEMP/ratel-smoke"
+          mkdir -p "$pack_dir" "$smoke_dir"
+          pnpm --filter @ratel-ai/ratel-local pack --pack-destination "$pack_dir"
+          (
+            cd "$smoke_dir"
+            pnpm init
+            pnpm add "$pack_dir"/*.tgz
+            node --input-type=module -e "import assert from 'node:assert/strict'; assert.equal(process.platform, process.env.EXPECTED_PLATFORM); assert.equal(process.arch, process.env.EXPECTED_ARCH); const pkg = await import('@ratel-ai/ratel-local'); const gateway = await pkg.buildGatewayFromConfig({ mcpServers: {} }, { resolvedSkills: [] }); await gateway.close();"
+            node node_modules/@ratel-ai/ratel-local/dist/bin.js --help
+          )

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this package are documented here. The format is based on 
 ### Added
 - Added opt-in `semantic` and `hybrid` retrieval with scoped, atomic configuration; validated local, Hugging Face, Ollama, and OpenAI-compatible embedding sources; fail-closed dense startup; and generation-safe OAuth reconnect behavior. BM25 remains the model-free default.
 - Added `ratel-local retrieval status|configure|reset|prepare` and a Retrieval settings page, with transactional scoped writes, model/source preflight, and explicit cache, memory, multilingual, privacy, trace, and reconnect guidance.
+- Added opt-in generation build health reporting and packed-package smoke CI for five native targets.
 
 ### Changed
 - Upgraded `@ratel-ai/sdk` to 0.5.2. Direct SDK consumers must now await `ToolCatalog.register()` and `SkillCatalog.register()`; Ratel Local awaits every registration and batches gateway skills in one call.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -5,7 +5,7 @@ How a new version is published to npm. Read end-to-end before cutting a release.
 ## How the pipeline is wired
 
 - **`release.yml`** fires on every `v*` tag push (and supports `workflow_dispatch` with `dry_run: true` for rehearsal). Job graph: `tag-version-check` (asserts `package.json.version` matches the tag and that `CHANGELOG.md` has a `## [<version>]` heading) → `publish-npm` (pnpm install → build → `pnpm pack` → `npm publish --provenance --access public --tag <rc|latest>`) → `github-release`. Authentication is via Trusted Publishers (OIDC) — no `NPM_TOKEN` secret stored in the repo. `*-rc.*` tags publish under the `rc` dist-tag; un-suffixed tags become `latest`.
-- **`ts.yml`** runs build / typecheck / lint / test on every PR and on push to `main`.
+- **`ts.yml`** runs build / typecheck / lint / test plus packed-package smoke checks on Linux x64/arm64, macOS x64/arm64, and Windows x64 on every PR and on push to `main`.
 - **`verify-install.yml`** runs daily and on-demand: `npx -y @ratel-ai/ratel-local@latest --help` on Ubuntu.
 
 ## Cutting a release

--- a/apps/ratel-local/src/cli/handlers/daemon.test.ts
+++ b/apps/ratel-local/src/cli/handlers/daemon.test.ts
@@ -79,6 +79,35 @@ function makeCtx(fs: MemFs, env: HierarchyEnv = { homeDir: HOME, projectRoot: RO
 }
 
 describe("runDaemon", () => {
+  it("exposes retrieval build health only when the experimental health flag is enabled", async () => {
+    const fs = new MemFs();
+    const logs: string[] = [];
+    const result = await runDaemon(
+      daemonArgs(),
+      makeCtx(fs),
+      {
+        readConfig: async () => ({ mcpServers: {}, retrieval: { method: "bm25" } }),
+        processEnv: { RATEL_EXPERIMENTAL_RETRIEVAL_HEALTH: "1" },
+      },
+      (message) => logs.push(message),
+      { open: () => {}, ensureToken: async () => "daemon-test-token" },
+    );
+    const daemonUrl = daemonUrlFromLogs(logs);
+
+    try {
+      const health = await fetch(new URL("/healthz", daemonUrl));
+      expect(health.status).toBe(200);
+      expect(await health.text()).toBe("ok retrieval=ready\n");
+
+      const status = await fetch(new URL("/api/daemon/status", daemonUrl));
+      expect(await status.json()).toMatchObject({
+        retrievalHealth: { status: "ready", generations: [] },
+      });
+    } finally {
+      await result.shutdown?.();
+    }
+  });
+
   it("reports an installed service as stopped when its health probe is offline", async () => {
     const fs = new MemFs();
     fs.files.set(daemonPaths(HOME).plist, "<plist />");
@@ -172,11 +201,13 @@ describe("runDaemon", () => {
       mcpUrl: string;
       upstreamCount: number;
       activeClientCount: number;
+      retrievalHealth?: unknown;
     };
     expect(status.port).toBe(new URL(uiUrl).port ? Number(new URL(uiUrl).port) : 0);
     expect(status.mcpUrl).toBe(new URL("/mcp", uiUrl).toString());
     expect(status.upstreamCount).toBe(0);
     expect(status.activeClientCount).toBe(0);
+    expect(status).not.toHaveProperty("retrievalHealth");
 
     let openedSessionUrl = "";
     await runDaemon(daemonArgs({ verb: "open", flags: {} }), makeCtx(fs), {}, () => {}, {

--- a/apps/ratel-local/src/cli/handlers/daemon.ts
+++ b/apps/ratel-local/src/cli/handlers/daemon.ts
@@ -37,6 +37,7 @@ import { ReconciledGatewayPool } from "../../daemon/reconciled-gateway-pool.js";
 import {
   InMemoryScopedGatewayPool,
   type ResolvedGatewaySnapshot,
+  type RetrievalHealthStats,
 } from "../../daemon/scoped-gateway-pool.js";
 import { openBrowser } from "../../ui/open-browser.js";
 import { InMemoryUiSessionTokens, newSessionToken } from "../../ui/security.js";
@@ -86,6 +87,7 @@ export interface DaemonStatusBody extends DaemonState {
   activeGatewayCount: number;
   activeUserGatewayCount: number;
   activeProjectGatewayCount: number;
+  retrievalHealth?: RetrievalHealthStats;
 }
 
 interface CommandResult {
@@ -228,6 +230,8 @@ export async function runDaemonServer(
     opts.snapshotResolver ??
     createContextSnapshotResolver({ homeDir: ctx.env.homeDir, projectRegistry });
   const serverVersion = options.serverVersion ?? "0.0.0";
+  const retrievalHealthEnabled =
+    (options.processEnv ?? process.env).RATEL_EXPERIMENTAL_RETRIEVAL_HEALTH === "1";
   const daemonToken = await (opts.ensureToken ?? ensureDaemonToken)(ctx.env.homeDir);
   const generationPool = new InMemoryScopedGatewayPool(async (scope) => {
     if (scope.resolvedContext) {
@@ -399,7 +403,17 @@ export async function runDaemonServer(
     sessionTokens: uiSessions,
     publicRoute: async (req, res, path) => {
       if (req.method === "GET" && path === "/healthz") {
-        writePlain(res, 200, "ok\n");
+        if (!retrievalHealthEnabled) {
+          writePlain(res, 200, "ok\n");
+          return true;
+        }
+        const retrievalHealth = gatewayPool.stats().retrievalHealth;
+        const ready = retrievalHealth.status === "ready";
+        writePlain(
+          res,
+          ready ? 200 : 503,
+          `${ready ? "ok" : "not ready"} retrieval=${retrievalHealth.status}\n`,
+        );
         return true;
       }
       if (req.method === "GET" && path === "/api/daemon/status") {
@@ -413,6 +427,7 @@ export async function runDaemonServer(
           activeGatewayCount: poolStats.activeGatewayCount,
           activeUserGatewayCount: poolStats.activeUserGatewayCount,
           activeProjectGatewayCount: poolStats.activeProjectGatewayCount,
+          ...(retrievalHealthEnabled ? { retrievalHealth: poolStats.retrievalHealth } : {}),
         });
         return true;
       }

--- a/apps/ratel-local/src/daemon/scoped-gateway-pool.test.ts
+++ b/apps/ratel-local/src/daemon/scoped-gateway-pool.test.ts
@@ -16,6 +16,62 @@ function gateway(name: string): GatewayHandle {
 }
 
 describe("InMemoryScopedGatewayPool", () => {
+  it("reports current generation builds without retaining failed generations", async () => {
+    let finishBuild: (() => void) | undefined;
+    const buildGate = new Promise<void>((resolve) => {
+      finishBuild = resolve;
+    });
+    const snapshot = {
+      kind: "project",
+      projectId: REPO_ID,
+      projectRoot: "/repo",
+      contextKey: `project:${REPO_ID}`,
+      runtimeRevision: "rev-health",
+      resolvedContext: {
+        retrieval: { method: "semantic" },
+      },
+    } as unknown as ResolvedGatewaySnapshot;
+    const pool = new InMemoryScopedGatewayPool(async (generation) => {
+      await buildGate;
+      return gateway(generation.runtimeRevision);
+    });
+
+    const pending = pool.acquire(snapshot);
+    expect(pool.stats().retrievalHealth).toMatchObject({
+      status: "building",
+      generations: [
+        {
+          contextKey: `project:${REPO_ID}`,
+          runtimeRevision: "rev-health",
+          method: "semantic",
+          status: "building",
+        },
+      ],
+    });
+
+    finishBuild?.();
+    const lease = await pending;
+    expect(pool.stats().retrievalHealth).toMatchObject({
+      status: "ready",
+      generations: [
+        {
+          contextKey: `project:${REPO_ID}`,
+          runtimeRevision: "rev-health",
+          method: "semantic",
+          status: "ready",
+        },
+      ],
+    });
+    await lease.release();
+    expect(pool.stats().retrievalHealth).toEqual({ status: "ready", generations: [] });
+
+    const failed = new InMemoryScopedGatewayPool(async () => {
+      throw new Error("endpoint timed out");
+    });
+    await expect(failed.acquire(snapshot)).rejects.toThrow("endpoint timed out");
+    expect(failed.stats().retrievalHealth).toEqual({ status: "ready", generations: [] });
+  });
+
   it("shares a gateway for one resolved generation and exposes its identity", async () => {
     const built: ResolvedGatewaySnapshot[] = [];
     const pool = new InMemoryScopedGatewayPool(async (snapshot) => {

--- a/apps/ratel-local/src/daemon/scoped-gateway-pool.ts
+++ b/apps/ratel-local/src/daemon/scoped-gateway-pool.ts
@@ -52,6 +52,21 @@ export interface ScopedGatewayPoolStats {
   activeProjectGatewayCount: number;
   upstreamCount: number;
   generations: GatewayGenerationStats[];
+  retrievalHealth: RetrievalHealthStats;
+}
+
+export type RetrievalHealthStatus = "building" | "ready";
+
+export interface RetrievalGenerationHealth extends GatewayGenerationIdentity {
+  context: GatewayContext;
+  projectRoot?: string;
+  method: "bm25" | "semantic" | "hybrid";
+  status: RetrievalHealthStatus;
+}
+
+export interface RetrievalHealthStats {
+  status: RetrievalHealthStatus;
+  generations: RetrievalGenerationHealth[];
 }
 
 export interface ScopedGatewayPool {
@@ -71,6 +86,7 @@ interface PoolRecord {
   snapshot: ResolvedGatewaySnapshot;
   promise: Promise<PoolEntry>;
   entry?: PoolEntry;
+  retrievalHealth: RetrievalGenerationHealth;
 }
 
 export class InMemoryScopedGatewayPool implements ScopedGatewayPool {
@@ -96,6 +112,7 @@ export class InMemoryScopedGatewayPool implements ScopedGatewayPool {
         const next: PoolRecord = {
           snapshot,
           promise: Promise.resolve(undefined as never),
+          retrievalHealth: generationHealth(snapshot, "building"),
         };
         next.promise = this.buildEntry(snapshot, key, next);
         record = next;
@@ -158,6 +175,7 @@ export class InMemoryScopedGatewayPool implements ScopedGatewayPool {
         .length,
       upstreamCount: generations.reduce((sum, generation) => sum + generation.upstreamCount, 0),
       generations,
+      retrievalHealth: this.retrievalHealth(),
     };
   }
 
@@ -203,11 +221,20 @@ export class InMemoryScopedGatewayPool implements ScopedGatewayPool {
         }
       });
       record.entry = entry;
+      record.retrievalHealth = generationHealth(snapshot, "ready");
       return entry;
     } catch (err) {
       if (this.records.get(key) === record) this.records.delete(key);
       throw err;
     }
+  }
+
+  private retrievalHealth(): RetrievalHealthStats {
+    const generations = Array.from(this.records.values(), (record) => record.retrievalHealth);
+    return {
+      status: aggregateRetrievalHealth(generations),
+      generations,
+    };
   }
 }
 
@@ -240,4 +267,25 @@ function gatewayContext(snapshot: ResolvedGatewaySnapshot): GatewayContext {
   return snapshot.kind === "global"
     ? { kind: "global" }
     : { kind: "project", projectId: snapshot.projectId };
+}
+
+function generationHealth(
+  snapshot: ResolvedGatewaySnapshot,
+  status: RetrievalHealthStatus,
+): RetrievalGenerationHealth {
+  return {
+    context: gatewayContext(snapshot),
+    ...(snapshot.kind === "project" ? { projectRoot: snapshot.projectRoot } : {}),
+    contextKey: snapshot.contextKey,
+    runtimeRevision: snapshot.runtimeRevision,
+    method: snapshot.resolvedContext?.retrieval?.method ?? "bm25",
+    status,
+  };
+}
+
+function aggregateRetrievalHealth(
+  generations: readonly RetrievalGenerationHealth[],
+): RetrievalHealthStatus {
+  if (generations.some((generation) => generation.status === "building")) return "building";
+  return "ready";
 }

--- a/docs/retrieval.md
+++ b/docs/retrieval.md
@@ -140,3 +140,18 @@ The browser UI exposes the same source choices and preflight action under **Retr
   including process startup or a retrieval revision.
 - Local retrieval traces remain under `~/.ratel/telemetry`.
 - BM25 is always the zero-download, zero-embedding-request path.
+
+## Health and rollback
+
+Set `RATEL_EXPERIMENTAL_RETRIEVAL_HEALTH=1` on the daemon to include `retrievalHealth` in
+`/api/daemon/status`. The status is `building` while a scoped gateway generation is being created
+and `ready` otherwise. `/healthz` returns `503` only while a generation is actively building; a
+failed build is returned to its requesting client and does not leave the daemon globally unhealthy.
+
+To roll back dense retrieval, reset the affected scope to BM25 and reconnect the affected client:
+
+```bash
+ratel-local retrieval configure --scope user --method bm25
+```
+
+Use `--scope project` or `--scope local` when that is where the dense override lives.


### PR DESCRIPTION
## Summary
- add opt-in building/ready retrieval health without sticky failed generations
- add packed install/import/CLI smoke coverage for five native targets
- document health behavior and BM25 rollback
- keep performance, quality, memory, and cost benchmarking out of scope

## Validation
- pnpm test (971 tests)
- pnpm build
- pnpm typecheck
- pnpm lint
- pnpm check:pack
- packed tarball install/import/CLI smoke on macOS arm64