### PR TITLE
fix: deduplicate capability search metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ All notable changes to this package are documented here. The format is based on 
 ### Removed
 - Removed the deprecated `search_tools` alias from MCP discovery and call dispatch. Agents now have a single capability-search entry point: `search_capabilities`.
 
+### Fixed
+- Removed duplicate upstream metadata from capability search responses: Ratel keeps `server.description` and omits `server.instructions` only when their strings are exactly equal; distinct metadata remains unchanged.
+
 ## [0.8.2] - 2026-08-19
 
 ### Fixed

--- a/packages/core/src/lib/server.test.ts
+++ b/packages/core/src/lib/server.test.ts
@@ -17,6 +17,7 @@ import {
   ToolCatalog,
 } from "@ratel-ai/sdk";
 import { describe, expect, it, vi } from "vitest";
+import { buildGatewayFromConfig } from "./gateway.js";
 import { createMcpServer } from "./server.js";
 import { AUTH_TOOL_ID } from "./tools/auth.js";
 
@@ -27,10 +28,10 @@ interface UpstreamToolSpec {
   handler?: (args: Record<string, unknown>) => unknown;
 }
 
-async function startUpstreamMcp(tools: UpstreamToolSpec[]) {
+async function startUpstreamMcp(tools: UpstreamToolSpec[], instructions?: string) {
   const server = new Server(
     { name: "fake-upstream", version: "0.0.0" },
-    { capabilities: { tools: {} } },
+    { capabilities: { tools: {} }, ...(instructions ? { instructions } : {}) },
   );
   server.setRequestHandler(ListToolsRequestSchema, async () => ({
     tools: tools.map((t) => ({
@@ -313,6 +314,60 @@ describe("createMcpServer", () => {
 
     await client.close();
     await handle.close();
+  });
+
+  it("search_capabilities omits upstream instructions that exactly duplicate the description", async () => {
+    const repeatedMetadata = "Use this weather server for forecasts and alerts.";
+    const upstream = await startUpstreamMcp(
+      [{ name: "weather", description: "Get the current weather forecast for a city." }],
+      repeatedMetadata,
+    );
+    const gateway = await buildGatewayFromConfig(
+      { mcpServers: { wx: { type: "stdio", command: "noop" } } },
+      { transportFactory: () => upstream.clientTransport },
+    );
+    expect(gateway.upstreamServers[0]).toMatchObject({
+      description: repeatedMetadata,
+      instructions: repeatedMetadata,
+    });
+
+    const [serverTransport, clientTransport] = InMemoryTransport.createLinkedPair();
+    const handle = await createMcpServer(gateway.catalog, {
+      name: "ratel-test",
+      version: "0.0.0",
+      transport: serverTransport,
+      upstreamServers: gateway.upstreamServers,
+    });
+    const client = new Client({ name: "test-client", version: "0.0.0" });
+    await client.connect(clientTransport);
+
+    const result = await client.callTool({
+      name: SEARCH_CAPABILITIES_ID,
+      arguments: { query: "weather forecast" },
+    });
+    const structured = result.structuredContent as {
+      tools: {
+        groups: Array<{
+          server: { name: string; description?: string; instructions?: string };
+        }>;
+      };
+    };
+    expect(structured.tools.groups[0].server).toEqual({
+      name: "wx",
+      description: repeatedMetadata,
+    });
+
+    const content = result.content as Array<{ type: string; text: string }>;
+    const parsed = JSON.parse(content[0].text) as typeof structured;
+    expect(parsed.tools.groups[0].server).toEqual({
+      name: "wx",
+      description: repeatedMetadata,
+    });
+
+    await client.close();
+    await handle.close();
+    await gateway.close();
+    await upstream.server.close();
   });
 
   it("invoke_tool runs a locally-registered tool and returns its output as structuredContent", async () => {

--- a/packages/core/src/lib/server.ts
+++ b/packages/core/src/lib/server.ts
@@ -41,6 +41,11 @@ export async function createMcpServer(
 ): Promise<McpServerHandle> {
   const { name, version, transport, upstreamServers, runAuthFlow, skillCatalog } = options;
   const hasSkills = skillCatalog !== undefined && skillCatalog.size() > 0;
+  const searchUpstreamServers = upstreamServers?.map((upstream) =>
+    upstream.description !== undefined && upstream.description === upstream.instructions
+      ? { ...upstream, instructions: undefined }
+      : upstream,
+  );
 
   const server = new Server(
     { name, version },
@@ -62,7 +67,7 @@ export async function createMcpServer(
   const gateway: Record<string, ExecutableTool> = {};
   const skills = hasSkills ? skillCatalog : undefined;
   const searchCapabilities = withRetrievalErrorSchema(
-    searchCapabilitiesTool(catalog, skills, { upstreamServers }),
+    searchCapabilitiesTool(catalog, skills, { upstreamServers: searchUpstreamServers }),
   );
   for (const tool of [searchCapabilities, invokeToolTool(catalog, { onUnauthorized })]) {
     gateway[tool.name] = tool;


### PR DESCRIPTION
## Summary
- omit upstream server instructions from capability-search groups when they exactly equal the description
- preserve distinct descriptions and instructions unchanged
- cover the real gateway fallback and MCP response path with a regression test
- document the behavior in the changelog

## Why
When an upstream has instructions but no configured description, the gateway uses those instructions as the description fallback while retaining the original instructions separately. Capability search then serialized both identical strings into every matching server group.

## Compatibility
Deduplication uses exact string equality only. The response keeps server.description, and any distinct server.instructions value remains unchanged. Underlying gateway metadata, server initialization instructions, and auth state are not mutated.

## Testing
- pnpm typecheck
- pnpm lint
- pnpm test
- pnpm build

Addresses the duplicate-search-metadata report in #43.