### PR TITLE
feat: daemon restart feature flag config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this package are documented here. The format is based on 
 
 ## [Unreleased]
 
+### Changed
+- Made `daemon restart` rewrite the Cloud telemetry feature-flag environment in
+  an installed launchd or systemd service only when `RATEL_FEATURE_CLOUD_TELEMETRY`
+  is present in the invoking environment; an absent variable preserves the
+  installed service, and `=0` disables by removing the persisted flag.
+
 ### Removed
 - Removed the deprecated `search_tools` alias from MCP discovery and call dispatch. Agents now have a single capability-search entry point: `search_capabilities`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,12 @@ All notable changes to this package are documented here. The format is based on 
 ## [Unreleased]
 
 ### Changed
-- Made `daemon restart` rewrite the Cloud telemetry feature-flag environment in
-  an installed launchd or systemd service only when `RATEL_FEATURE_CLOUD_TELEMETRY`
-  is present in the invoking environment; an absent variable preserves the
-  installed service, and `=0` disables by removing the persisted flag.
+- Made `daemon restart` reconfigure the Cloud telemetry feature flag in an
+  installed launchd or systemd service when `RATEL_FEATURE_CLOUD_TELEMETRY` is
+  present in the invoking environment (`=1` enables, any other value disables,
+  absent preserves). Restart now waits for the stopped daemon to release its
+  port, and confirms the restarted daemon adopted the change through the new
+  `cloudTelemetry` field on `/api/daemon/status`.
 
 ### Removed
 - Removed the deprecated `search_tools` alias from MCP discovery and call dispatch. Agents now have a single capability-search entry point: `search_capabilities`.

--- a/README.md
+++ b/README.md
@@ -184,20 +184,23 @@ ship dark. Enable the daemon-wide feature explicitly before configuring an API
 key or native exporter:
 
 ```bash
-# New installation or interactive foreground setup
+# New installation
 RATEL_FEATURE_CLOUD_TELEMETRY=1 ratel-local setup
 
-# Existing background service
-ratel-local daemon uninstall
-RATEL_FEATURE_CLOUD_TELEMETRY=1 ratel-local daemon install
+# Existing installed daemon
+RATEL_FEATURE_CLOUD_TELEMETRY=1 ratel-local daemon restart
+
+# Disable
+RATEL_FEATURE_CLOUD_TELEMETRY=0 ratel-local daemon restart
 
 ratel-local traces status
 ```
 
-Only the exact value `1` enables the feature. Setup persists the enabled flag in
-new macOS launchd and Linux systemd service definitions. See the [Cloud OTLP
-relay and native exporter setup contract](docs/cloud-otlp-relay.md) for privacy
-levels, precedence, failure behavior, and rollback instructions.
+Only the exact value `1` enables the feature, and the setting is persisted into
+the installed launchd or systemd service. Omitting the variable leaves an
+installed daemon unchanged. See the [Cloud OTLP relay and native exporter setup
+contract](docs/cloud-otlp-relay.md) for privacy levels, precedence, failure
+behavior, and rollback instructions.
 
 ### Verify capability search
 

--- a/README.md
+++ b/README.md
@@ -196,9 +196,9 @@ RATEL_FEATURE_CLOUD_TELEMETRY=0 ratel-local daemon restart
 ratel-local traces status
 ```
 
-Only the exact value `1` enables the feature, and the setting is persisted into
-the installed launchd or systemd service. Omitting the variable leaves an
-installed daemon unchanged. See the [Cloud OTLP relay and native exporter setup
+Only the exact value `1` enables the feature; any other value disables it. The
+setting is persisted into the installed launchd or systemd service, and omitting
+the variable leaves an installed daemon unchanged. See the [Cloud OTLP relay and native exporter setup
 contract](docs/cloud-otlp-relay.md) for privacy levels, precedence, failure
 behavior, and rollback instructions.
 

--- a/apps/ratel-local/plugin/skills/ratel-local/SKILL.md
+++ b/apps/ratel-local/plugin/skills/ratel-local/SKILL.md
@@ -181,19 +181,24 @@ editing Claude Code or Codex configuration:
 Cloud telemetry ships off by default. Before offering setup or changing an
 exporter, check `ratel-local traces status`. If the feature is off, explain that
 the user must start a foreground daemon with
-`RATEL_FEATURE_CLOUD_TELEMETRY=1`, or reinstall a background service with that
-environment persisted. Merely exporting the flag before `daemon restart` does
-not rewrite an installed service. Do not treat saved Cloud credentials as an
-enablement signal.
+`RATEL_FEATURE_CLOUD_TELEMETRY=1`, or restart the background service with that
+environment present so the installed service definition is updated. Do not treat
+saved Cloud credentials as an enablement signal. `daemon start` does not rewrite
+an installed service.
 
 ```bash
 # Enable an existing background service
+RATEL_FEATURE_CLOUD_TELEMETRY=1 ratel-local daemon restart
+
+# Keep enabled (flag absent)
+ratel-local daemon restart
+
+# Disable
+RATEL_FEATURE_CLOUD_TELEMETRY=0 ratel-local daemon restart
+
+# Fallback: reinstall with the environment persisted
 ratel-local daemon uninstall
 RATEL_FEATURE_CLOUD_TELEMETRY=1 ratel-local daemon install
-
-# Roll back by reinstalling without the environment assignment
-ratel-local daemon uninstall
-ratel-local daemon install
 ```
 
 These lifecycle commands preserve Ratel configuration and saved Cloud settings.

--- a/apps/ratel-local/src/cli/handlers/daemon.test.ts
+++ b/apps/ratel-local/src/cli/handlers/daemon.test.ts
@@ -1012,6 +1012,18 @@ describe("runDaemon", () => {
     expect(fs.files.get(paths.plist)).toBe(original);
   });
 
+  it("refuses to enable Cloud telemetry in an unrecognised service file", () => {
+    expect(() => applyCloudTelemetryToLaunchAgentPlist("<plist />", true)).toThrow(
+      /not a Ratel Local unit/,
+    );
+    expect(() => applyCloudTelemetryToSystemdUserService("[Service]\n", true)).toThrow(
+      /not a Ratel Local unit/,
+    );
+    // Disabling stays a no-op there: there is no Ratel route to remove.
+    expect(applyCloudTelemetryToLaunchAgentPlist("<plist />", false)).toBe("<plist />");
+    expect(applyCloudTelemetryToSystemdUserService("[Service]\n", false)).toBe("[Service]\n");
+  });
+
   // Without `pathEnv` the flag is the only environment entry, so enabling has to
   // create the dict from scratch and disabling has to remove it again. That is
   // the shape an install performs when PATH is unset in its environment.

--- a/apps/ratel-local/src/cli/handlers/daemon.test.ts
+++ b/apps/ratel-local/src/cli/handlers/daemon.test.ts
@@ -28,6 +28,7 @@ import {
   inspectDaemonService,
   runDaemon,
   SYSTEMD_SERVICE,
+  waitForDaemonStopped,
 } from "./daemon.js";
 import { createTestPreparedChanges } from "./test-prepared-changes.js";
 import type { HandlerCtx } from "./types.js";
@@ -1011,36 +1012,44 @@ describe("runDaemon", () => {
     expect(fs.files.get(paths.plist)).toBe(original);
   });
 
-  it("round-trips Cloud telemetry flag edits against generated service files", () => {
-    const pathEnv = "/opt/node/bin:/usr/bin:/bin";
-    const base = {
-      executablePath: "/opt/bin/ratel-local",
-      homeDir: HOME,
-      port: DEFAULT_DAEMON_PORT,
-      pathEnv,
-    };
-    const disabledPlist = createLaunchAgentPlist({
-      ...base,
-      featureFlags: { cloudTelemetry: false },
-    });
-    const enabledPlist = createLaunchAgentPlist({
-      ...base,
-      featureFlags: { cloudTelemetry: true },
-    });
-    expect(applyCloudTelemetryToLaunchAgentPlist(disabledPlist, true)).toBe(enabledPlist);
-    expect(applyCloudTelemetryToLaunchAgentPlist(enabledPlist, false)).toBe(disabledPlist);
+  // Without `pathEnv` the flag is the only environment entry, so enabling has to
+  // create the dict from scratch and disabling has to remove it again. That is
+  // the shape an install performs when PATH is unset in its environment.
+  for (const pathEnv of ["/opt/node/bin:/usr/bin:/bin", undefined]) {
+    it(`round-trips Cloud telemetry flag edits against generated service files (pathEnv: ${pathEnv ? "set" : "unset"})`, () => {
+      const base = {
+        executablePath: "/opt/bin/ratel-local",
+        homeDir: HOME,
+        port: DEFAULT_DAEMON_PORT,
+        ...(pathEnv ? { pathEnv } : {}),
+      };
+      const disabledPlist = createLaunchAgentPlist({
+        ...base,
+        featureFlags: { cloudTelemetry: false },
+      });
+      const enabledPlist = createLaunchAgentPlist({
+        ...base,
+        featureFlags: { cloudTelemetry: true },
+      });
+      expect(applyCloudTelemetryToLaunchAgentPlist(disabledPlist, true)).toBe(enabledPlist);
+      expect(applyCloudTelemetryToLaunchAgentPlist(enabledPlist, false)).toBe(disabledPlist);
+      expect(applyCloudTelemetryToLaunchAgentPlist(enabledPlist, true)).toBe(enabledPlist);
+      expect(applyCloudTelemetryToLaunchAgentPlist(disabledPlist, false)).toBe(disabledPlist);
 
-    const disabledUnit = createSystemdUserService({
-      ...base,
-      featureFlags: { cloudTelemetry: false },
+      const disabledUnit = createSystemdUserService({
+        ...base,
+        featureFlags: { cloudTelemetry: false },
+      });
+      const enabledUnit = createSystemdUserService({
+        ...base,
+        featureFlags: { cloudTelemetry: true },
+      });
+      expect(applyCloudTelemetryToSystemdUserService(disabledUnit, true)).toBe(enabledUnit);
+      expect(applyCloudTelemetryToSystemdUserService(enabledUnit, false)).toBe(disabledUnit);
+      expect(applyCloudTelemetryToSystemdUserService(enabledUnit, true)).toBe(enabledUnit);
+      expect(applyCloudTelemetryToSystemdUserService(disabledUnit, false)).toBe(disabledUnit);
     });
-    const enabledUnit = createSystemdUserService({
-      ...base,
-      featureFlags: { cloudTelemetry: true },
-    });
-    expect(applyCloudTelemetryToSystemdUserService(disabledUnit, true)).toBe(enabledUnit);
-    expect(applyCloudTelemetryToSystemdUserService(enabledUnit, false)).toBe(disabledUnit);
-  });
+  }
 
   for (const platform of ["darwin", "linux"] as const) {
     it(`enables Cloud telemetry on ${platform} restart when the flag is explicitly set`, async () => {
@@ -1177,6 +1186,38 @@ describe("runDaemon", () => {
     });
   }
 
+  it("skips the rewrite when the explicit flag already matches the service", async () => {
+    const fs = new MemFs();
+    const paths = daemonPaths(HOME);
+    const original = createSystemdUserService({
+      executablePath: "/opt/bin/ratel-local",
+      homeDir: HOME,
+      port: DEFAULT_DAEMON_PORT,
+      featureFlags: { cloudTelemetry: true },
+    });
+    fs.files.set(paths.systemdService, original);
+    const commands: Array<{ command: string; args: string[] }> = [];
+
+    await runDaemon(
+      daemonArgs({ verb: "restart", flags: { telemetry: "off", open: false } }),
+      makeCtx(fs),
+      { processEnv: { [CLOUD_TELEMETRY_FEATURE_ENV]: "1" } },
+      () => {},
+      {
+        platform: "linux",
+        commandRunner: async (command, args) => {
+          commands.push({ command, args });
+          return { stdout: "", stderr: "" };
+        },
+        probe: offlineThenHealthyProbe(),
+        lifecycleProgress: false,
+      },
+    );
+
+    expect(fs.files.get(paths.systemdService)).toBe(original);
+    expect(commands.some((entry) => entry.args.includes("daemon-reload"))).toBe(false);
+  });
+
   it("keeps Linux restart visibly active without rewriting the service", async () => {
     const fs = new MemFs();
     const paths = daemonPaths(HOME);
@@ -1271,6 +1312,33 @@ describe("runDaemon", () => {
         lifecycleProgress: false,
       },
     );
+
+  it("fails when the stopped daemon never releases its port", async () => {
+    // The silent-success bug this guards against: a daemon that keeps answering
+    // still holds the pre-rewrite service definition.
+    await expect(
+      waitForDaemonStopped(DEFAULT_DAEMON_PORT, async () => ({ ok: true }), 300),
+    ).rejects.toThrow(/did not stop; restart cannot apply service changes/);
+  });
+
+  it("notes, but does not fail, a restart whose daemon stops answering", async () => {
+    const fs = new MemFs();
+    fs.files.set(daemonPaths(HOME).plist, installedPlist());
+    const logs: string[] = [];
+    let calls = 0;
+
+    await restartWithProbe(
+      fs,
+      async () => {
+        calls += 1;
+        // Down for the stop check, up for waitForDaemon, gone again by verification.
+        return calls === 2 ? { ok: true } : { ok: false, error: "connection refused" };
+      },
+      logs,
+    );
+
+    expect(logs.some((message) => message.includes("the daemon did not answer"))).toBe(true);
+  });
 
   it("accepts a restart whose daemon reports the requested Cloud telemetry state", async () => {
     const fs = new MemFs();

--- a/apps/ratel-local/src/cli/handlers/daemon.test.ts
+++ b/apps/ratel-local/src/cli/handlers/daemon.test.ts
@@ -16,6 +16,8 @@ import { CLOUD_TELEMETRY_FEATURE_ENV } from "../../feature-flags.js";
 import type { ParsedArgs } from "../args.js";
 import { silentPromptAdapter } from "../prompts.js";
 import {
+  applyCloudTelemetryToLaunchAgentPlist,
+  applyCloudTelemetryToSystemdUserService,
   createLaunchAgentPlist,
   createSystemdUserService,
   DAEMON_INSTALL_PATH_ENV,
@@ -972,14 +974,12 @@ describe("runDaemon", () => {
   it("keeps restart visibly active with friendly lifecycle copy", async () => {
     const fs = new MemFs();
     const paths = daemonPaths(HOME);
-    fs.files.set(
-      paths.plist,
-      createLaunchAgentPlist({
-        executablePath: "/opt/bin/ratel-local",
-        homeDir: HOME,
-        port: DEFAULT_DAEMON_PORT,
-      }),
-    );
+    const original = createLaunchAgentPlist({
+      executablePath: "/opt/bin/ratel-local",
+      homeDir: HOME,
+      port: DEFAULT_DAEMON_PORT,
+    });
+    fs.files.set(paths.plist, original);
     const progress: string[] = [];
     const logs: string[] = [];
     const ctx = makeCtx(fs);
@@ -992,7 +992,7 @@ describe("runDaemon", () => {
     await runDaemon(
       daemonArgs({ verb: "restart", flags: { telemetry: "off", open: false } }),
       ctx,
-      {},
+      { processEnv: {} },
       (message) => logs.push(message),
       {
         platform: "darwin",
@@ -1008,7 +1008,362 @@ describe("runDaemon", () => {
       "stop:Ratel Local is ready",
     ]);
     expect(logs).toEqual([]);
+    expect(fs.files.get(paths.plist)).toBe(original);
   });
+
+  it("round-trips Cloud telemetry flag edits against generated service files", () => {
+    const pathEnv = "/opt/node/bin:/usr/bin:/bin";
+    const base = {
+      executablePath: "/opt/bin/ratel-local",
+      homeDir: HOME,
+      port: DEFAULT_DAEMON_PORT,
+      pathEnv,
+    };
+    const disabledPlist = createLaunchAgentPlist({
+      ...base,
+      featureFlags: { cloudTelemetry: false },
+    });
+    const enabledPlist = createLaunchAgentPlist({
+      ...base,
+      featureFlags: { cloudTelemetry: true },
+    });
+    expect(applyCloudTelemetryToLaunchAgentPlist(disabledPlist, true)).toBe(enabledPlist);
+    expect(applyCloudTelemetryToLaunchAgentPlist(enabledPlist, false)).toBe(disabledPlist);
+
+    const disabledUnit = createSystemdUserService({
+      ...base,
+      featureFlags: { cloudTelemetry: false },
+    });
+    const enabledUnit = createSystemdUserService({
+      ...base,
+      featureFlags: { cloudTelemetry: true },
+    });
+    expect(applyCloudTelemetryToSystemdUserService(disabledUnit, true)).toBe(enabledUnit);
+    expect(applyCloudTelemetryToSystemdUserService(enabledUnit, false)).toBe(disabledUnit);
+  });
+
+  for (const platform of ["darwin", "linux"] as const) {
+    it(`enables Cloud telemetry on ${platform} restart when the flag is explicitly set`, async () => {
+      const fs = new MemFs();
+      const paths = daemonPaths(HOME);
+      const pathEnv = "/opt/node/bin:/usr/bin:/bin";
+      const servicePath = platform === "linux" ? paths.systemdService : paths.plist;
+      const input = {
+        executablePath: "/opt/bin/ratel-local",
+        homeDir: HOME,
+        port: DEFAULT_DAEMON_PORT,
+        pathEnv,
+        featureFlags: { cloudTelemetry: false },
+      };
+      fs.files.set(
+        servicePath,
+        platform === "linux" ? createSystemdUserService(input) : createLaunchAgentPlist(input),
+      );
+      const commands: Array<{ command: string; args: string[] }> = [];
+
+      await runDaemon(
+        daemonArgs({ verb: "restart", flags: { telemetry: "off", open: false } }),
+        makeCtx(fs),
+        { processEnv: { [CLOUD_TELEMETRY_FEATURE_ENV]: "1" } },
+        () => {},
+        {
+          platform,
+          getUid: () => 501,
+          commandRunner: async (command, args) => {
+            commands.push({ command, args });
+            return { stdout: "", stderr: "" };
+          },
+          probe: offlineThenHealthyProbe(),
+          lifecycleProgress: false,
+        },
+      );
+
+      const next = fs.files.get(servicePath) ?? "";
+      expect(next).toContain(CLOUD_TELEMETRY_FEATURE_ENV);
+      expect(next).toContain(pathEnv);
+      if (platform === "linux") {
+        expect(commands).toEqual([
+          { command: "systemctl", args: ["--user", "daemon-reload"] },
+          { command: "systemctl", args: ["--user", "stop", SYSTEMD_SERVICE] },
+          { command: "systemctl", args: ["--user", "start", SYSTEMD_SERVICE] },
+        ]);
+      } else {
+        expect(commands).toEqual([
+          { command: "launchctl", args: ["bootout", "gui/501", paths.plist] },
+          { command: "launchctl", args: ["bootstrap", "gui/501", paths.plist] },
+          { command: "launchctl", args: ["kickstart", "-k", "gui/501/ai.ratel.local.daemon"] },
+        ]);
+      }
+    });
+
+    it(`preserves Cloud telemetry on ${platform} restart when the flag env is absent`, async () => {
+      const fs = new MemFs();
+      const paths = daemonPaths(HOME);
+      const pathEnv = "/opt/node/bin:/usr/bin:/bin";
+      const servicePath = platform === "linux" ? paths.systemdService : paths.plist;
+      const input = {
+        executablePath: "/opt/bin/ratel-local",
+        homeDir: HOME,
+        port: DEFAULT_DAEMON_PORT,
+        pathEnv,
+        featureFlags: { cloudTelemetry: true },
+      };
+      const original =
+        platform === "linux" ? createSystemdUserService(input) : createLaunchAgentPlist(input);
+      fs.files.set(servicePath, original);
+      const commands: Array<{ command: string; args: string[] }> = [];
+
+      await runDaemon(
+        daemonArgs({ verb: "restart", flags: { telemetry: "off", open: false } }),
+        makeCtx(fs),
+        { processEnv: {} },
+        () => {},
+        {
+          platform,
+          getUid: () => 501,
+          commandRunner: async (command, args) => {
+            commands.push({ command, args });
+            return { stdout: "", stderr: "" };
+          },
+          probe: offlineThenHealthyProbe(),
+          lifecycleProgress: false,
+        },
+      );
+
+      expect(fs.files.get(servicePath)).toBe(original);
+      expect(commands.some((entry) => entry.args.includes("daemon-reload"))).toBe(false);
+      if (platform === "linux") {
+        expect(commands).toEqual([
+          { command: "systemctl", args: ["--user", "stop", SYSTEMD_SERVICE] },
+          { command: "systemctl", args: ["--user", "start", SYSTEMD_SERVICE] },
+        ]);
+      }
+    });
+
+    it(`disables Cloud telemetry on ${platform} restart when the flag is explicitly 0`, async () => {
+      const fs = new MemFs();
+      const paths = daemonPaths(HOME);
+      const pathEnv = "/opt/node/bin:/usr/bin:/bin";
+      const servicePath = platform === "linux" ? paths.systemdService : paths.plist;
+      const input = {
+        executablePath: "/opt/bin/ratel-local",
+        homeDir: HOME,
+        port: DEFAULT_DAEMON_PORT,
+        pathEnv,
+        featureFlags: { cloudTelemetry: true },
+      };
+      fs.files.set(
+        servicePath,
+        platform === "linux" ? createSystemdUserService(input) : createLaunchAgentPlist(input),
+      );
+
+      await runDaemon(
+        daemonArgs({ verb: "restart", flags: { telemetry: "off", open: false } }),
+        makeCtx(fs),
+        { processEnv: { [CLOUD_TELEMETRY_FEATURE_ENV]: "0" } },
+        () => {},
+        {
+          platform,
+          getUid: () => 501,
+          commandRunner: async () => ({ stdout: "", stderr: "" }),
+          probe: offlineThenHealthyProbe(),
+          lifecycleProgress: false,
+        },
+      );
+
+      const next = fs.files.get(servicePath) ?? "";
+      expect(next).not.toContain(CLOUD_TELEMETRY_FEATURE_ENV);
+      expect(next).toContain(pathEnv);
+    });
+  }
+
+  it("keeps Linux restart visibly active without rewriting the service", async () => {
+    const fs = new MemFs();
+    const paths = daemonPaths(HOME);
+    const original = createSystemdUserService({
+      executablePath: "/opt/bin/ratel-local",
+      homeDir: HOME,
+      port: DEFAULT_DAEMON_PORT,
+    });
+    fs.files.set(paths.systemdService, original);
+    const progress: string[] = [];
+    const commands: Array<{ command: string; args: string[] }> = [];
+    const ctx = makeCtx(fs);
+    ctx.prompts.spinner = () => ({
+      start: (message) => progress.push(`start:${message}`),
+      message: (message) => progress.push(`message:${message}`),
+      stop: (message) => progress.push(`stop:${message}`),
+    });
+
+    await runDaemon(
+      daemonArgs({ verb: "restart", flags: { telemetry: "off", open: false } }),
+      ctx,
+      { processEnv: {} },
+      () => {},
+      {
+        platform: "linux",
+        commandRunner: async (command, args) => {
+          commands.push({ command, args });
+          return { stdout: "", stderr: "" };
+        },
+        probe: offlineThenHealthyProbe(),
+      },
+    );
+
+    expect(progress).toEqual([
+      "start:Restarting Ratel Local…",
+      "message:Starting Ratel Local again…",
+      "stop:Ratel Local is ready",
+    ]);
+    expect(fs.files.get(paths.systemdService)).toBe(original);
+    expect(commands).toEqual([
+      { command: "systemctl", args: ["--user", "stop", SYSTEMD_SERVICE] },
+      { command: "systemctl", args: ["--user", "start", SYSTEMD_SERVICE] },
+    ]);
+  });
+
+  it("does not create a service when restarting with an explicit flag while uninstalled", async () => {
+    const fs = new MemFs();
+    const paths = daemonPaths(HOME);
+
+    await expect(
+      runDaemon(
+        daemonArgs({ verb: "restart", flags: { telemetry: "off", open: false } }),
+        makeCtx(fs),
+        { processEnv: { [CLOUD_TELEMETRY_FEATURE_ENV]: "1" } },
+        () => {},
+        {
+          platform: "darwin",
+          getUid: () => 501,
+          commandRunner: async () => ({ stdout: "", stderr: "" }),
+          lifecycleProgress: false,
+        },
+      ),
+    ).rejects.toThrow(/not installed/);
+
+    expect(fs.files.has(paths.plist)).toBe(false);
+    expect(fs.files.has(paths.systemdService)).toBe(false);
+  });
+
+  const installedPlist = () =>
+    createLaunchAgentPlist({
+      executablePath: "/opt/bin/ratel-local",
+      homeDir: HOME,
+      port: DEFAULT_DAEMON_PORT,
+      featureFlags: { cloudTelemetry: false },
+    });
+
+  const restartWithProbe = (
+    fs: MemFs,
+    probe: ReturnType<typeof restartStatusProbe>,
+    logs: string[],
+  ) =>
+    runDaemon(
+      daemonArgs({ verb: "restart", flags: { telemetry: "off", open: false } }),
+      makeCtx(fs),
+      { processEnv: { [CLOUD_TELEMETRY_FEATURE_ENV]: "1" } },
+      (message) => logs.push(message),
+      {
+        platform: "darwin",
+        getUid: () => 501,
+        commandRunner: async () => ({ stdout: "", stderr: "" }),
+        probe,
+        lifecycleProgress: false,
+      },
+    );
+
+  it("accepts a restart whose daemon reports the requested Cloud telemetry state", async () => {
+    const fs = new MemFs();
+    fs.files.set(daemonPaths(HOME).plist, installedPlist());
+    const logs: string[] = [];
+
+    await restartWithProbe(fs, restartStatusProbe(true), logs);
+
+    expect(logs.some((message) => message.includes("could not confirm"))).toBe(false);
+  });
+
+  it("fails a restart whose daemon still reports the previous Cloud telemetry state", async () => {
+    const fs = new MemFs();
+    fs.files.set(daemonPaths(HOME).plist, installedPlist());
+
+    await expect(restartWithProbe(fs, restartStatusProbe(false), [])).rejects.toThrow(
+      /previous service definition may still be loaded/,
+    );
+  });
+
+  it("notes, but does not fail, a restart whose daemon cannot report the flag", async () => {
+    const fs = new MemFs();
+    fs.files.set(daemonPaths(HOME).plist, installedPlist());
+    const logs: string[] = [];
+
+    await restartWithProbe(fs, restartStatusProbe(undefined), logs);
+
+    expect(logs.some((message) => message.includes("could not confirm Cloud telemetry"))).toBe(
+      true,
+    );
+  });
+
+  for (const platform of ["darwin", "linux"] as const) {
+    it(`waits for the old daemon to release the port before restarting on ${platform}`, async () => {
+      const fs = new MemFs();
+      const paths = daemonPaths(HOME);
+      const servicePath = platform === "linux" ? paths.systemdService : paths.plist;
+      const input = {
+        executablePath: "/opt/bin/ratel-local",
+        homeDir: HOME,
+        port: DEFAULT_DAEMON_PORT,
+        featureFlags: { cloudTelemetry: false },
+      };
+      fs.files.set(
+        servicePath,
+        platform === "linux" ? createSystemdUserService(input) : createLaunchAgentPlist(input),
+      );
+      const commands: Array<{ command: string; args: string[] }> = [];
+      let probes = 0;
+
+      await runDaemon(
+        daemonArgs({ verb: "restart", flags: { telemetry: "off", open: false } }),
+        makeCtx(fs),
+        { processEnv: { [CLOUD_TELEMETRY_FEATURE_ENV]: "1" } },
+        () => {},
+        {
+          platform,
+          getUid: () => 501,
+          commandRunner: async (command, args) => {
+            commands.push({ command, args });
+            return { stdout: "", stderr: "" };
+          },
+          // The stopped daemon keeps answering for two probes before it releases
+          // the port; the restarted one answers afterwards.
+          probe: async (port: number) => {
+            probes += 1;
+            if (probes <= 2) return { ok: true };
+            if (probes === 3) return { ok: false, error: "connection refused" };
+            return { ok: port === DEFAULT_DAEMON_PORT };
+          },
+          lifecycleProgress: false,
+        },
+      );
+
+      // The rewritten service must actually be loaded: an early "already
+      // running" return would skip the bootstrap/start below.
+      expect(probes).toBeGreaterThan(3);
+      expect(fs.files.get(servicePath) ?? "").toContain(CLOUD_TELEMETRY_FEATURE_ENV);
+      if (platform === "linux") {
+        expect(commands).toEqual([
+          { command: "systemctl", args: ["--user", "daemon-reload"] },
+          { command: "systemctl", args: ["--user", "stop", SYSTEMD_SERVICE] },
+          { command: "systemctl", args: ["--user", "start", SYSTEMD_SERVICE] },
+        ]);
+      } else {
+        expect(commands).toEqual([
+          { command: "launchctl", args: ["bootout", "gui/501", paths.plist] },
+          { command: "launchctl", args: ["bootstrap", "gui/501", paths.plist] },
+          { command: "launchctl", args: ["kickstart", "-k", "gui/501/ai.ratel.local.daemon"] },
+        ]);
+      }
+    });
+  }
 
   it("ends the lifecycle state clearly when the daemon cannot start", async () => {
     const fs = new MemFs();
@@ -1290,6 +1645,36 @@ describe("runDaemon", () => {
     expect(logs.join("\n")).toContain("2 upstream server(s), 1 active MCP client(s)");
   });
 });
+
+function restartStatusProbe(cloudTelemetry?: boolean) {
+  let calls = 0;
+  return async (port: number) => {
+    calls += 1;
+    // Stopped for the first probe, then the restarted daemon answers.
+    if (calls === 1) return { ok: false, error: "connection refused" };
+    return {
+      ok: true,
+      status: {
+        service: DAEMON_SERVICE_ID,
+        protocolVersion: DAEMON_PROTOCOL_VERSION,
+        pid: 321,
+        port,
+        uiUrl: `http://127.0.0.1:${port}`,
+        mcpUrl: `http://127.0.0.1:${port}/mcp`,
+        startedAt: "2026-08-24T08:00:00.000Z",
+        version: "0.8.2",
+        configMode: "auto" as const,
+        uptimeSeconds: 1,
+        upstreamCount: 0,
+        activeClientCount: 0,
+        activeGatewayCount: 0,
+        activeUserGatewayCount: 0,
+        activeProjectGatewayCount: 0,
+        ...(cloudTelemetry === undefined ? {} : { cloudTelemetry }),
+      },
+    };
+  };
+}
 
 function offlineThenHealthyProbe() {
   let calls = 0;

--- a/apps/ratel-local/src/cli/handlers/daemon.ts
+++ b/apps/ratel-local/src/cli/handlers/daemon.ts
@@ -67,6 +67,7 @@ import {
 import { DAEMON_INSTALL_PATH_ENV } from "../../daemon/subprocess-environment.js";
 import {
   CLOUD_TELEMETRY_FEATURE_ENV,
+  cloudTelemetryOverrideFromEnv,
   type FeatureFlags,
   featureFlagServiceEnvironment,
   featureFlagsFromEnv,
@@ -125,6 +126,8 @@ export interface DaemonStatusBody extends DaemonState {
   activeUserGatewayCount: number;
   activeProjectGatewayCount: number;
   retrievalHealth?: RetrievalHealthStats;
+  /** Absent on daemons older than the restart-reconfiguration support. */
+  cloudTelemetry?: boolean;
 }
 
 interface CommandResult {
@@ -133,6 +136,7 @@ interface CommandResult {
 }
 
 type CommandRunner = (command: string, args: string[]) => Promise<CommandResult>;
+type DaemonStartMode = "start" | "restart";
 type ProbeDaemon = (
   port: number,
 ) => Promise<{ ok: boolean; reachable?: boolean; status?: DaemonStatusBody; error?: string }>;
@@ -252,6 +256,7 @@ export async function runDaemon(
     return {};
   }
   if (verb === "restart") {
+    let restartNote: string | undefined;
     await runDaemonLifecycle(
       ctx,
       opts,
@@ -262,11 +267,20 @@ export async function runDaemon(
       },
       async (spinner) => {
         const lifecycleLog = opts.lifecycleProgress === false ? log : () => {};
+        const applied = await reconfigureInstalledServiceFeatureFlags(ctx, options, opts);
         await stopDaemon(ctx, lifecycleLog, opts);
         spinner?.message("Starting Ratel Local again…");
-        await startDaemon(parsed, ctx, options, lifecycleLog, opts);
+        await startDaemon(parsed, ctx, options, lifecycleLog, opts, "restart");
+        if (applied !== undefined) {
+          restartNote = await verifyCloudTelemetryApplied(
+            await daemonPort(parsed, ctx),
+            opts.probe ?? probeDaemon,
+            applied,
+          );
+        }
       },
     );
+    if (restartNote) log(restartNote);
     return {};
   }
   if (verb === "open") {
@@ -672,6 +686,7 @@ export async function runDaemonServer(
           activeGatewayCount: poolStats.activeGatewayCount,
           activeUserGatewayCount: poolStats.activeUserGatewayCount,
           activeProjectGatewayCount: poolStats.activeProjectGatewayCount,
+          cloudTelemetry: featureFlags.cloudTelemetry,
           ...(retrievalHealthEnabled ? { retrievalHealth: poolStats.retrievalHealth } : {}),
         });
         return true;
@@ -715,7 +730,7 @@ export async function runDaemonServer(
     log(`[ratel] Cloud OTLP log endpoint available at ${state.uiUrl}${OTLP_LOGS_PATH}`);
   } else {
     log(
-      `[ratel] Cloud telemetry disabled; start a foreground daemon with ${CLOUD_TELEMETRY_FEATURE_ENV}=1 or reinstall the background service with that environment`,
+      `[ratel] Cloud telemetry disabled; start a foreground daemon with ${CLOUD_TELEMETRY_FEATURE_ENV}=1 or run ${CLOUD_TELEMETRY_FEATURE_ENV}=1 ratel-local daemon restart`,
     );
   }
   if (featureFlags.cloudTelemetry && activeCloudOptions) {
@@ -945,6 +960,91 @@ WantedBy=default.target
 `;
 }
 
+const LAUNCH_AGENT_FLAG_ENTRY = `    <key>${CLOUD_TELEMETRY_FEATURE_ENV}</key>\n    <string>1</string>`;
+const LAUNCH_AGENT_FLAG_ENTRY_RE = new RegExp(
+  `\\n    <key>${CLOUD_TELEMETRY_FEATURE_ENV}</key>\\n    <string>[^<]*</string>`,
+);
+const SYSTEMD_FLAG_LINE = `Environment=${CLOUD_TELEMETRY_FEATURE_ENV}=1`;
+const SYSTEMD_FLAG_LINE_RE = new RegExp(`^Environment=${CLOUD_TELEMETRY_FEATURE_ENV}=.*\\n`, "m");
+const SERVICE_SHAPE_ERROR =
+  'installed daemon service is not a Ratel Local unit; reinstall with "ratel-local daemon install"';
+
+export function applyCloudTelemetryToLaunchAgentPlist(plist: string, enabled: boolean): string {
+  const stripped = plist.replace(LAUNCH_AGENT_FLAG_ENTRY_RE, "");
+  if (!enabled) {
+    return stripped.replace(/\n {2}<key>EnvironmentVariables<\/key>\n {2}<dict>\n {2}<\/dict>/, "");
+  }
+  const envBlock =
+    /(<key>EnvironmentVariables<\/key>\n {2}<dict>\n)([\s\S]*?)(\n {2}<\/dict>)/.exec(stripped);
+  if (envBlock?.index !== undefined) {
+    const inserted = `${envBlock[1]}${envBlock[2]}\n${LAUNCH_AGENT_FLAG_ENTRY}${envBlock[3]}`;
+    return (
+      stripped.slice(0, envBlock.index) +
+      inserted +
+      stripped.slice(envBlock.index + envBlock[0].length)
+    );
+  }
+  if (!stripped.includes("<key>StandardOutPath</key>")) throw new Error(SERVICE_SHAPE_ERROR);
+  return stripped.replace(
+    "  <key>StandardOutPath</key>",
+    `  <key>EnvironmentVariables</key>\n  <dict>\n${LAUNCH_AGENT_FLAG_ENTRY}\n  </dict>\n  <key>StandardOutPath</key>`,
+  );
+}
+
+export function applyCloudTelemetryToSystemdUserService(unit: string, enabled: boolean): string {
+  const stripped = unit.replace(SYSTEMD_FLAG_LINE_RE, "");
+  if (!enabled) return stripped;
+  if (!stripped.includes("Restart=always")) throw new Error(SERVICE_SHAPE_ERROR);
+  return stripped.replace("Restart=always", `${SYSTEMD_FLAG_LINE}\nRestart=always`);
+}
+
+/**
+ * Apply an explicit Cloud telemetry override to the installed service file.
+ * Returns the applied value, or `undefined` when nothing was written — no
+ * override in the environment, or no installed service to rewrite.
+ */
+async function reconfigureInstalledServiceFeatureFlags(
+  ctx: HandlerCtx,
+  options: ServeOptions,
+  opts: DaemonHandlerDeps,
+): Promise<boolean | undefined> {
+  const override = cloudTelemetryOverrideFromEnv(options.processEnv ?? process.env);
+  if (override === undefined) return undefined;
+  const platform = daemonPlatform(opts);
+  const paths = daemonPaths(ctx.env.homeDir);
+  const servicePath = platform === "linux" ? paths.systemdService : paths.plist;
+  const current = await ctx.fs.read(servicePath);
+  if (current === null) return undefined;
+  const next =
+    platform === "linux"
+      ? applyCloudTelemetryToSystemdUserService(current, override)
+      : applyCloudTelemetryToLaunchAgentPlist(current, override);
+  await ctx.fs.writeAtomic(servicePath, next);
+  if (platform === "linux") await systemctl(opts, ["daemon-reload"]);
+  return override;
+}
+
+/**
+ * Confirm the restarted daemon actually runs with the flag we just wrote.
+ * Rewriting the service file is not proof: launchd or systemd may still be
+ * serving the previous definition. Throws on a mismatch; returns a note when
+ * the running daemon is too old to report the flag at all.
+ */
+async function verifyCloudTelemetryApplied(
+  port: number,
+  probe: ProbeDaemon,
+  expected: boolean,
+): Promise<string | undefined> {
+  const observed = (await probe(port)).status?.cloudTelemetry;
+  if (observed === expected) return undefined;
+  if (observed === undefined) {
+    return `[ratel] could not confirm Cloud telemetry is ${expected ? "enabled" : "disabled"}: the running daemon does not report it. Check "ratel-local traces status".`;
+  }
+  throw new Error(
+    `service was updated but the restarted daemon reports Cloud telemetry ${observed ? "enabled" : "disabled"}, expected ${expected ? "enabled" : "disabled"}; the previous service definition may still be loaded`,
+  );
+}
+
 async function installDaemon(
   parsed: ParsedArgs,
   ctx: HandlerCtx,
@@ -1006,10 +1106,11 @@ async function startDaemon(
   options: ServeOptions,
   log: (m: string) => void,
   opts: DaemonHandlerDeps,
+  mode: DaemonStartMode = "start",
 ): Promise<void> {
   const platform = daemonPlatform(opts);
   if (platform === "linux") {
-    await startLinuxDaemon(parsed, ctx, options, log, opts);
+    await startLinuxDaemon(parsed, ctx, options, log, opts, mode);
     return;
   }
   ensureMacos("daemon start", opts);
@@ -1020,8 +1121,11 @@ async function startDaemon(
   const port = await daemonPort(parsed, ctx);
   const probe = opts.probe ?? probeDaemon;
   if ((await probe(port)).ok) {
-    log(`[ratel] daemon already running at http://127.0.0.1:${port}`);
-    return;
+    if (mode === "start") {
+      log(`[ratel] daemon already running at http://127.0.0.1:${port}`);
+      return;
+    }
+    await waitForDaemonStopped(port, probe);
   }
   await bootstrapDaemon(ctx, opts, { ignoreFailure: true });
   await kickstartDaemon(ctx, opts);
@@ -1094,6 +1198,7 @@ async function startLinuxDaemon(
   options: ServeOptions,
   log: (m: string) => void,
   opts: DaemonHandlerDeps,
+  mode: DaemonStartMode = "start",
 ): Promise<void> {
   const paths = daemonPaths(ctx.env.homeDir);
   if (!(await ctx.fs.exists(paths.systemdService))) {
@@ -1102,8 +1207,11 @@ async function startLinuxDaemon(
   const port = await daemonPort(parsed, ctx);
   const probe = opts.probe ?? probeDaemon;
   if ((await probe(port)).ok) {
-    log(`[ratel] daemon already running at http://127.0.0.1:${port}`);
-    return;
+    if (mode === "start") {
+      log(`[ratel] daemon already running at http://127.0.0.1:${port}`);
+      return;
+    }
+    await waitForDaemonStopped(port, probe);
   }
   await systemctl(opts, ["start", SYSTEMD_SERVICE]);
   await waitForDaemon(port, probe, options.serverVersion);
@@ -1238,6 +1346,23 @@ async function assertDaemonPortAvailable(port: number, probe: ProbeDaemon): Prom
       }`,
     );
   }
+}
+
+/**
+ * Wait for a stopped daemon to release its port. `daemon restart` rewrites the
+ * installed service definition before stopping, and `start` hands back a
+ * still-running daemon untouched — so starting before the old process is gone
+ * would silently keep the pre-rewrite definition live.
+ */
+async function waitForDaemonStopped(port: number, probe: ProbeDaemon): Promise<void> {
+  const deadline = Date.now() + 5_000;
+  while (Date.now() < deadline) {
+    if (!(await probe(port)).ok) return;
+    await new Promise((resolve) => setTimeout(resolve, 150));
+  }
+  throw new Error(
+    `daemon at http://127.0.0.1:${port} did not stop; restart cannot apply service changes`,
+  );
 }
 
 async function waitForDaemon(

--- a/apps/ratel-local/src/cli/handlers/daemon.ts
+++ b/apps/ratel-local/src/cli/handlers/daemon.ts
@@ -964,16 +964,21 @@ const LAUNCH_AGENT_FLAG_ENTRY = `    <key>${CLOUD_TELEMETRY_FEATURE_ENV}</key>\n
 const LAUNCH_AGENT_FLAG_ENTRY_RE = new RegExp(
   `\\n    <key>${CLOUD_TELEMETRY_FEATURE_ENV}</key>\\n    <string>[^<]*</string>`,
 );
+const EMPTY_LAUNCH_AGENT_ENV_BLOCK_RE =
+  /\n {2}<key>EnvironmentVariables<\/key>\n {2}<dict>\n {2}<\/dict>/;
 const SYSTEMD_FLAG_LINE = `Environment=${CLOUD_TELEMETRY_FEATURE_ENV}=1`;
 const SYSTEMD_FLAG_LINE_RE = new RegExp(`^Environment=${CLOUD_TELEMETRY_FEATURE_ENV}=.*\\n`, "m");
 const SERVICE_SHAPE_ERROR =
   'installed daemon service is not a Ratel Local unit; reinstall with "ratel-local daemon install"';
 
 export function applyCloudTelemetryToLaunchAgentPlist(plist: string, enabled: boolean): string {
-  const stripped = plist.replace(LAUNCH_AGENT_FLAG_ENTRY_RE, "");
-  if (!enabled) {
-    return stripped.replace(/\n {2}<key>EnvironmentVariables<\/key>\n {2}<dict>\n {2}<\/dict>/, "");
-  }
+  // Drop the flag entry, then an environment dict it may have left empty. Both
+  // branches below assume the shape `createLaunchAgentPlist` emits: without the
+  // second replace, enabling twice appends a new dict beside the emptied one.
+  const stripped = plist
+    .replace(LAUNCH_AGENT_FLAG_ENTRY_RE, "")
+    .replace(EMPTY_LAUNCH_AGENT_ENV_BLOCK_RE, "");
+  if (!enabled) return stripped;
   const envBlock =
     /(<key>EnvironmentVariables<\/key>\n {2}<dict>\n)([\s\S]*?)(\n {2}<\/dict>)/.exec(stripped);
   if (envBlock?.index !== undefined) {
@@ -1019,8 +1024,10 @@ async function reconfigureInstalledServiceFeatureFlags(
     platform === "linux"
       ? applyCloudTelemetryToSystemdUserService(current, override)
       : applyCloudTelemetryToLaunchAgentPlist(current, override);
-  await ctx.fs.writeAtomic(servicePath, next);
-  if (platform === "linux") await systemctl(opts, ["daemon-reload"]);
+  if (next !== current) {
+    await ctx.fs.writeAtomic(servicePath, next);
+    if (platform === "linux") await systemctl(opts, ["daemon-reload"]);
+  }
   return override;
 }
 
@@ -1035,13 +1042,16 @@ async function verifyCloudTelemetryApplied(
   probe: ProbeDaemon,
   expected: boolean,
 ): Promise<string | undefined> {
-  const observed = (await probe(port)).status?.cloudTelemetry;
+  const wanted = expected ? "enabled" : "disabled";
+  const result = await probe(port);
+  const unconfirmed = (reason: string) =>
+    `[ratel] could not confirm Cloud telemetry is ${wanted}: ${reason}. Check "ratel-local traces status".`;
+  if (!result.ok) return unconfirmed("the daemon did not answer");
+  const observed = result.status?.cloudTelemetry;
   if (observed === expected) return undefined;
-  if (observed === undefined) {
-    return `[ratel] could not confirm Cloud telemetry is ${expected ? "enabled" : "disabled"}: the running daemon does not report it. Check "ratel-local traces status".`;
-  }
+  if (observed === undefined) return unconfirmed("the running daemon does not report it");
   throw new Error(
-    `service was updated but the restarted daemon reports Cloud telemetry ${observed ? "enabled" : "disabled"}, expected ${expected ? "enabled" : "disabled"}; the previous service definition may still be loaded`,
+    `service was updated but the restarted daemon reports Cloud telemetry ${observed ? "enabled" : "disabled"}, expected ${wanted}; the previous service definition may still be loaded. Reinstall with "ratel-local daemon uninstall" then "${CLOUD_TELEMETRY_FEATURE_ENV}=${expected ? "1" : "0"} ratel-local daemon install".`,
   );
 }
 
@@ -1354,8 +1364,12 @@ async function assertDaemonPortAvailable(port: number, probe: ProbeDaemon): Prom
  * still-running daemon untouched — so starting before the old process is gone
  * would silently keep the pre-rewrite definition live.
  */
-async function waitForDaemonStopped(port: number, probe: ProbeDaemon): Promise<void> {
-  const deadline = Date.now() + 5_000;
+export async function waitForDaemonStopped(
+  port: number,
+  probe: ProbeDaemon,
+  timeoutMs = 5_000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
     if (!(await probe(port)).ok) return;
     await new Promise((resolve) => setTimeout(resolve, 150));

--- a/apps/ratel-local/src/cli/handlers/traces.test.ts
+++ b/apps/ratel-local/src/cli/handlers/traces.test.ts
@@ -106,7 +106,9 @@ describe("runTraces", () => {
   it("refuses telemetry mutations while the daemon feature flag is off", async () => {
     const { ctx } = context("enable", { agent: "claude-code", yes: true });
     const request = vi.fn(async () => response({ ...status(), featureEnabled: false }));
-    await expect(runTraces(ctx, { request })).rejects.toThrow(/RATEL_FEATURE_CLOUD_TELEMETRY=1/);
+    await expect(runTraces(ctx, { request })).rejects.toThrow(
+      /RATEL_FEATURE_CLOUD_TELEMETRY=1.*daemon restart/,
+    );
     expect(request).toHaveBeenCalledOnce();
   });
 

--- a/apps/ratel-local/src/cli/handlers/traces.ts
+++ b/apps/ratel-local/src/cli/handlers/traces.ts
@@ -80,7 +80,7 @@ export async function runTraces(
   }
   if (status.featureEnabled === false) {
     throw new ArgError(
-      "Cloud telemetry is disabled; start a foreground daemon with RATEL_FEATURE_CLOUD_TELEMETRY=1 or reinstall the background service with that environment",
+      "Cloud telemetry is disabled; start a foreground daemon with RATEL_FEATURE_CLOUD_TELEMETRY=1 or run RATEL_FEATURE_CLOUD_TELEMETRY=1 ratel-local daemon restart",
     );
   }
 

--- a/apps/ratel-local/src/feature-flags.test.ts
+++ b/apps/ratel-local/src/feature-flags.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   CLOUD_TELEMETRY_FEATURE_ENV,
+  cloudTelemetryOverrideFromEnv,
   featureFlagServiceEnvironment,
   featureFlagsFromEnv,
 } from "./feature-flags.js";
@@ -20,5 +21,13 @@ describe("feature flags", () => {
     expect(featureFlagServiceEnvironment({ cloudTelemetry: true })).toEqual({
       [CLOUD_TELEMETRY_FEATURE_ENV]: "1",
     });
+  });
+
+  it("treats Cloud telemetry env presence as an explicit service override", () => {
+    expect(cloudTelemetryOverrideFromEnv({})).toBeUndefined();
+    expect(cloudTelemetryOverrideFromEnv({ [CLOUD_TELEMETRY_FEATURE_ENV]: "1" })).toBe(true);
+    expect(cloudTelemetryOverrideFromEnv({ [CLOUD_TELEMETRY_FEATURE_ENV]: "0" })).toBe(false);
+    expect(cloudTelemetryOverrideFromEnv({ [CLOUD_TELEMETRY_FEATURE_ENV]: "" })).toBe(false);
+    expect(cloudTelemetryOverrideFromEnv({ [CLOUD_TELEMETRY_FEATURE_ENV]: "true" })).toBe(false);
   });
 });

--- a/apps/ratel-local/src/feature-flags.ts
+++ b/apps/ratel-local/src/feature-flags.ts
@@ -18,3 +18,13 @@ export function featureFlagsFromEnv(env: NodeJS.ProcessEnv): FeatureFlags {
 export function featureFlagServiceEnvironment(flags: FeatureFlags): Record<string, string> {
   return flags.cloudTelemetry ? { [CLOUD_TELEMETRY_FEATURE_ENV]: "1" } : {};
 }
+
+/**
+ * Explicit Cloud telemetry override from the invoking environment.
+ * `undefined` means the variable is absent and installed service state must
+ * be preserved. Any present value is an override: only exact `1` enables.
+ */
+export function cloudTelemetryOverrideFromEnv(env: NodeJS.ProcessEnv): boolean | undefined {
+  if (!Object.hasOwn(env, CLOUD_TELEMETRY_FEATURE_ENV)) return undefined;
+  return env[CLOUD_TELEMETRY_FEATURE_ENV] === "1";
+}

--- a/docs/adr/0020-daemon-restart-feature-flag-reconfiguration.md
+++ b/docs/adr/0020-daemon-restart-feature-flag-reconfiguration.md
@@ -30,7 +30,10 @@ so npm/npx cannot reorder agent plugin executables.
   invoking environment and a service file is installed, rewrite only that
   feature-flag environment entry in the existing launchd or systemd unit, then
   perform the normal stop/start. On Linux, run `systemctl --user daemon-reload`
-  after the rewrite.
+  after the rewrite. Wait for the stopped daemon to release its port before
+  starting, then confirm the restarted daemon adopted the change through
+  `cloudTelemetry` on the loopback `/api/daemon/status` route — a non-secret
+  boolean; a daemon too old to report it yields a note, not a failure.
 - If the variable is **absent**, leave the installed service file unchanged and
   only stop/start.
 - Presence is the override signal. Only the exact value `1` enables; any other
@@ -52,7 +55,8 @@ remain in force.
 
 - Operators can enable or disable Cloud telemetry on an installed daemon with
   an explicit env assignment on `daemon restart`, and keep it enabled with a
-  plain restart.
+  plain restart. A restart that cannot stop the old daemon, or whose daemon
+  reports the previous state, fails instead of reporting success.
 - Absent-env restarts preserve prior ADR 0018 semantics and do not silently
   disable telemetry.
 - Install-time PATH isolation is preserved because restart reconfiguration does

--- a/docs/adr/0020-daemon-restart-feature-flag-reconfiguration.md
+++ b/docs/adr/0020-daemon-restart-feature-flag-reconfiguration.md
@@ -21,8 +21,8 @@ expectation that
 `RATEL_FEATURE_CLOUD_TELEMETRY=1 ratel-local daemon restart` should take effect.
 
 Regenerating the whole service from the invoking shell would also refresh
-install-time `PATH` / `RATEL_DAEMON_INSTALL_PATH`, which ADR-era work preserved
-so npm/npx cannot reorder agent plugin executables.
+install-time `PATH` / `RATEL_DAEMON_INSTALL_PATH`, which ADR 0007 preserved so
+npm/npx cannot reorder agent plugin executables.
 
 ## Decision
 
@@ -61,4 +61,3 @@ remain in force.
   disable telemetry.
 - Install-time PATH isolation is preserved because restart reconfiguration does
   not regenerate the whole unit from the current shell.
-- ADR-0021 is reserved for Cloud credential ownership (week-plan B1).

--- a/docs/adr/0020-daemon-restart-feature-flag-reconfiguration.md
+++ b/docs/adr/0020-daemon-restart-feature-flag-reconfiguration.md
@@ -1,0 +1,60 @@
+# 20. Daemon restart feature-flag reconfiguration
+
+Date: 2026-08-24
+
+## Status
+
+Accepted
+
+## Context
+
+ADR 0018 made Cloud telemetry an environment-only, opt-in daemon boundary and
+persisted only enabled flags into generated launchd and systemd units. It also
+decided that changing that persisted flag required reinstalling the service
+definition, and that a plain restart must not reinterpret the invoking shell's
+environment.
+
+Operators then needed an explicit uninstall/install cycle to enable or disable
+Cloud telemetry on an already-installed background daemon. That cycle is easy
+to get wrong, and documenting it as the only path conflicts with the natural
+expectation that
+`RATEL_FEATURE_CLOUD_TELEMETRY=1 ratel-local daemon restart` should take effect.
+
+Regenerating the whole service from the invoking shell would also refresh
+install-time `PATH` / `RATEL_DAEMON_INSTALL_PATH`, which ADR-era work preserved
+so npm/npx cannot reorder agent plugin executables.
+
+## Decision
+
+- On `daemon restart`, if `RATEL_FEATURE_CLOUD_TELEMETRY` is **present** in the
+  invoking environment and a service file is installed, rewrite only that
+  feature-flag environment entry in the existing launchd or systemd unit, then
+  perform the normal stop/start. On Linux, run `systemctl --user daemon-reload`
+  after the rewrite.
+- If the variable is **absent**, leave the installed service file unchanged and
+  only stop/start.
+- Presence is the override signal. Only the exact value `1` enables; any other
+  present value, including `0`, disables by removing the persisted enabled
+  entry. Do not persist `=0`.
+- Do not regenerate ProgramArguments, ExecStart, WorkingDirectory, or PATH /
+  `RATEL_DAEMON_INSTALL_PATH` as part of this path.
+- `daemon start` and `setup` remain non-rewriting for this flag.
+  Uninstall/install remains a valid fallback.
+
+This supersedes only ADR 0018's decision that enabling or disabling an existing
+background service requires reinstalling its service definition and that a
+plain restart does not reinterpret the invoking shell's environment. ADR 0018's
+exact-`1` enablement, environment-only boundary, persist-only-enabled-flags,
+credential separation, fail-open telemetry boundary, and gated behavior set
+remain in force.
+
+## Consequences
+
+- Operators can enable or disable Cloud telemetry on an installed daemon with
+  an explicit env assignment on `daemon restart`, and keep it enabled with a
+  plain restart.
+- Absent-env restarts preserve prior ADR 0018 semantics and do not silently
+  disable telemetry.
+- Install-time PATH isolation is preserved because restart reconfiguration does
+  not regenerate the whole unit from the current shell.
+- ADR-0021 is reserved for Cloud credential ownership (week-plan B1).

--- a/docs/cloud-otlp-relay.md
+++ b/docs/cloud-otlp-relay.md
@@ -38,7 +38,7 @@ RATEL_FEATURE_CLOUD_TELEMETRY=1 ratel-local daemon restart
 # Keep enabled — variable absent; installed service file is preserved
 ratel-local daemon restart
 
-# Disable
+# Disable — any present value other than `1` removes the persisted flag
 RATEL_FEATURE_CLOUD_TELEMETRY=0 ratel-local daemon restart
 ```
 

--- a/docs/cloud-otlp-relay.md
+++ b/docs/cloud-otlp-relay.md
@@ -28,16 +28,22 @@ RATEL_FEATURE_CLOUD_TELEMETRY=1 ratel-local daemon run --no-open --auto-config
 
 When setup installs a macOS launchd or Linux systemd service, it copies the
 enabled flag into that service definition. A later setup run does not rewrite an
-already-current service. Enable an existing service explicitly:
+already-current service. Enable, keep, or disable an existing service by making
+the feature-flag variable present or absent on `daemon restart`:
 
 ```bash
-ratel-local daemon uninstall
-RATEL_FEATURE_CLOUD_TELEMETRY=1 ratel-local daemon install
+# Enable — rewrites only the feature-flag environment entry
+RATEL_FEATURE_CLOUD_TELEMETRY=1 ratel-local daemon restart
+
+# Keep enabled — variable absent; installed service file is preserved
+ratel-local daemon restart
+
+# Disable
+RATEL_FEATURE_CLOUD_TELEMETRY=0 ratel-local daemon restart
 ```
 
-To roll back, repeat those commands without the environment assignment.
-Reinstalling the service does not delete Ratel configuration or saved Cloud
-settings.
+`daemon start` does not rewrite the service. Uninstall then install remains a
+valid fallback and does not delete Ratel configuration or saved Cloud settings.
 
 The startup environment is the only feature-flag source. Cloud endpoint and
 credential settings do not override it, so a saved key cannot silently enable


### PR DESCRIPTION
## Problem

`daemon restart` never regenerated the service file, so changing `RATEL_FEATURE_CLOUD_TELEMETRY` on an installed daemon required `daemon uninstall` + `daemon install`. Exporting the flag before a restart silently did nothing.

## Solution

**Presence** of the variable is the override signal, not its value, so a plain restart can never silently disable telemetry:

| invoking environment | installed service |
| --- | --- |
| `=1` | enabled |
| `=0` or any other value | disabled |
| absent | untouched |

Only the feature-flag entry is rewritten; `ProgramArguments`, `ExecStart`, `PATH` and `RATEL_DAEMON_INSTALL_PATH` are preserved. `daemon start` and `setup` remain non-rewriting.

## Notes

- `restart` now waits for the stopped daemon to release its port. It used to return early when the port still answered, silently keeping the previous service definition and reporting success.
- `/api/daemon/status` reports `cloudTelemetry`; `restart` uses it to confirm the change took. A daemon too old to report it yields a note, not a failure.
- Verified on a real launchd service: enable → plain restart preserves → disable, plist byte-identical afterwards.
- ADR-0020 supersedes only ADR-0018's reinstall-to-change-the-flag decision.