### PR TITLE
fix: remove legacy search_tools from the gateway

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this package are documented here. The format is based on 
 
 ## [Unreleased]
 
+### Changed
+- Hid the deprecated `search_tools` alias from MCP `tools/list` discovery so agents see only `search_capabilities`; direct `tools/call` invocation of `search_tools` remains temporarily supported with its legacy tools-only `{ groups }` result.
+
 ## [0.8.1] - 2026-08-19
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@ All notable changes to this package are documented here. The format is based on 
 
 ## [Unreleased]
 
-### Changed
-- Hid the deprecated `search_tools` alias from MCP `tools/list` discovery so agents see only `search_capabilities`; direct `tools/call` invocation of `search_tools` remains temporarily supported with its legacy tools-only `{ groups }` result.
+### Removed
+- Removed the deprecated `search_tools` alias from MCP discovery and call dispatch. Agents now have a single capability-search entry point: `search_capabilities`.
 
 ## [0.8.1] - 2026-08-19
 

--- a/apps/ratel-local/plugin/skills/ratel-improve-tools/SKILL.md
+++ b/apps/ratel-local/plugin/skills/ratel-improve-tools/SKILL.md
@@ -43,9 +43,7 @@ If no logs exist, say that there is no tool usage data yet and suggest enabling/
 6. Look for:
 
 - high-frequency tools that deserve first-class upstreams, aliases, or better descriptions;
-- repeated `search_capabilities` calls that do not lead to useful `invoke_tool`
-  calls (including legacy clients still calling the deprecated `search_tools`
-  alias);
+- repeated `search_capabilities` calls that do not lead to useful `invoke_tool` calls;
 - failed or denied tool calls that indicate missing auth, missing tools, weak schemas, or bad defaults;
 - direct non-Ratel Local tool usage that should be imported into Ratel;
 - similar tools split across upstreams where a curated choice would reduce noise;

--- a/apps/ratel-local/src/cli/cli.test.ts
+++ b/apps/ratel-local/src/cli/cli.test.ts
@@ -7,7 +7,7 @@ import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
 import type { BackupFs, JsonFs, ProjectRegistry } from "@ratel-ai/ratel-local-core";
 import { AUTH_TOOL_ID, nodeFs } from "@ratel-ai/ratel-local-core";
-import { INVOKE_TOOL_ID, SEARCH_CAPABILITIES_ID, SEARCH_TOOLS_ID } from "@ratel-ai/sdk";
+import { INVOKE_TOOL_ID, SEARCH_CAPABILITIES_ID } from "@ratel-ai/sdk";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { runCli } from "./cli.js";
 
@@ -159,7 +159,7 @@ describe("runCli — serve", () => {
     await client.connect(downstreamClientTransport);
     const { tools } = await client.listTools();
     expect(tools.map((t) => t.name).sort()).toEqual(
-      [SEARCH_CAPABILITIES_ID, INVOKE_TOOL_ID, AUTH_TOOL_ID, SEARCH_TOOLS_ID].sort(),
+      [SEARCH_CAPABILITIES_ID, INVOKE_TOOL_ID, AUTH_TOOL_ID].sort(),
     );
 
     const search = await client.callTool({

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -9,7 +9,7 @@ output schema).
 
 | Part | Layer | What it proves |
 |------|-------|----------------|
-| **A** | Gateway (pull) | `ratel-local serve` discovery exposes `search_capabilities` / `invoke_tool` / `get_skill_content` / `auth`, while the deprecated `search_tools` alias remains directly callable; the two reserved buckets mean a matching **skill is never starved by matching tools**; `invoke_tool` round-trips to a real upstream MCP; `get_skill_content` returns the body and a clean `{ error }` (not a protocol crash) for an unknown id. |
+| **A** | Gateway (pull) | `ratel-local serve` exposes `search_capabilities` / `invoke_tool` / `get_skill_content` / `auth`; the two reserved buckets mean a matching **skill is never starved by matching tools**; `invoke_tool` round-trips to a real upstream MCP; `get_skill_content` returns the body and a clean `{ error }` (not a protocol crash) for an unknown id. |
 | **B** | Lifecycle | `skill activate → list → deactivate` links skills into Ratel without moving their native folders, then reverses the operation non-destructively with an accurate manifest. |
 | **C** | Push | The `UserPromptSubmit` preload hook + **real** project-signal detection: the *same* prompt surfaces the React skill in a React repo and the Django skill in a Django repo, and the clear-winner gate stays **silent** when nothing clearly fits. |
 
@@ -24,7 +24,7 @@ dependencies and build the public app first:
 ```bash
 pnpm install --frozen-lockfile
 pnpm build
-bash e2e/run.sh        # → "20 passed, 0 failed"
+bash e2e/run.sh        # → "19 passed, 0 failed"
 ```
 
 The per-bug regressions are also locked into the normal unit suites

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -9,7 +9,7 @@ output schema).
 
 | Part | Layer | What it proves |
 |------|-------|----------------|
-| **A** | Gateway (pull) | `ratel-local serve` exposes `search_capabilities` / deprecated `search_tools` / `invoke_tool` / `get_skill_content` / `auth`; the two reserved buckets mean a matching **skill is never starved by matching tools**; `invoke_tool` round-trips to a real upstream MCP; `get_skill_content` returns the body and a clean `{ error }` (not a protocol crash) for an unknown id. |
+| **A** | Gateway (pull) | `ratel-local serve` discovery exposes `search_capabilities` / `invoke_tool` / `get_skill_content` / `auth`, while the deprecated `search_tools` alias remains directly callable; the two reserved buckets mean a matching **skill is never starved by matching tools**; `invoke_tool` round-trips to a real upstream MCP; `get_skill_content` returns the body and a clean `{ error }` (not a protocol crash) for an unknown id. |
 | **B** | Lifecycle | `skill activate → list → deactivate` links skills into Ratel without moving their native folders, then reverses the operation non-destructively with an accurate manifest. |
 | **C** | Push | The `UserPromptSubmit` preload hook + **real** project-signal detection: the *same* prompt surfaces the React skill in a React repo and the Django skill in a Django repo, and the clear-winner gate stays **silent** when nothing clearly fits. |
 
@@ -24,7 +24,7 @@ dependencies and build the public app first:
 ```bash
 pnpm install --frozen-lockfile
 pnpm build
-bash e2e/run.sh        # → "19 passed, 0 failed"
+bash e2e/run.sh        # → "20 passed, 0 failed"
 ```
 
 The per-bug regressions are also locked into the normal unit suites

--- a/e2e/driver.mjs
+++ b/e2e/driver.mjs
@@ -41,7 +41,7 @@ await client.connect(transport);
 const { tools } = await client.listTools();
 const names = tools.map((t) => t.name).sort();
 check(
-  "A1a surface is exactly [auth, get_skill_content, invoke_tool, search_capabilities]",
+  "A1  surface is exactly [auth, get_skill_content, invoke_tool, search_capabilities]",
   JSON.stringify(names) ===
     JSON.stringify([
       "auth",
@@ -50,18 +50,6 @@ check(
       "search_capabilities",
     ]),
   JSON.stringify(names),
-);
-
-// The deprecated alias stays directly callable for clients that pinned its name.
-const legacySearchRes = await client.callTool({
-  name: "search_tools",
-  arguments: { query: "supabase" },
-});
-const legacySearch = JSON.parse(legacySearchRes.content[0].text);
-check(
-  "A1b hidden search_tools alias remains directly callable",
-  Array.isArray(legacySearch.groups) && legacySearch.groups.length > 0,
-  JSON.stringify(legacySearch).slice(0, 140),
 );
 
 // A2 — search returns BOTH buckets; the supabase SKILL survives 4 matching TOOLS.

--- a/e2e/driver.mjs
+++ b/e2e/driver.mjs
@@ -37,20 +37,31 @@ const transport = new StdioClientTransport({
 const client = new Client({ name: "e2e", version: "0.0.0" });
 await client.connect(transport);
 
-// A1 — the gateway surface includes four gateway tools (one deprecated) + auth.
+// A1 — discovery exposes only the current gateway tools + auth.
 const { tools } = await client.listTools();
 const names = tools.map((t) => t.name).sort();
 check(
-  "A1  surface is exactly [auth, get_skill_content, invoke_tool, search_capabilities, search_tools]",
+  "A1a surface is exactly [auth, get_skill_content, invoke_tool, search_capabilities]",
   JSON.stringify(names) ===
     JSON.stringify([
       "auth",
       "get_skill_content",
       "invoke_tool",
       "search_capabilities",
-      "search_tools",
     ]),
   JSON.stringify(names),
+);
+
+// The deprecated alias stays directly callable for clients that pinned its name.
+const legacySearchRes = await client.callTool({
+  name: "search_tools",
+  arguments: { query: "supabase" },
+});
+const legacySearch = JSON.parse(legacySearchRes.content[0].text);
+check(
+  "A1b hidden search_tools alias remains directly callable",
+  Array.isArray(legacySearch.groups) && legacySearch.groups.length > 0,
+  JSON.stringify(legacySearch).slice(0, 140),
 );
 
 // A2 — search returns BOTH buckets; the supabase SKILL survives 4 matching TOOLS.

--- a/e2e/run.sh
+++ b/e2e/run.sh
@@ -12,7 +12,7 @@
 # This is a LOCAL/manual check, not a CI job. Prereqs:
 #   pnpm install --frozen-lockfile
 #   pnpm build
-#   bash e2e/run.sh          # → "19 passed, 0 failed"
+#   bash e2e/run.sh          # → "20 passed, 0 failed"
 set -u
 RMCP="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 BIN="$RMCP/apps/ratel-local/dist/bin.js"
@@ -32,7 +32,7 @@ skill_md "$HGW/.ratel/skills" supabase-auth "Set up Supabase authentication: RLS
 skill_md "$HGW/.ratel/skills" frontend-react "React/Next UI component patterns and layout." "dashboard,page,form" "react,next" "BODY-MARKER-FRONTEND"
 printf '{"mcpServers":{"up":{"type":"stdio","command":"node","args":["%s/e2e/upstream.mjs"]}}}' "$RMCP" > "$HGW/config.json"
 E2E_HOME="$HGW" E2E_BIN="$BIN" E2E_CONFIG="$HGW/config.json" node "$RMCP/e2e/driver.mjs"
-[ $? -eq 0 ] && PASS=$((PASS+6)) || FAIL=$((FAIL+1))   # driver prints + returns its own 6 checks
+[ $? -eq 0 ] && PASS=$((PASS+7)) || FAIL=$((FAIL+1))   # driver prints + returns its own 7 checks
 rm -rf "$HGW"
 
 echo ""

--- a/e2e/run.sh
+++ b/e2e/run.sh
@@ -12,7 +12,7 @@
 # This is a LOCAL/manual check, not a CI job. Prereqs:
 #   pnpm install --frozen-lockfile
 #   pnpm build
-#   bash e2e/run.sh          # → "20 passed, 0 failed"
+#   bash e2e/run.sh          # → "19 passed, 0 failed"
 set -u
 RMCP="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 BIN="$RMCP/apps/ratel-local/dist/bin.js"
@@ -32,7 +32,7 @@ skill_md "$HGW/.ratel/skills" supabase-auth "Set up Supabase authentication: RLS
 skill_md "$HGW/.ratel/skills" frontend-react "React/Next UI component patterns and layout." "dashboard,page,form" "react,next" "BODY-MARKER-FRONTEND"
 printf '{"mcpServers":{"up":{"type":"stdio","command":"node","args":["%s/e2e/upstream.mjs"]}}}' "$RMCP" > "$HGW/config.json"
 E2E_HOME="$HGW" E2E_BIN="$BIN" E2E_CONFIG="$HGW/config.json" node "$RMCP/e2e/driver.mjs"
-[ $? -eq 0 ] && PASS=$((PASS+7)) || FAIL=$((FAIL+1))   # driver prints + returns its own 7 checks
+[ $? -eq 0 ] && PASS=$((PASS+6)) || FAIL=$((FAIL+1))   # driver prints + returns its own 6 checks
 rm -rf "$HGW"
 
 echo ""

--- a/packages/core/src/lib/server.test.ts
+++ b/packages/core/src/lib/server.test.ts
@@ -162,18 +162,15 @@ describe("createMcpServer", () => {
     await handle.close();
   });
 
-  it("exposes search_capabilities, invoke_tool, and the deprecated search_tools alias via tools/list", async () => {
+  it("hides the deprecated search_tools alias from tools/list", async () => {
     const catalog = new ToolCatalog();
     await catalog.register(localTool("echo", "Echo a message back to the caller.", (a) => a));
 
     const { client, handle } = await buildClientAgainst(catalog);
     const { tools } = await client.listTools();
     expect(tools.map((t) => t.name).sort()).toEqual(
-      [SEARCH_CAPABILITIES_ID, SEARCH_TOOLS_ID, INVOKE_TOOL_ID].sort(),
+      [SEARCH_CAPABILITIES_ID, INVOKE_TOOL_ID].sort(),
     );
-    // The compat alias is advertised but flagged so new clients prefer search_capabilities.
-    const legacy = tools.find((t) => t.name === SEARCH_TOOLS_ID);
-    expect(legacy?.description).toContain("Deprecated");
 
     await client.close();
     await handle.close();
@@ -648,7 +645,7 @@ describe("createMcpServer skills", () => {
     body: "# API Design\n\nUse nouns for resources.",
   };
 
-  it("registers get_skill_content (4 tools incl. the search_tools alias) when the skill catalog is non-empty", async () => {
+  it("lists get_skill_content when the skill catalog is non-empty", async () => {
     const [serverTransport, clientTransport] = InMemoryTransport.createLinkedPair();
     const handle = await createMcpServer(new ToolCatalog(), {
       name: "ratel-test",
@@ -661,14 +658,14 @@ describe("createMcpServer skills", () => {
 
     const { tools } = await client.listTools();
     expect(tools.map((t) => t.name).sort()).toEqual(
-      [GET_SKILL_CONTENT_ID, INVOKE_TOOL_ID, SEARCH_CAPABILITIES_ID, SEARCH_TOOLS_ID].sort(),
+      [GET_SKILL_CONTENT_ID, INVOKE_TOOL_ID, SEARCH_CAPABILITIES_ID].sort(),
     );
 
     await client.close();
     await handle.close();
   });
 
-  it("omits get_skill_content when the skill catalog is empty (3 tools incl. the search_tools alias)", async () => {
+  it("omits get_skill_content when the skill catalog is empty", async () => {
     const [serverTransport, clientTransport] = InMemoryTransport.createLinkedPair();
     const handle = await createMcpServer(new ToolCatalog(), {
       name: "ratel-test",
@@ -681,7 +678,7 @@ describe("createMcpServer skills", () => {
 
     const { tools } = await client.listTools();
     expect(tools.map((t) => t.name).sort()).toEqual(
-      [SEARCH_CAPABILITIES_ID, INVOKE_TOOL_ID, SEARCH_TOOLS_ID].sort(),
+      [SEARCH_CAPABILITIES_ID, INVOKE_TOOL_ID].sort(),
     );
 
     await client.close();
@@ -750,15 +747,14 @@ describe("createMcpServer skills", () => {
       });
 
       const listed = await client.listTools();
-      for (const name of [SEARCH_CAPABILITIES_ID, SEARCH_TOOLS_ID]) {
-        const outputSchema = listed.tools.find((tool) => tool.name === name)?.outputSchema as {
-          type?: string;
-          oneOf?: Array<{ required?: string[] }>;
-        };
-        expect(outputSchema.type).toBe("object");
-        expect(outputSchema.oneOf).toHaveLength(2);
-        expect(outputSchema.oneOf?.[1]?.required).toEqual(["error", "code", "message", "isError"]);
-      }
+      const outputSchema = listed.tools.find((tool) => tool.name === SEARCH_CAPABILITIES_ID)
+        ?.outputSchema as {
+        type?: string;
+        oneOf?: Array<{ required?: string[] }>;
+      };
+      expect(outputSchema.type).toBe("object");
+      expect(outputSchema.oneOf).toHaveLength(2);
+      expect(outputSchema.oneOf?.[1]?.required).toEqual(["error", "code", "message", "isError"]);
 
       const legacyResult = await client.callTool({
         name: SEARCH_TOOLS_ID,

--- a/packages/core/src/lib/server.test.ts
+++ b/packages/core/src/lib/server.test.ts
@@ -12,7 +12,6 @@ import {
   INVOKE_TOOL_ID,
   registerMcpServer,
   SEARCH_CAPABILITIES_ID,
-  SEARCH_TOOLS_ID,
   type Skill,
   SkillCatalog,
   ToolCatalog,
@@ -162,7 +161,7 @@ describe("createMcpServer", () => {
     await handle.close();
   });
 
-  it("hides the deprecated search_tools alias from tools/list", async () => {
+  it("exposes only search_capabilities and invoke_tool for capability discovery", async () => {
     const catalog = new ToolCatalog();
     await catalog.register(localTool("echo", "Echo a message back to the caller.", (a) => a));
 
@@ -211,37 +210,15 @@ describe("createMcpServer", () => {
     }
   });
 
-  it("search_tools (deprecated) still returns the pre-0.2.0 tools-only {groups} shape", async () => {
-    const catalog = new ToolCatalog();
-    await catalog.register(
-      localTool("wx__weather", "Get the current weather forecast for a city.", () => ({})),
-    );
+  it("rejects calls to the removed search_tools alias", async () => {
+    const { client, handle } = await buildClientAgainst(new ToolCatalog());
 
-    const [serverTransport, clientTransport] = InMemoryTransport.createLinkedPair();
-    const handle = await createMcpServer(catalog, {
-      name: "ratel-test",
-      version: "0.0.0",
-      transport: serverTransport,
-      upstreamServers: [{ name: "wx", toolCount: 1 }],
-    });
-    const client = new Client({ name: "test-client", version: "0.0.0" });
-    await client.connect(clientTransport);
-
-    const result = await client.callTool({
-      name: SEARCH_TOOLS_ID,
-      arguments: { query: "weather forecast" },
-    });
-
-    // Old shape: a top-level `groups` array, NOT the two-bucket { tools, skills }.
-    const structured = result.structuredContent as {
-      groups: Array<{ server: { name: string }; hits: Array<{ toolId: string }> }>;
-      tools?: unknown;
-      skills?: unknown;
-    };
-    expect(structured.groups[0].server.name).toBe("wx");
-    expect(structured.groups[0].hits[0].toolId).toBe("wx__weather");
-    expect(structured.tools).toBeUndefined();
-    expect(structured.skills).toBeUndefined();
+    await expect(
+      client.callTool({
+        name: "search_tools",
+        arguments: { query: "weather forecast" },
+      }),
+    ).rejects.toThrow(/unknown gateway tool: search_tools/);
 
     await client.close();
     await handle.close();
@@ -755,13 +732,6 @@ describe("createMcpServer skills", () => {
       expect(outputSchema.type).toBe("object");
       expect(outputSchema.oneOf).toHaveLength(2);
       expect(outputSchema.oneOf?.[1]?.required).toEqual(["error", "code", "message", "isError"]);
-
-      const legacyResult = await client.callTool({
-        name: SEARCH_TOOLS_ID,
-        arguments: { query: "weather forecast" },
-      });
-      expect(legacyResult.isError).toBe(true);
-      expect(legacyResult.structuredContent).toEqual(result.structuredContent);
     } finally {
       search.mockRestore();
       await client.close();

--- a/packages/core/src/lib/server.ts
+++ b/packages/core/src/lib/server.ts
@@ -9,10 +9,8 @@ import {
   invokeToolTool,
   type JSONSchema7,
   SEARCH_CAPABILITIES_ID,
-  SEARCH_TOOLS_ID,
   type SkillCatalog,
   searchCapabilitiesTool,
-  searchToolsTool,
   type ToolCatalog,
   type UpstreamServerInfo,
 } from "@ratel-ai/sdk";
@@ -69,11 +67,6 @@ export async function createMcpServer(
   for (const tool of [searchCapabilities, invokeToolTool(catalog, { onUnauthorized })]) {
     gateway[tool.name] = tool;
   }
-  // Backward-compat: keep the pre-0.2.0 `search_tools` alias callable for MCP
-  // clients that pinned its name, but omit it from tools/list below so new
-  // clients discover only `search_capabilities`.
-  const legacySearch = withRetrievalErrorSchema(searchToolsTool(catalog, { upstreamServers }));
-  gateway[legacySearch.name] = legacySearch;
   if (skills) {
     const t = getSkillContentTool(skills);
     gateway[t.name] = t;
@@ -84,16 +77,14 @@ export async function createMcpServer(
   }
 
   server.setRequestHandler(ListToolsRequestSchema, async () => ({
-    tools: Object.values(gateway)
-      .filter((tool) => tool.name !== SEARCH_TOOLS_ID)
-      .map((tool) => ({
-        name: tool.name,
-        description: tool.description,
-        inputSchema: tool.inputSchema as { [k: string]: unknown; type: "object" },
-        ...(isObjectSchema(tool.outputSchema)
-          ? { outputSchema: tool.outputSchema as { [k: string]: unknown; type: "object" } }
-          : {}),
-      })),
+    tools: Object.values(gateway).map((tool) => ({
+      name: tool.name,
+      description: tool.description,
+      inputSchema: tool.inputSchema as { [k: string]: unknown; type: "object" },
+      ...(isObjectSchema(tool.outputSchema)
+        ? { outputSchema: tool.outputSchema as { [k: string]: unknown; type: "object" } }
+        : {}),
+    })),
   }));
 
   server.setRequestHandler(CallToolRequestSchema, async (req) => {
@@ -106,10 +97,7 @@ export async function createMcpServer(
     try {
       out = await tool.execute(args);
     } catch (error) {
-      if (
-        !(error instanceof EmbedderError) ||
-        (req.params.name !== SEARCH_CAPABILITIES_ID && req.params.name !== SEARCH_TOOLS_ID)
-      ) {
+      if (!(error instanceof EmbedderError) || req.params.name !== SEARCH_CAPABILITIES_ID) {
         throw error;
       }
       out = {

--- a/packages/core/src/lib/server.ts
+++ b/packages/core/src/lib/server.ts
@@ -69,15 +69,11 @@ export async function createMcpServer(
   for (const tool of [searchCapabilities, invokeToolTool(catalog, { onUnauthorized })]) {
     gateway[tool.name] = tool;
   }
-  // Backward-compat: keep advertising the pre-0.2.0 `search_tools` (deprecated
-  // alias, tools-only `{ groups }` result) so MCP clients that pinned its name
-  // don't break on upgrade. New clients should use `search_capabilities` — which
-  // also returns skills — so the description steers them there.
+  // Backward-compat: keep the pre-0.2.0 `search_tools` alias callable for MCP
+  // clients that pinned its name, but omit it from tools/list below so new
+  // clients discover only `search_capabilities`.
   const legacySearch = withRetrievalErrorSchema(searchToolsTool(catalog, { upstreamServers }));
-  gateway[legacySearch.name] = {
-    ...legacySearch,
-    description: `[Deprecated: prefer search_capabilities, which also returns skills.] ${legacySearch.description}`,
-  };
+  gateway[legacySearch.name] = legacySearch;
   if (skills) {
     const t = getSkillContentTool(skills);
     gateway[t.name] = t;
@@ -88,14 +84,16 @@ export async function createMcpServer(
   }
 
   server.setRequestHandler(ListToolsRequestSchema, async () => ({
-    tools: Object.values(gateway).map((tool) => ({
-      name: tool.name,
-      description: tool.description,
-      inputSchema: tool.inputSchema as { [k: string]: unknown; type: "object" },
-      ...(isObjectSchema(tool.outputSchema)
-        ? { outputSchema: tool.outputSchema as { [k: string]: unknown; type: "object" } }
-        : {}),
-    })),
+    tools: Object.values(gateway)
+      .filter((tool) => tool.name !== SEARCH_TOOLS_ID)
+      .map((tool) => ({
+        name: tool.name,
+        description: tool.description,
+        inputSchema: tool.inputSchema as { [k: string]: unknown; type: "object" },
+        ...(isObjectSchema(tool.outputSchema)
+          ? { outputSchema: tool.outputSchema as { [k: string]: unknown; type: "object" } }
+          : {}),
+      })),
   }));
 
   server.setRequestHandler(CallToolRequestSchema, async (req) => {


### PR DESCRIPTION
## Summary

- remove deprecated `search_tools` from MCP `tools/list` discovery
- remove its `tools/call` registration and compatibility-only error handling
- leave `search_capabilities` as the single capability-search entry point
- update protocol, CLI, changelog, plugin guidance, and real-process gateway coverage

## Compatibility

This removes direct `search_tools` invocation as well as discovery. Legacy clients must migrate to `search_capabilities`; there is no hidden compatibility endpoint.

## Verification

- regression coverage confirms `search_tools` is absent from `tools/list` and rejected by `tools/call`
- `pnpm --filter @ratel-ai/ratel-local-core exec vitest run src/lib/server.test.ts`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test` (1,114 tests passed)
- `pnpm build`
- real-process gateway E2E: 6/6 gateway checks passed

`bash e2e/run.sh` continues past the gateway checks into a stale lifecycle section that calls the already-removed `skill activate/deactivate` commands; that unrelated section reports 5 failures.