### PR TITLE
release: v0.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this package are documented here. The format is based on 
 
 ## [Unreleased]
 
+## [0.8.2] - 2026-08-19
+
+### Fixed
+- Made `mcp list` resolve the scoped OAuth credential key and resource fingerprint used by the gateway, so authenticated HTTP/SSE servers are no longer reported as unauthenticated.
+- Made the connector keep initial catalog requests pending until the daemon handshake succeeds or actually fails, instead of switching to the bootstrap-only surface after a hardcoded timeout.
+
 ## [0.8.1] - 2026-08-19
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ persistent daemon, detects Claude Code and Codex, connects the agents you
 select, and offers existing MCP servers and skills as a separate reviewed
 import.
 
-This README tracks the `0.8.1` stable release, matching the package version
+This README tracks the `0.8.2` stable release, matching the package version
 pinned by the bundled plugin. Unqualified npm installs resolve the `latest`
 dist-tag; the examples below remain exact-versioned for reproducibility.
 
@@ -44,7 +44,7 @@ the gateway and agent skills. Stable builds use the **Ratel** marketplace from
 the repository's default `main` branch. Prerelease builds alone pin the same
 marketplace identity to their immutable matching release tag: Codex uses
 `--ref`, while Claude Code uses the equivalent `owner/repo@ref` source. Stable
-`0.8.1` therefore carries no RC branch or tag override.
+`0.8.2` therefore carries no RC branch or tag override.
 
 If an agent already has the plugin, `link` reconciles that marketplace channel and reinstalls the plugin. It verifies that an RC tag exists before changing a working installation and attempts to restore the stable plugin if an RC switch fails after removal. When stable is restored, the command preserves that connection but reports the RC setup as failed rather than claiming the requested channel is active. If no usable plugin remains, a new link uses the reviewed explicit MCP gateway fallback; a failed existing-plugin reconciliation stops with an error. Importing still recognizes an enabled plugin as an existing Ratel connection and does not add a second gateway. If the Codex plugin is enabled but its bundled Ratel MCP server is disabled, `link` re-enables that server. Agent Setup offers **Fix duplicate installation** when both the plugin and an explicit Ratel MCP entry are present, and **Switch to plugin** for MCP-only installations. Both actions preserve the existing MCP connection unless plugin installation succeeds, and only recognized Ratel entries are removed.
 
@@ -55,7 +55,7 @@ If an agent already has the plugin, `link` reconciles that marketplace channel a
 Node.js 20.6 or newer is required.
 
 ```bash
-npm install --global @ratel-ai/ratel-local@0.8.1
+npm install --global @ratel-ai/ratel-local@0.8.2
 ratel-local --version
 ```
 
@@ -82,7 +82,7 @@ marketplace channel.
 If you do not have a global installation, run the release-pinned package:
 
 ```bash
-npx -y @ratel-ai/ratel-local@0.8.1 setup
+npx -y @ratel-ai/ratel-local@0.8.2 setup
 ```
 
 #### 3. Confirm Ratel Local and restart
@@ -146,11 +146,13 @@ ratel-local import --agent codex
 ```
 
 `daemon start` is idempotent: when the service is already healthy it leaves the
-daemon and active MCP sessions running. A connector that exposes only daemon
-bootstrap tools checks status before recovery and can safely attach to that live
+daemon and active MCP sessions running. During a slow cold start, the connector
+waits for the daemon handshake and then exposes the complete catalog. Bootstrap
+tools appear only after attachment actually fails or a live connection is later
+lost; they check status before recovery and can safely attach to the running
 service. Set `RATEL_FEATURE_CONNECTOR_RECOVERY=1` on connector processes to opt
-into bounded automatic reattachment after daemon interruptions; this rollout
-flag is off by default.
+into bounded automatic reattachment after later daemon interruptions; this
+rollout flag is off by default.
 
 Add new upstreams directly after onboarding:
 

--- a/apps/ratel-local/package.json
+++ b/apps/ratel-local/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ratel-ai/ratel-local",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Ratel Local package: a project-scoped persistent MCP gateway with BM25, semantic, and hybrid capability search plus the ratel-local CLI.",
   "private": false,
   "type": "module",

--- a/apps/ratel-local/plugin/.claude-plugin/plugin.json
+++ b/apps/ratel-local/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ratel-local",
   "displayName": "Ratel Local",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Persistent project-scoped Ratel gateway with BM25, semantic, and hybrid capability search.",
   "author": {
     "name": "Agentified",

--- a/apps/ratel-local/plugin/.codex-plugin/plugin.json
+++ b/apps/ratel-local/plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ratel-local",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Persistent project-scoped Ratel gateway with BM25, semantic, and hybrid capability search.",
   "author": {
     "name": "Agentified",

--- a/apps/ratel-local/plugin/.mcp.json
+++ b/apps/ratel-local/plugin/.mcp.json
@@ -5,7 +5,7 @@
       "command": "npx",
       "args": [
         "-y",
-        "@ratel-ai/ratel-local@0.8.1",
+        "@ratel-ai/ratel-local@0.8.2",
         "connect"
       ]
     }

--- a/apps/ratel-local/plugin/README.md
+++ b/apps/ratel-local/plugin/README.md
@@ -24,7 +24,7 @@ shared `assets/icon.svg` remains referenced by the Codex manifest.
 The plugin MCP config starts the lightweight scoped connector through `npx`:
 
 ```bash
-npx -y @ratel-ai/ratel-local@0.8.1 connect
+npx -y @ratel-ai/ratel-local@0.8.2 connect
 ```
 
 The connector forwards the agent's resolved project root to the authenticated
@@ -35,7 +35,7 @@ connections only between sessions in the same canonical project.
 Run complete onboarding once on macOS or Linux:
 
 ```bash
-npx -y @ratel-ai/ratel-local@0.8.1 setup
+npx -y @ratel-ai/ratel-local@0.8.2 setup
 ```
 
 The wizard installs, updates, or starts the daemon; detects Claude Code and
@@ -47,12 +47,14 @@ For unattended daemon setup, use `setup --daemon-only --yes`. Agent automation
 requires explicit repeatable `--agent` flags, and `--yes` never imports native
 configuration automatically.
 
-If the daemon is missing, stopped, or temporarily detached, the connector still
-starts and exposes status, start, and setup-guidance MCP tools. The start tool
-checks daemon health first: it attaches to an already-running daemon without
-restarting it. Set `RATEL_FEATURE_CONNECTOR_RECOVERY=1` to opt into bounded
-automatic reattachment after daemon interruptions. The setup tool returns the
-terminal command above; it never launches interactive prompts on MCP stdio.
+While the initial daemon handshake is pending, the connector waits and exposes
+the complete catalog once attachment succeeds. If attachment actually fails, or
+if a live connection is later lost, it exposes status, start, and setup-guidance
+MCP tools. The start tool checks daemon health first: it attaches to an
+already-running daemon without restarting it. Set
+`RATEL_FEATURE_CONNECTOR_RECOVERY=1` to opt into bounded automatic reattachment
+after later daemon interruptions. The setup tool returns the terminal command
+above; it never launches interactive prompts on MCP stdio.
 
 ## Hooks
 
@@ -103,7 +105,7 @@ claude plugin install ratel-local@ratel
 
 Stable Ratel Local packages use the marketplace from the repository's default
 `main` branch. Prerelease packages alone reconcile that same marketplace to the
-immutable Git tag matching their exact package version; stable `0.8.1` does not
+immutable Git tag matching their exact package version; stable `0.8.2` does not
 use an RC branch or ref.
 
 If Claude Code is already running, restart it or run `/reload-plugins` inside

--- a/apps/ratel-local/plugin/skills/ratel-local/SKILL.md
+++ b/apps/ratel-local/plugin/skills/ratel-local/SKILL.md
@@ -19,7 +19,7 @@ the plugin `.mcp.json`.
 
 ## Plugin Runtime
 
-The plugin `.mcp.json` runs `npx -y @ratel-ai/ratel-local@0.8.1 connect`.
+The plugin `.mcp.json` runs `npx -y @ratel-ai/ratel-local@0.8.2 connect`.
 The connector sends its resolved project root to the authenticated loopback
 daemon, which loads the appropriate config chain and shares upstream
 connections only within that canonical project scope. Do not replace the
@@ -28,12 +28,12 @@ into the plugin `.mcp.json`.
 
 Stable packages install the Ratel marketplace from the repository's default
 `main` branch. Only prerelease package versions reconcile the marketplace to an
-immutable matching Git tag. Never add an RC branch or ref for stable `0.8.1`.
+immutable matching Git tag. Never add an RC branch or ref for stable `0.8.2`.
 
 Run the setup wizard once from a terminal:
 
 ```bash
-npx -y @ratel-ai/ratel-local@0.8.1 setup
+npx -y @ratel-ai/ratel-local@0.8.2 setup
 ```
 
 This is the default onboarding path: it makes the daemon ready, detects Claude
@@ -49,7 +49,7 @@ never be run on MCP stdio.
 For human CLI work, install the package globally and use the `ratel-local` bin:
 
 ```bash
-pnpm add -g @ratel-ai/ratel-local@0.8.1
+pnpm add -g @ratel-ai/ratel-local@0.8.2
 ratel-local --version
 ```
 
@@ -375,7 +375,7 @@ ratel-local backup list
 ## Debug Checklist
 
 1. Confirm Node and `npx` are available.
-2. Confirm the plugin `.mcp.json` starts `@ratel-ai/ratel-local@0.8.1` with `connect`.
+2. Confirm the plugin `.mcp.json` starts `@ratel-ai/ratel-local@0.8.2` with `connect`.
 3. Run `ratel-local daemon status`; if needed, run `ratel-local setup`.
 4. Run `ratel-local mcp list` to verify Ratel config has upstreams.
 5. Run `ratel-local connect` from the relevant project to reproduce the scoped bridge outside the host, or `ratel-local serve --auto-config` to isolate the gateway itself.
@@ -385,7 +385,7 @@ ratel-local backup list
 
 Common findings:
 
-- Bootstrap tools only: the daemon may be missing, stopped, or temporarily detached. Call `ratel_daemon_status` first. When it reports `running`, `ratel_daemon_start` safely reattaches without restarting the daemon. When it reports `stopped`, call `ratel_daemon_start`; when it reports `not-installed`, use the command returned by `ratel_daemon_setup`.
+- Bootstrap tools only: initial attachment failed or a live connection was later lost; pending cold starts wait for the complete catalog instead. Call `ratel_daemon_status` first. When it reports `running`, `ratel_daemon_start` safely reattaches without restarting the daemon. When it reports `stopped`, call `ratel_daemon_start`; when it reports `not-installed`, use the command returned by `ratel_daemon_setup`.
 - Repeated daemon interruptions: set `RATEL_FEATURE_CONNECTOR_RECOVERY=1` on the connector process to opt into bounded automatic reattachment. The feature is off by default while it rolls out.
 - Empty catalog: no Ratel configs were found or all configs have empty `mcpServers`.
 - Dense retrieval startup failure: run `ratel-local retrieval status`, then `ratel-local retrieval prepare` in the affected project. Reset that scope to BM25 when the configured model or endpoint should not be used.

--- a/apps/ratel-local/src/cli/handlers/mcp-list.test.ts
+++ b/apps/ratel-local/src/cli/handlers/mcp-list.test.ts
@@ -1,4 +1,5 @@
-import type { BackupFs, HierarchyEnv, JsonFs } from "@ratel-ai/ratel-local-core";
+import type { BackupFs, HierarchyEnv, JsonFs, ServerEntry } from "@ratel-ai/ratel-local-core";
+import { parseConfig, resolveMcpEntries } from "@ratel-ai/ratel-local-core";
 import { describe, expect, it } from "vitest";
 import type { ParsedArgs } from "../args.js";
 import { silentPromptAdapter } from "../prompts.js";
@@ -7,6 +8,20 @@ import type { HandlerCtx } from "./types.js";
 
 const HOME = "/home/u";
 const ROOT = "/r";
+
+function userOAuthKey(name: string, entry: ServerEntry) {
+  const [resolved] = resolveMcpEntries({
+    homeDir: HOME,
+    documents: [
+      {
+        ref: { scope: "user" },
+        config: parseConfig({ mcpServers: { [name]: entry } }),
+      },
+    ],
+  });
+  if (!resolved) throw new Error(`failed to resolve ${name}`);
+  return resolved.oauthKey;
+}
 
 class MemFs implements BackupFs, JsonFs {
   files = new Map<string, string>();
@@ -139,18 +154,22 @@ describe("runMcpList", () => {
         },
       })}\n`,
     );
+    const freshKey = userOAuthKey("fresh", { type: "http", url: "https://fresh.example" });
+    const staleKey = userOAuthKey("stale", { type: "http", url: "https://stale.example" });
     fs.files.set(
-      "/home/u/.ratel/oauth/fresh.json",
+      freshKey.path,
       JSON.stringify({
         tokens: { access_token: "abc", token_type: "Bearer" },
         expires_at: Date.now() + 60_000,
+        resource_fingerprint: freshKey.fingerprint,
       }),
     );
     fs.files.set(
-      "/home/u/.ratel/oauth/stale.json",
+      staleKey.path,
       JSON.stringify({
         tokens: { access_token: "abc", token_type: "Bearer" },
         expires_at: Date.now() - 60_000,
+        resource_fingerprint: staleKey.fingerprint,
       }),
     );
 
@@ -166,5 +185,28 @@ describe("runMcpList", () => {
     expect(out).toMatch(/fresh[^\n]*ok/);
     // past expires_at → expired.
     expect(out).toMatch(/stale[^\n]*expired/);
+  });
+
+  it("requires auth when scoped credentials belong to a different resource", async () => {
+    const fs = new MemFs();
+    fs.files.set(
+      "/home/u/.ratel/config.json",
+      `${JSON.stringify({
+        mcpServers: { remote: { type: "http", url: "https://current.example" } },
+      })}\n`,
+    );
+    const key = userOAuthKey("remote", { type: "http", url: "https://current.example" });
+    fs.files.set(
+      key.path,
+      JSON.stringify({
+        tokens: { access_token: "abc" },
+        resource_fingerprint: "credentials-for-an-old-url",
+      }),
+    );
+
+    const { ctx, logs } = makeCtx(fs, {});
+    await runMcpList(ctx);
+
+    expect(logs.join("\n")).toMatch(/remote[^\n]*needs auth/);
   });
 });

--- a/apps/ratel-local/src/cli/handlers/mcp-list.ts
+++ b/apps/ratel-local/src/cli/handlers/mcp-list.ts
@@ -1,10 +1,13 @@
-import { join } from "node:path";
-import type { RatelConfig, ServerEntry } from "@ratel-ai/ratel-local-core";
+import { realpath } from "node:fs/promises";
+import type { OAuthStoreKey, RatelConfig, ServerEntry } from "@ratel-ai/ratel-local-core";
 import {
   ProjectRootNotFoundError,
+  parseConfig,
+  projectIdFromCanonicalRoot,
   type RatelScope,
   ratelConfigPath,
   readJson,
+  resolveMcpEntries,
 } from "@ratel-ai/ratel-local-core";
 import type { HandlerCtx } from "./types.js";
 
@@ -16,29 +19,49 @@ interface StoredOAuth {
   tokens?: { access_token?: string };
   expires_at?: number;
   unsupported?: { reason?: string; detected_at?: string };
+  resource_fingerprint?: string;
 }
 
 export async function runMcpList(ctx: HandlerCtx): Promise<void> {
   let totalEntries = 0;
   const sections: string[] = [];
+  const projectRoot = ctx.env.projectRoot
+    ? await realpath(ctx.env.projectRoot).catch(() => ctx.env.projectRoot)
+    : undefined;
+  const env = { ...ctx.env, ...(projectRoot ? { projectRoot } : {}) };
+  const projectId = projectRoot ? projectIdFromCanonicalRoot(projectRoot) : undefined;
 
   for (const scope of SCOPES) {
     let path: string;
     try {
-      path = ratelConfigPath(scope, ctx.env);
+      path = ratelConfigPath(scope, env);
     } catch (err) {
       if (err instanceof ProjectRootNotFoundError) continue;
       throw err;
     }
-    const cfg = await readJson<RatelConfig>(ctx.fs, path);
-    if (!cfg) continue;
+    const document = await readJson<RatelConfig>(ctx.fs, path);
+    if (!document) continue;
+    const cfg = parseConfig(document);
     const entries = Object.entries(cfg.mcpServers);
     if (entries.length === 0) continue;
+    const ref =
+      scope === "user"
+        ? ({ scope: "user" } as const)
+        : projectId
+          ? ({ scope, projectId } as const)
+          : undefined;
+    if (!ref) continue;
+    const resolvedEntries = resolveMcpEntries({
+      homeDir: env.homeDir,
+      ...(projectRoot ? { projectRoot } : {}),
+      documents: [{ ref, config: cfg }],
+    });
 
     totalEntries += entries.length;
     const lines = [`${scope}:  (${path})`];
     for (const [name, entry] of entries) {
-      const status = await resolveAuthStatus(ctx, name, entry);
+      const resolved = resolvedEntries.find((candidate) => candidate.name === name);
+      const status = await resolveAuthStatus(ctx, entry, resolved?.oauthKey);
       lines.push(`  ${name.padEnd(20)} [${status}]  ${formatEntry(entry)}`);
     }
     sections.push(lines.join("\n"));
@@ -62,13 +85,15 @@ function formatEntry(entry: ServerEntry): string {
 
 async function resolveAuthStatus(
   ctx: HandlerCtx,
-  name: string,
   entry: ServerEntry,
+  oauthKey: OAuthStoreKey | undefined,
 ): Promise<AuthStatus> {
   if (entry.type !== "http" && entry.type !== "sse") return "n/a";
-  if (!ctx.env.homeDir) return "needs auth";
-  const path = join(ctx.env.homeDir, ".ratel", "oauth", `${name}.json`);
-  const stored = await readJson<StoredOAuth>(ctx.fs, path);
+  if (!oauthKey) return "needs auth";
+  const stored = await readJson<StoredOAuth>(ctx.fs, oauthKey.path);
+  if (stored?.resource_fingerprint && stored.resource_fingerprint !== oauthKey.fingerprint) {
+    return "needs auth";
+  }
   if (!stored?.tokens?.access_token) {
     if (stored?.unsupported?.reason) return "unsupported";
     return "needs auth";

--- a/apps/ratel-local/src/connector/proxy.test.ts
+++ b/apps/ratel-local/src/connector/proxy.test.ts
@@ -180,26 +180,43 @@ describe("runConnectorProxy", () => {
     await connector.shutdown();
   });
 
-  it("initializes stdio in bootstrap mode while a daemon connection is hung", async () => {
+  it("keeps the first tool list pending while a slow daemon attachment is in flight", async () => {
+    const remote = await backend();
     const [connectorTransport, hostTransport] = InMemoryTransport.createLinkedPair();
+    let finishAttach: ((client: Client) => void) | undefined;
+    const connectBackend = vi.fn(
+      () =>
+        new Promise<Client>((resolve) => {
+          finishAttach = resolve;
+        }),
+    );
     const connector = await runConnectorProxy({
       serverTransport: connectorTransport,
-      connectBackend: () => new Promise<Client>(() => {}),
-      daemonStatus: async () => ({ state: "unavailable" }),
+      connectBackend,
+      daemonStatus: async () => ({ state: "running" }),
       startDaemon: async () => {},
       serverVersion: "1.0.0",
-      connectTimeoutMs: 20,
+      connectTimeoutMs: 10,
       initialConnectionGraceMs: 1,
     });
     const host = new Client({ name: "host", version: "1.0.0" });
     await host.connect(hostTransport);
 
-    expect((await host.listTools()).tools.map((tool) => tool.name)).toContain(
-      "ratel_daemon_status",
-    );
+    let settled = false;
+    const tools = host.listTools().then((result) => {
+      settled = true;
+      return result;
+    });
+    await new Promise((resolve) => setTimeout(resolve, 25));
+
+    expect(settled).toBe(false);
+    finishAttach?.(remote.client);
+    expect((await tools).tools.map((tool) => tool.name)).toEqual(["search_capabilities"]);
+    expect(connectBackend).toHaveBeenCalledOnce();
 
     await host.close();
     await connector.shutdown();
+    await remote.server.close();
   });
 
   it("waits for an in-flight initial attachment before returning the first tool list", async () => {

--- a/apps/ratel-local/src/connector/proxy.ts
+++ b/apps/ratel-local/src/connector/proxy.ts
@@ -21,6 +21,7 @@ export interface ConnectorProxyOptions {
   startDaemon: () => Promise<void>;
   serverVersion: string;
   log?: (message: string) => void;
+  /** @deprecated Attachment now waits for the backend handshake to settle. */
   connectTimeoutMs?: number;
   initialConnectionGraceMs?: number;
   automaticReconnect?: boolean;
@@ -77,32 +78,39 @@ export async function runConnectorProxy(
     },
   );
 
+  const adoptBackend = async (client: Client): Promise<Client> => {
+    if (closed) {
+      await client.close().catch(() => undefined);
+      throw new Error("connector is closed");
+    }
+    if (backend) {
+      if (backend !== client) await client.close().catch(() => undefined);
+      return backend;
+    }
+    backend = client;
+    client.onclose = () => {
+      if (backend !== client) return;
+      backend = null;
+      if (!closed) {
+        void server.sendToolListChanged().catch(() => undefined);
+        scheduleReconnect();
+      }
+    };
+    client.onerror = (error) => {
+      log(`[ratel] daemon connection error: ${error.message}`);
+    };
+    client.setNotificationHandler(ToolListChangedNotificationSchema, async () => {
+      await server.sendToolListChanged();
+    });
+    return client;
+  };
+
   const attach = async (): Promise<Client> => {
     if (backend) return backend;
     if (attaching) return attaching;
-    attaching = connectWithTimeout(options.connectBackend, options.connectTimeoutMs ?? 8_000)
-      .then((client) => {
-        if (closed) {
-          void client.close();
-          throw new Error("connector is closed");
-        }
-        backend = client;
-        client.onclose = () => {
-          if (backend !== client) return;
-          backend = null;
-          if (!closed) {
-            void server.sendToolListChanged().catch(() => undefined);
-            scheduleReconnect();
-          }
-        };
-        client.onerror = (error) => {
-          log(`[ratel] daemon connection error: ${error.message}`);
-        };
-        client.setNotificationHandler(ToolListChangedNotificationSchema, async () => {
-          await server.sendToolListChanged();
-        });
-        return client;
-      })
+    attaching = options
+      .connectBackend()
+      .then(adoptBackend)
       .finally(() => {
         attaching = null;
       });
@@ -232,30 +240,6 @@ export async function runConnectorProxy(
       await current?.close();
     },
   };
-}
-
-async function connectWithTimeout(
-  connect: () => Promise<Client>,
-  timeoutMs: number,
-): Promise<Client> {
-  const pending = connect();
-  let timedOut = false;
-  let timer: ReturnType<typeof setTimeout> | undefined;
-  const timeout = new Promise<never>((_, reject) => {
-    timer = setTimeout(() => {
-      timedOut = true;
-      reject(new Error(`daemon connection timed out after ${timeoutMs}ms`));
-    }, timeoutMs);
-    timer.unref?.();
-  });
-  try {
-    return await Promise.race([pending, timeout]);
-  } catch (err) {
-    if (timedOut) void pending.then((client) => client.close()).catch(() => undefined);
-    throw err;
-  } finally {
-    if (timer) clearTimeout(timer);
-  }
 }
 
 function delay(ms: number): Promise<void> {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ratel-local-workspace",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.33.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ratel-ai/ratel-local-core",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ratel-ai/ratel-local-ui",
   "private": true,
-  "version": "0.8.1",
+  "version": "0.8.2",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary

- resolve `mcp list` OAuth status through the same scoped credential key and resource fingerprint used by the gateway
- keep the connector catalog request pending during initial daemon attachment instead of exposing bootstrap tools after a hardcoded timeout
- bump the package and bundled plugins to `0.8.2`

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm build`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test` (1,115 tests)
- `pnpm check:pack`
- packed `@ratel-ai/ratel-local@0.8.2` tarball and inspected its published manifest
