### PR TITLE
release: v0.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this package are documented here. The format is based on 
 
 ## [Unreleased]
 
+## [0.8.1] - 2026-08-19
+
+### Fixed
+- Made connector recovery probe daemon health before taking lifecycle action, attach to an already-running daemon without restarting it, and return the recovery tool result before asking hosts to refresh their tool catalog.
+- Made `daemon start` idempotent on macOS and Linux so a healthy daemon and its active MCP sessions are preserved; explicit `daemon restart` retains restart semantics.
+- Added bounded automatic connector reattachment behind the off-by-default `RATEL_FEATURE_CONNECTOR_RECOVERY=1` rollout flag.
+- Made `ratel-local connect --help` print connector usage instead of starting a live MCP bridge.
+- Expanded bootstrap-mode guidance to distinguish a missing or stopped daemon from a temporarily detached connector.
+
 ## [0.8.0] - 2026-08-14
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ persistent daemon, detects Claude Code and Codex, connects the agents you
 select, and offers existing MCP servers and skills as a separate reviewed
 import.
 
-This README tracks the `0.8.0` stable release, matching the package version
+This README tracks the `0.8.1` stable release, matching the package version
 pinned by the bundled plugin. Unqualified npm installs resolve the `latest`
 dist-tag; the examples below remain exact-versioned for reproducibility.
 
@@ -44,7 +44,7 @@ the gateway and agent skills. Stable builds use the **Ratel** marketplace from
 the repository's default `main` branch. Prerelease builds alone pin the same
 marketplace identity to their immutable matching release tag: Codex uses
 `--ref`, while Claude Code uses the equivalent `owner/repo@ref` source. Stable
-`0.8.0` therefore carries no RC branch or tag override.
+`0.8.1` therefore carries no RC branch or tag override.
 
 If an agent already has the plugin, `link` reconciles that marketplace channel and reinstalls the plugin. It verifies that an RC tag exists before changing a working installation and attempts to restore the stable plugin if an RC switch fails after removal. When stable is restored, the command preserves that connection but reports the RC setup as failed rather than claiming the requested channel is active. If no usable plugin remains, a new link uses the reviewed explicit MCP gateway fallback; a failed existing-plugin reconciliation stops with an error. Importing still recognizes an enabled plugin as an existing Ratel connection and does not add a second gateway. If the Codex plugin is enabled but its bundled Ratel MCP server is disabled, `link` re-enables that server. Agent Setup offers **Fix duplicate installation** when both the plugin and an explicit Ratel MCP entry are present, and **Switch to plugin** for MCP-only installations. Both actions preserve the existing MCP connection unless plugin installation succeeds, and only recognized Ratel entries are removed.
 
@@ -55,7 +55,7 @@ If an agent already has the plugin, `link` reconciles that marketplace channel a
 Node.js 20.6 or newer is required.
 
 ```bash
-npm install --global @ratel-ai/ratel-local@0.8.0
+npm install --global @ratel-ai/ratel-local@0.8.1
 ratel-local --version
 ```
 
@@ -82,7 +82,7 @@ marketplace channel.
 If you do not have a global installation, run the release-pinned package:
 
 ```bash
-npx -y @ratel-ai/ratel-local@0.8.0 setup
+npx -y @ratel-ai/ratel-local@0.8.1 setup
 ```
 
 #### 3. Confirm Ratel Local and restart
@@ -144,6 +144,13 @@ ratel-local link --agent codex
 ratel-local import --agent claude-code
 ratel-local import --agent codex
 ```
+
+`daemon start` is idempotent: when the service is already healthy it leaves the
+daemon and active MCP sessions running. A connector that exposes only daemon
+bootstrap tools checks status before recovery and can safely attach to that live
+service. Set `RATEL_FEATURE_CONNECTOR_RECOVERY=1` on connector processes to opt
+into bounded automatic reattachment after daemon interruptions; this rollout
+flag is off by default.
 
 Add new upstreams directly after onboarding:
 

--- a/apps/ratel-local/package.json
+++ b/apps/ratel-local/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ratel-ai/ratel-local",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Ratel Local package: a project-scoped persistent MCP gateway with BM25, semantic, and hybrid capability search plus the ratel-local CLI.",
   "private": false,
   "type": "module",

--- a/apps/ratel-local/plugin/.claude-plugin/plugin.json
+++ b/apps/ratel-local/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ratel-local",
   "displayName": "Ratel Local",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Persistent project-scoped Ratel gateway with BM25, semantic, and hybrid capability search.",
   "author": {
     "name": "Agentified",

--- a/apps/ratel-local/plugin/.codex-plugin/plugin.json
+++ b/apps/ratel-local/plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ratel-local",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Persistent project-scoped Ratel gateway with BM25, semantic, and hybrid capability search.",
   "author": {
     "name": "Agentified",

--- a/apps/ratel-local/plugin/.mcp.json
+++ b/apps/ratel-local/plugin/.mcp.json
@@ -5,7 +5,7 @@
       "command": "npx",
       "args": [
         "-y",
-        "@ratel-ai/ratel-local@0.8.0",
+        "@ratel-ai/ratel-local@0.8.1",
         "connect"
       ]
     }

--- a/apps/ratel-local/plugin/README.md
+++ b/apps/ratel-local/plugin/README.md
@@ -24,7 +24,7 @@ shared `assets/icon.svg` remains referenced by the Codex manifest.
 The plugin MCP config starts the lightweight scoped connector through `npx`:
 
 ```bash
-npx -y @ratel-ai/ratel-local@0.8.0 connect
+npx -y @ratel-ai/ratel-local@0.8.1 connect
 ```
 
 The connector forwards the agent's resolved project root to the authenticated
@@ -35,7 +35,7 @@ connections only between sessions in the same canonical project.
 Run complete onboarding once on macOS or Linux:
 
 ```bash
-npx -y @ratel-ai/ratel-local@0.8.0 setup
+npx -y @ratel-ai/ratel-local@0.8.1 setup
 ```
 
 The wizard installs, updates, or starts the daemon; detects Claude Code and
@@ -47,9 +47,12 @@ For unattended daemon setup, use `setup --daemon-only --yes`. Agent automation
 requires explicit repeatable `--agent` flags, and `--yes` never imports native
 configuration automatically.
 
-If the daemon is missing or stopped, the connector still starts and exposes
-status, start, and setup-guidance MCP tools. The setup tool returns the terminal
-command above; it never launches interactive prompts on MCP stdio.
+If the daemon is missing, stopped, or temporarily detached, the connector still
+starts and exposes status, start, and setup-guidance MCP tools. The start tool
+checks daemon health first: it attaches to an already-running daemon without
+restarting it. Set `RATEL_FEATURE_CONNECTOR_RECOVERY=1` to opt into bounded
+automatic reattachment after daemon interruptions. The setup tool returns the
+terminal command above; it never launches interactive prompts on MCP stdio.
 
 ## Hooks
 
@@ -100,7 +103,7 @@ claude plugin install ratel-local@ratel
 
 Stable Ratel Local packages use the marketplace from the repository's default
 `main` branch. Prerelease packages alone reconcile that same marketplace to the
-immutable Git tag matching their exact package version; stable `0.8.0` does not
+immutable Git tag matching their exact package version; stable `0.8.1` does not
 use an RC branch or ref.
 
 If Claude Code is already running, restart it or run `/reload-plugins` inside

--- a/apps/ratel-local/plugin/skills/ratel-local/SKILL.md
+++ b/apps/ratel-local/plugin/skills/ratel-local/SKILL.md
@@ -19,7 +19,7 @@ the plugin `.mcp.json`.
 
 ## Plugin Runtime
 
-The plugin `.mcp.json` runs `npx -y @ratel-ai/ratel-local@0.8.0 connect`.
+The plugin `.mcp.json` runs `npx -y @ratel-ai/ratel-local@0.8.1 connect`.
 The connector sends its resolved project root to the authenticated loopback
 daemon, which loads the appropriate config chain and shares upstream
 connections only within that canonical project scope. Do not replace the
@@ -28,27 +28,28 @@ into the plugin `.mcp.json`.
 
 Stable packages install the Ratel marketplace from the repository's default
 `main` branch. Only prerelease package versions reconcile the marketplace to an
-immutable matching Git tag. Never add an RC branch or ref for stable `0.8.0`.
+immutable matching Git tag. Never add an RC branch or ref for stable `0.8.1`.
 
 Run the setup wizard once from a terminal:
 
 ```bash
-npx -y @ratel-ai/ratel-local@0.8.0 setup
+npx -y @ratel-ai/ratel-local@0.8.1 setup
 ```
 
 This is the default onboarding path: it makes the daemon ready, detects Claude
 Code and Codex, connects selected agents through the plugin-first link flow,
 then separately offers a previewed and confirmed MCP/skill import.
 
-When the daemon is unavailable, the connector exposes
+When the daemon is unavailable or the connector is temporarily detached, it exposes
 `ratel_daemon_status`, `ratel_daemon_start`, and `ratel_daemon_setup`. The
-setup tool returns the terminal command; interactive setup must never be run on
-MCP stdio.
+start tool checks health and attaches without restarting an already-running
+daemon. The setup tool returns the terminal command; interactive setup must
+never be run on MCP stdio.
 
 For human CLI work, install the package globally and use the `ratel-local` bin:
 
 ```bash
-pnpm add -g @ratel-ai/ratel-local@0.8.0
+pnpm add -g @ratel-ai/ratel-local@0.8.1
 ratel-local --version
 ```
 
@@ -374,7 +375,7 @@ ratel-local backup list
 ## Debug Checklist
 
 1. Confirm Node and `npx` are available.
-2. Confirm the plugin `.mcp.json` starts `@ratel-ai/ratel-local@0.8.0` with `connect`.
+2. Confirm the plugin `.mcp.json` starts `@ratel-ai/ratel-local@0.8.1` with `connect`.
 3. Run `ratel-local daemon status`; if needed, run `ratel-local setup`.
 4. Run `ratel-local mcp list` to verify Ratel config has upstreams.
 5. Run `ratel-local connect` from the relevant project to reproduce the scoped bridge outside the host, or `ratel-local serve --auto-config` to isolate the gateway itself.
@@ -384,7 +385,8 @@ ratel-local backup list
 
 Common findings:
 
-- Bootstrap tools only: the daemon is missing or stopped; use `ratel_daemon_status`, then run the setup command returned by `ratel_daemon_setup` or call `ratel_daemon_start` for an installed service.
+- Bootstrap tools only: the daemon may be missing, stopped, or temporarily detached. Call `ratel_daemon_status` first. When it reports `running`, `ratel_daemon_start` safely reattaches without restarting the daemon. When it reports `stopped`, call `ratel_daemon_start`; when it reports `not-installed`, use the command returned by `ratel_daemon_setup`.
+- Repeated daemon interruptions: set `RATEL_FEATURE_CONNECTOR_RECOVERY=1` on the connector process to opt into bounded automatic reattachment. The feature is off by default while it rolls out.
 - Empty catalog: no Ratel configs were found or all configs have empty `mcpServers`.
 - Dense retrieval startup failure: run `ratel-local retrieval status`, then `ratel-local retrieval prepare` in the affected project. Reset that scope to BM25 when the configured model or endpoint should not be used.
 - Missing project tools: the host did not expose a useful project root; set `RATEL_PROJECT_ROOT` or run from the project directory.

--- a/apps/ratel-local/src/cli/cli.test.ts
+++ b/apps/ratel-local/src/cli/cli.test.ts
@@ -314,6 +314,17 @@ describe("runCli — help and routing", () => {
     }
   });
 
+  it("prints connect help without starting an MCP connector", async () => {
+    const logs: string[] = [];
+
+    const result = await runCli(["connect", "--help"], {
+      logger: (message) => logs.push(message),
+    });
+
+    expect(logs.join("\n")).toContain("usage: ratel-local connect");
+    expect(result.shutdown).toBeUndefined();
+  });
+
   it("--version logs the injected package version", async () => {
     const logs: string[] = [];
     await runCli(["--version"], { cliVersion: "1.2.3", logger: (m) => logs.push(m) });

--- a/apps/ratel-local/src/cli/cli.ts
+++ b/apps/ratel-local/src/cli/cli.ts
@@ -29,7 +29,7 @@ import { type AgentPluginInstaller, createRatelAgentPluginInstaller } from "../a
 import { ArgError, type ParsedArgs, parseArgs } from "./args.js";
 import { daemonLoopbackUrl, requestRunningDaemon, requireDaemonJson } from "./daemon-api.js";
 import { BACKUP_USAGE, runBackup } from "./handlers/backup.js";
-import { runConnect } from "./handlers/connect.js";
+import { CONNECT_USAGE, runConnect } from "./handlers/connect.js";
 import { daemonPaths, runDaemon } from "./handlers/daemon.js";
 import { runDoctor } from "./handlers/doctor.js";
 import { IMPORT_USAGE, runImport } from "./handlers/import.js";
@@ -156,6 +156,11 @@ export async function runCli(argv: string[], options: RunCliOptions = {}): Promi
 
   if (parsed.group === "traces" && (parsed.verb === undefined || parsed.flags.help === true)) {
     log(TRACES_USAGE);
+    return {};
+  }
+
+  if (parsed.group === "connect" && parsed.flags.help === true) {
+    log(CONNECT_USAGE);
     return {};
   }
 

--- a/apps/ratel-local/src/cli/handlers/connect.ts
+++ b/apps/ratel-local/src/cli/handlers/connect.ts
@@ -21,6 +21,22 @@ import {
 import { resolveAutoConfig, type ServeOptions } from "./serve.js";
 import type { HandlerCtx } from "./types.js";
 
+export const CONNECTOR_RECOVERY_FEATURE_ENV = "RATEL_FEATURE_CONNECTOR_RECOVERY";
+
+export const CONNECT_USAGE = `usage: ratel-local connect [options]
+
+Bridge one agent MCP session to the project-scoped Ratel daemon.
+
+Options:
+  --project-root PATH       resolve project and local Ratel configuration from PATH
+  --daemon-url URL          override the authenticated loopback MCP endpoint
+  --agent-host HOST         declare claude-code or codex
+  --link-scope SCOPE        declare user, project, or local link scope
+  --help                    show this help
+
+Set ${CONNECTOR_RECOVERY_FEATURE_ENV}=1 to opt into automatic connector reattachment
+after a daemon interruption.`;
+
 export interface ConnectBackendInput {
   daemonUrl: URL;
   token: string;
@@ -37,6 +53,8 @@ export interface ConnectOptions extends ServeOptions {
   startDaemon?: () => Promise<void>;
   connectorTransport?: Transport;
   readToken?: (homeDir: string) => Promise<string | null>;
+  automaticReconnect?: boolean;
+  reconnectDelaysMs?: number[];
 }
 
 export async function runConnect(
@@ -111,6 +129,10 @@ export async function runConnect(
     startDaemon: start,
     serverVersion: version,
     log,
+    automaticReconnect:
+      options.automaticReconnect ??
+      (options.processEnv ?? process.env)[CONNECTOR_RECOVERY_FEATURE_ENV] === "1",
+    reconnectDelaysMs: options.reconnectDelaysMs,
   });
 }
 

--- a/apps/ratel-local/src/cli/handlers/daemon.test.ts
+++ b/apps/ratel-local/src/cli/handlers/daemon.test.ts
@@ -1027,6 +1027,34 @@ describe("runDaemon", () => {
     expect(progress).toEqual(["start:Starting Ratel Local…", "stop:Ratel Local couldn't start"]);
   });
 
+  it("does not kickstart an already-running macOS daemon", async () => {
+    const fs = new MemFs();
+    const paths = daemonPaths(HOME);
+    fs.files.set(paths.plist, "<plist />");
+    const commands: Array<{ command: string; args: string[] }> = [];
+    const logs: string[] = [];
+
+    await runDaemon(
+      daemonArgs({ verb: "start", flags: { telemetry: "off", open: false } }),
+      makeCtx(fs),
+      {},
+      (message) => logs.push(message),
+      {
+        platform: "darwin",
+        getUid: () => 501,
+        commandRunner: async (command, args) => {
+          commands.push({ command, args });
+          return { stdout: "", stderr: "" };
+        },
+        probe: async () => ({ ok: true }),
+        lifecycleProgress: false,
+      },
+    );
+
+    expect(commands).toEqual([]);
+    expect(logs).toEqual(["[ratel] daemon already running at http://127.0.0.1:5731"]);
+  });
+
   it("clears stale daemon state when uninstalling the macOS service", async () => {
     const fs = new MemFs();
     const paths = daemonPaths(HOME);
@@ -1184,6 +1212,33 @@ describe("runDaemon", () => {
 
     expect(fs.files.has(paths.systemdService)).toBe(false);
     expect(fs.files.has(paths.state)).toBe(false);
+  });
+
+  it("does not start an already-running Linux daemon again", async () => {
+    const fs = new MemFs();
+    const paths = daemonPaths(HOME);
+    fs.files.set(paths.systemdService, "[Service]");
+    const commands: Array<{ command: string; args: string[] }> = [];
+    const logs: string[] = [];
+
+    await runDaemon(
+      daemonArgs({ verb: "start", flags: { telemetry: "off", open: false } }),
+      makeCtx(fs),
+      {},
+      (message) => logs.push(message),
+      {
+        platform: "linux",
+        commandRunner: async (command, args) => {
+          commands.push({ command, args });
+          return { stdout: "", stderr: "" };
+        },
+        probe: async () => ({ ok: true }),
+        lifecycleProgress: false,
+      },
+    );
+
+    expect(commands).toEqual([]);
+    expect(logs).toEqual(["[ratel] daemon already running at http://127.0.0.1:5731"]);
   });
 
   it("reports daemon status from the persisted state and live probe", async () => {

--- a/apps/ratel-local/src/cli/handlers/daemon.ts
+++ b/apps/ratel-local/src/cli/handlers/daemon.ts
@@ -1017,10 +1017,15 @@ async function startDaemon(
   if (!(await ctx.fs.exists(paths.plist))) {
     throw new Error(`daemon is not installed; run "ratel-local daemon install" first`);
   }
+  const port = await daemonPort(parsed, ctx);
+  const probe = opts.probe ?? probeDaemon;
+  if ((await probe(port)).ok) {
+    log(`[ratel] daemon already running at http://127.0.0.1:${port}`);
+    return;
+  }
   await bootstrapDaemon(ctx, opts, { ignoreFailure: true });
   await kickstartDaemon(ctx, opts);
-  const port = await daemonPort(parsed, ctx);
-  await waitForDaemon(port, opts.probe ?? probeDaemon, options.serverVersion);
+  await waitForDaemon(port, probe, options.serverVersion);
   log(`[ratel] daemon started at http://127.0.0.1:${port}`);
 }
 
@@ -1094,9 +1099,14 @@ async function startLinuxDaemon(
   if (!(await ctx.fs.exists(paths.systemdService))) {
     throw new Error(`daemon is not installed; run "ratel-local daemon install" first`);
   }
-  await systemctl(opts, ["start", SYSTEMD_SERVICE]);
   const port = await daemonPort(parsed, ctx);
-  await waitForDaemon(port, opts.probe ?? probeDaemon, options.serverVersion);
+  const probe = opts.probe ?? probeDaemon;
+  if ((await probe(port)).ok) {
+    log(`[ratel] daemon already running at http://127.0.0.1:${port}`);
+    return;
+  }
+  await systemctl(opts, ["start", SYSTEMD_SERVICE]);
+  await waitForDaemon(port, probe, options.serverVersion);
   log(`[ratel] daemon started at http://127.0.0.1:${port}`);
 }
 

--- a/apps/ratel-local/src/connector/proxy.test.ts
+++ b/apps/ratel-local/src/connector/proxy.test.ts
@@ -1,7 +1,11 @@
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
-import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+  ToolListChangedNotificationSchema,
+} from "@modelcontextprotocol/sdk/types.js";
 import { describe, expect, it, vi } from "vitest";
 import { runConnectorProxy } from "./proxy.js";
 
@@ -77,6 +81,74 @@ describe("runConnectorProxy", () => {
     expect((await host.listTools()).tools.map((tool) => tool.name)).toEqual([
       "search_capabilities",
     ]);
+
+    await host.close();
+    await connector.shutdown();
+    await remote.server.close();
+  });
+
+  it("attaches to an already-running daemon without restarting it", async () => {
+    const remote = await backend();
+    const [connectorTransport, hostTransport] = InMemoryTransport.createLinkedPair();
+    const connectBackend = vi
+      .fn<() => Promise<Client>>()
+      .mockRejectedValueOnce(new Error("initial connection failed"))
+      .mockResolvedValue(remote.client);
+    const startDaemon = vi.fn(async () => {});
+    const connector = await runConnectorProxy({
+      serverTransport: connectorTransport,
+      connectBackend,
+      daemonStatus: async () => ({ state: "running" }),
+      startDaemon,
+      serverVersion: "1.0.0",
+    });
+    const host = new Client({ name: "host", version: "1.0.0" });
+    await host.connect(hostTransport);
+
+    const start = await host.callTool({ name: "ratel_daemon_start", arguments: {} });
+
+    expect(start.isError).not.toBe(true);
+    expect(startDaemon).not.toHaveBeenCalled();
+    expect(connectBackend).toHaveBeenCalledTimes(2);
+    expect((await host.listTools()).tools.map((tool) => tool.name)).toEqual([
+      "search_capabilities",
+    ]);
+
+    await host.close();
+    await connector.shutdown();
+    await remote.server.close();
+  });
+
+  it("returns the recovery result before notifying the host to refresh tools", async () => {
+    const remote = await backend();
+    const [connectorTransport, hostTransport] = InMemoryTransport.createLinkedPair();
+    const connectBackend = vi
+      .fn<() => Promise<Client>>()
+      .mockRejectedValueOnce(new Error("daemon offline"))
+      .mockResolvedValue(remote.client);
+    const connector = await runConnectorProxy({
+      serverTransport: connectorTransport,
+      connectBackend,
+      daemonStatus: async () => ({ state: "stopped" }),
+      startDaemon: async () => {},
+      serverVersion: "1.0.0",
+    });
+    const host = new Client(
+      { name: "host", version: "1.0.0" },
+      { capabilities: { tools: { listChanged: true } } },
+    );
+    let callResolved = false;
+    let notificationBeforeResult = false;
+    host.setNotificationHandler(ToolListChangedNotificationSchema, async () => {
+      if (!callResolved) notificationBeforeResult = true;
+    });
+    await host.connect(hostTransport);
+
+    await host.callTool({ name: "ratel_daemon_start", arguments: {} });
+    callResolved = true;
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(notificationBeforeResult).toBe(false);
 
     await host.close();
     await connector.shutdown();
@@ -239,5 +311,38 @@ describe("runConnectorProxy", () => {
     );
     await host.close();
     await connector.shutdown();
+  });
+
+  it("reattaches with backoff after the daemon disconnects when recovery is enabled", async () => {
+    const first = await backend();
+    const second = await backend();
+    const [connectorTransport, hostTransport] = InMemoryTransport.createLinkedPair();
+    const connectBackend = vi
+      .fn<() => Promise<Client>>()
+      .mockResolvedValueOnce(first.client)
+      .mockRejectedValueOnce(new Error("daemon restarting"))
+      .mockResolvedValue(second.client);
+    const connector = await runConnectorProxy({
+      serverTransport: connectorTransport,
+      connectBackend,
+      daemonStatus: async () => ({ state: "running" }),
+      startDaemon: async () => {},
+      serverVersion: "1.0.0",
+      automaticReconnect: true,
+      reconnectDelaysMs: [0],
+    });
+    const host = new Client({ name: "host", version: "1.0.0" });
+    await host.connect(hostTransport);
+
+    await first.server.close();
+    await vi.waitFor(() => expect(connectBackend).toHaveBeenCalledTimes(3));
+
+    expect((await host.listTools()).tools.map((tool) => tool.name)).toEqual([
+      "search_capabilities",
+    ]);
+
+    await host.close();
+    await connector.shutdown();
+    await second.server.close();
   });
 });

--- a/apps/ratel-local/src/connector/proxy.ts
+++ b/apps/ratel-local/src/connector/proxy.ts
@@ -23,6 +23,8 @@ export interface ConnectorProxyOptions {
   log?: (message: string) => void;
   connectTimeoutMs?: number;
   initialConnectionGraceMs?: number;
+  automaticReconnect?: boolean;
+  reconnectDelaysMs?: number[];
 }
 
 export interface ConnectorProxyHandle {
@@ -58,6 +60,12 @@ export async function runConnectorProxy(
   let backend: Client | null = null;
   let attaching: Promise<Client> | null = null;
   let closed = false;
+  let reconnectAttempt = 0;
+  let reconnectTimer: ReturnType<typeof setTimeout> | undefined;
+  const notificationTimers = new Set<ReturnType<typeof setTimeout>>();
+  const reconnectDelaysMs = options.reconnectDelaysMs?.length
+    ? options.reconnectDelaysMs
+    : [250, 500, 1_000, 2_000, 5_000];
 
   const server = new Server(
     { name: "ratel-local-connector", version: options.serverVersion },
@@ -82,7 +90,10 @@ export async function runConnectorProxy(
         client.onclose = () => {
           if (backend !== client) return;
           backend = null;
-          if (!closed) void server.sendToolListChanged().catch(() => undefined);
+          if (!closed) {
+            void server.sendToolListChanged().catch(() => undefined);
+            scheduleReconnect();
+          }
         };
         client.onerror = (error) => {
           log(`[ratel] daemon connection error: ${error.message}`);
@@ -97,6 +108,43 @@ export async function runConnectorProxy(
       });
     return attaching;
   };
+
+  function scheduleReconnect(): void {
+    if (!options.automaticReconnect || closed || backend || attaching || reconnectTimer) {
+      return;
+    }
+    const delayMs = reconnectDelaysMs[Math.min(reconnectAttempt, reconnectDelaysMs.length - 1)];
+    reconnectTimer = setTimeout(() => {
+      reconnectTimer = undefined;
+      void attach()
+        .then(() => {
+          reconnectAttempt = 0;
+          scheduleToolListChanged();
+        })
+        .catch((error) => {
+          reconnectAttempt += 1;
+          log(`[ratel] daemon reconnect failed: ${(error as Error).message}`);
+          scheduleReconnect();
+        });
+    }, delayMs);
+    reconnectTimer.unref?.();
+  }
+
+  function scheduleToolListChanged(): void {
+    const timer = setTimeout(() => {
+      notificationTimers.delete(timer);
+      if (!closed) void server.sendToolListChanged().catch(() => undefined);
+    }, 0);
+    timer.unref?.();
+    notificationTimers.add(timer);
+  }
+
+  function clearScheduledWork(): void {
+    if (reconnectTimer) clearTimeout(reconnectTimer);
+    reconnectTimer = undefined;
+    for (const timer of notificationTimers) clearTimeout(timer);
+    notificationTimers.clear();
+  }
 
   server.setRequestHandler(ListToolsRequestSchema, async () => {
     if (!backend && attaching) await attaching.catch(() => undefined);
@@ -120,10 +168,17 @@ export async function runConnectorProxy(
         return jsonResult({ state: "running", message: "Ratel daemon is already connected." });
       }
       try {
-        await options.startDaemon();
+        const status = await options.daemonStatus();
+        const started = status.state !== "running";
+        if (started) await options.startDaemon();
         await attach();
-        await server.sendToolListChanged();
-        return jsonResult({ state: "running", message: "Ratel daemon started and connected." });
+        scheduleToolListChanged();
+        return jsonResult({
+          state: "running",
+          message: started
+            ? "Ratel daemon started and connected."
+            : "Ratel daemon was already running and is now connected.",
+        });
       } catch (err) {
         return jsonResult(
           {
@@ -143,6 +198,7 @@ export async function runConnectorProxy(
   server.onclose = () => {
     if (closed) return;
     closed = true;
+    clearScheduledWork();
     const current = backend;
     backend = null;
     void current?.close();
@@ -158,6 +214,7 @@ export async function runConnectorProxy(
       log(
         `[ratel] daemon unavailable; connector entered bootstrap mode: ${(err as Error).message}`,
       );
+      scheduleReconnect();
     });
   await Promise.race([
     initialAttach.catch(() => undefined),
@@ -168,6 +225,7 @@ export async function runConnectorProxy(
     shutdown: async () => {
       if (closed) return;
       closed = true;
+      clearScheduledWork();
       const current = backend;
       backend = null;
       await server.close();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ratel-local-workspace",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.33.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ratel-ai/ratel-local-core",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ratel-ai/ratel-local-ui",
   "private": true,
-  "version": "0.8.0",
+  "version": "0.8.1",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## What changed

- make connector recovery probe daemon health and attach without restarting a healthy service
- make `daemon start` idempotent on macOS and Linux
- defer tool-catalog refresh notifications until the recovery tool result is returned
- add bounded automatic reattachment behind `RATEL_FEATURE_CONNECTOR_RECOVERY=1`
- make `ratel-local connect --help` print usage without launching a bridge
- bump all synchronized package/plugin pins and changelog to 0.8.1

## Root cause

A detached connector exposed bootstrap tools even while the daemon was healthy. Calling `ratel_daemon_start` then reached macOS `launchctl kickstart -k`, force-restarting that daemon and dropping the connector's own in-flight recovery transport.

## Impact

Recovery no longer disrupts healthy daemon sessions. Automatic retry is available behind an off-by-default rollout flag, and explicit restart behavior remains unchanged.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm build`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test` (1,114 tests)
- `pnpm check:pack`
- packed tarball manifest inspection
- direct `--version` and `connect --help` smoke checks
