### PR TITLE
feat: add cloud v1 catalog loader with conditional cache

### DIFF
--- a/apps/ratel-local/src/cloud/catalog.test.ts
+++ b/apps/ratel-local/src/cloud/catalog.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it } from "vitest";
+import {
+  CloudCatalogAuthError,
+  CloudCatalogProtocolError,
+  CloudCatalogUnavailableError,
+  cloudCatalogEndpoint,
+  createCloudCatalogLoader,
+} from "./catalog.js";
+
+const ENDPOINT = "https://cloud.ratel.sh/v1/catalog";
+const VERSION = "6f7f0cee520a24a6edbb6dc7df6b623751cbdf05771e7e7bbe45cc9de943f0a6";
+
+// Shape taken from a real `GET /v1/catalog` against a seeded project; the
+// bodies are truncated because the loader treats them as opaque strings.
+const WIRE = {
+  catalogVersion: VERSION,
+  skills: [
+    {
+      id: "ratel-assessment",
+      name: "ratel-assessment",
+      description: "Read a partner's agent codebase, score it across the 12-dime",
+      tags: [],
+      tools: [],
+      metadata: {},
+      body: "# /ratel-assessment — front-door audit o",
+    },
+  ],
+};
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), { status });
+}
+
+/** Records the requests a loader makes so header behaviour can be asserted. */
+function recordingFetch(...responses: Array<Response | (() => never)>) {
+  const calls: Array<{ url: string; headers: Headers }> = [];
+  let index = 0;
+  const impl = (async (input: URL | RequestInfo, init?: RequestInit) => {
+    calls.push({ url: String(input), headers: new Headers(init?.headers) });
+    const next = responses[Math.min(index++, responses.length - 1)];
+    if (typeof next === "function") next();
+    return next as Response;
+  }) as unknown as typeof fetch;
+  return { calls, impl };
+}
+
+const loader = (fetchImpl: typeof fetch) =>
+  createCloudCatalogLoader({ endpoint: ENDPOINT, apiKey: "rtl_test", fetch: fetchImpl });
+
+describe("cloudCatalogEndpoint", () => {
+  it("requires a secret-free HTTPS URL", () => {
+    expect(cloudCatalogEndpoint(ENDPOINT).toString()).toBe(ENDPOINT);
+    expect(() => cloudCatalogEndpoint("http://localhost:3000/v1/catalog")).toThrow(/HTTPS/);
+    expect(() => cloudCatalogEndpoint("https://user:pw@cloud.ratel.sh/v1/catalog")).toThrow(
+      /HTTPS/,
+    );
+    expect(() => cloudCatalogEndpoint("not a url")).toThrow(/invalid/);
+  });
+});
+
+describe("createCloudCatalogLoader", () => {
+  it("pulls the catalog and maps the wire projection onto engine skills", async () => {
+    const { calls, impl } = recordingFetch(jsonResponse(WIRE));
+    const { snapshot, degraded } = await loader(impl).load();
+
+    expect(degraded).toBeUndefined();
+    expect(snapshot.catalogVersion).toBe(VERSION);
+    expect(snapshot.skills).toEqual(WIRE.skills);
+    expect(calls[0].headers.get("authorization")).toBe("Bearer rtl_test");
+    // Nothing cached yet, so the first pull must be unconditional.
+    expect(calls[0].headers.has("if-none-match")).toBe(false);
+  });
+
+  it("revalidates with If-None-Match and reuses the cache on 304", async () => {
+    const { calls, impl } = recordingFetch(jsonResponse(WIRE), new Response(null, { status: 304 }));
+    const client = loader(impl);
+    const first = await client.load();
+    const second = await client.load();
+
+    expect(calls[1].headers.get("if-none-match")).toBe(`"${VERSION}"`);
+    expect(second.snapshot).toEqual(first.snapshot);
+    expect(second.degraded).toBeUndefined();
+  });
+
+  it("ignores fields the schema lets a source add", async () => {
+    const extra = {
+      ...WIRE,
+      skills: [{ ...WIRE.skills[0], status: "published", updatedAt: "2026-08-25" }],
+    };
+    const { snapshot } = await loader(recordingFetch(jsonResponse(extra)).impl).load();
+    expect(Object.keys(snapshot.skills[0]).sort()).toEqual([
+      "body",
+      "description",
+      "id",
+      "metadata",
+      "name",
+      "tags",
+      "tools",
+    ]);
+  });
+
+  it("serves a stale snapshot when the source becomes unavailable", async () => {
+    const { impl } = recordingFetch(jsonResponse(WIRE), jsonResponse({ error: "nope" }, 503));
+    const client = loader(impl);
+    await client.load();
+    const second = await client.load();
+
+    expect(second.snapshot.catalogVersion).toBe(VERSION);
+    expect(second.degraded).toBe("HTTP 503");
+  });
+
+  it("fails when the source is unavailable and nothing is cached", async () => {
+    const { impl } = recordingFetch(jsonResponse({ error: "nope" }, 503));
+    await expect(loader(impl).load()).rejects.toThrow(CloudCatalogUnavailableError);
+  });
+
+  it("fails on a network error with nothing cached, and degrades with a cache", async () => {
+    const boom = () => {
+      throw new Error("connect ECONNREFUSED");
+    };
+    await expect(loader(recordingFetch(boom).impl).load()).rejects.toThrow(
+      CloudCatalogUnavailableError,
+    );
+
+    const client = loader(recordingFetch(jsonResponse(WIRE), boom).impl);
+    await client.load();
+    expect((await client.load()).degraded).toMatch(/ECONNREFUSED/);
+  });
+
+  it("surfaces an invalid credential even when a snapshot is cached", async () => {
+    const { impl } = recordingFetch(jsonResponse(WIRE), jsonResponse({ error: "nope" }, 401));
+    const client = loader(impl);
+    await client.load();
+    // A revoked key must not hide behind the last good catalog.
+    await expect(client.load()).rejects.toThrow(CloudCatalogAuthError);
+  });
+
+  it("surfaces a contract violation instead of falling back to the cache", async () => {
+    const { impl } = recordingFetch(
+      jsonResponse(WIRE),
+      jsonResponse({ catalogVersion: VERSION, skills: [{ id: "broken" }] }),
+    );
+    const client = loader(impl);
+    await client.load();
+    await expect(client.load()).rejects.toThrow(CloudCatalogProtocolError);
+  });
+
+  it("rejects malformed payloads", async () => {
+    const cases: unknown[] = [
+      { skills: [] },
+      { catalogVersion: VERSION },
+      { catalogVersion: "", skills: [] },
+      { catalogVersion: VERSION, skills: [{ ...WIRE.skills[0], tags: "no" }] },
+      { catalogVersion: VERSION, skills: [{ ...WIRE.skills[0], metadata: { k: [1] } }] },
+    ];
+    for (const body of cases) {
+      await expect(loader(recordingFetch(jsonResponse(body)).impl).load()).rejects.toThrow(
+        CloudCatalogProtocolError,
+      );
+    }
+  });
+
+  it("rejects a 304 that arrives before anything is cached", async () => {
+    const { impl } = recordingFetch(new Response(null, { status: 304 }));
+    await expect(loader(impl).load()).rejects.toThrow(/304 without a cached catalog/);
+  });
+});

--- a/apps/ratel-local/src/cloud/catalog.test.ts
+++ b/apps/ratel-local/src/cloud/catalog.test.ts
@@ -5,9 +5,10 @@ import {
   CloudCatalogUnavailableError,
   cloudCatalogEndpoint,
   createCloudCatalogLoader,
+  DEFAULT_CLOUD_CATALOG_ENDPOINT,
 } from "./catalog.js";
 
-const ENDPOINT = "https://cloud.ratel.sh/v1/catalog";
+const ENDPOINT = DEFAULT_CLOUD_CATALOG_ENDPOINT;
 const VERSION = "6f7f0cee520a24a6edbb6dc7df6b623751cbdf05771e7e7bbe45cc9de943f0a6";
 
 // Shape taken from a real `GET /v1/catalog` against a seeded project; the
@@ -37,7 +38,8 @@ function recordingFetch(...responses: Array<Response | (() => never)>) {
   let index = 0;
   const impl = (async (input: URL | RequestInfo, init?: RequestInit) => {
     calls.push({ url: String(input), headers: new Headers(init?.headers) });
-    const next = responses[Math.min(index++, responses.length - 1)];
+    if (index >= responses.length) throw new Error("no more responses");
+    const next = responses[index++];
     if (typeof next === "function") next();
     return next as Response;
   }) as unknown as typeof fetch;
@@ -59,6 +61,13 @@ describe("cloudCatalogEndpoint", () => {
 });
 
 describe("createCloudCatalogLoader", () => {
+  it("rejects an API key that cannot fit in a header", () => {
+    expect(() => createCloudCatalogLoader({ endpoint: ENDPOINT, apiKey: "" })).toThrow(/header/);
+    expect(() => createCloudCatalogLoader({ endpoint: ENDPOINT, apiKey: "rtl\nkey" })).toThrow(
+      /header/,
+    );
+  });
+
   it("pulls the catalog and maps the wire projection onto engine skills", async () => {
     const { calls, impl } = recordingFetch(jsonResponse(WIRE));
     const { snapshot, degraded } = await loader(impl).load();
@@ -72,7 +81,11 @@ describe("createCloudCatalogLoader", () => {
   });
 
   it("revalidates with If-None-Match and reuses the cache on 304", async () => {
-    const { calls, impl } = recordingFetch(jsonResponse(WIRE), new Response(null, { status: 304 }));
+    const { calls, impl } = recordingFetch(
+      jsonResponse(WIRE),
+      new Response(null, { status: 304 }),
+      new Response(null, { status: 304 }),
+    );
     const client = loader(impl);
     const first = await client.load();
     const second = await client.load();
@@ -80,6 +93,10 @@ describe("createCloudCatalogLoader", () => {
     expect(calls[1].headers.get("if-none-match")).toBe(`"${VERSION}"`);
     expect(second.snapshot).toEqual(first.snapshot);
     expect(second.degraded).toBeUndefined();
+
+    first.snapshot.skills.length = 0;
+    const third = await client.load();
+    expect(third.snapshot.skills).toHaveLength(1);
   });
 
   it("ignores fields the schema lets a source add", async () => {
@@ -127,6 +144,28 @@ describe("createCloudCatalogLoader", () => {
     expect((await client.load()).degraded).toMatch(/ECONNREFUSED/);
   });
 
+  it("degrades when the body read fails after headers, and errors with nothing cached", async () => {
+    const hangingBody = () =>
+      new Response(
+        new ReadableStream({
+          start(controller) {
+            controller.error(new Error("socket hang up"));
+          },
+        }),
+        { status: 200 },
+      );
+
+    await expect(loader(recordingFetch(hangingBody()).impl).load()).rejects.toThrow(
+      CloudCatalogUnavailableError,
+    );
+
+    const client = loader(recordingFetch(jsonResponse(WIRE), hangingBody()).impl);
+    await client.load();
+    const second = await client.load();
+    expect(second.snapshot.catalogVersion).toBe(VERSION);
+    expect(second.degraded).toMatch(/hang up/);
+  });
+
   it("surfaces an invalid credential even when a snapshot is cached", async () => {
     const { impl } = recordingFetch(jsonResponse(WIRE), jsonResponse({ error: "nope" }, 401));
     const client = loader(impl);
@@ -145,6 +184,15 @@ describe("createCloudCatalogLoader", () => {
     await expect(client.load()).rejects.toThrow(CloudCatalogProtocolError);
   });
 
+  it("rejects a skill missing a required wire field", async () => {
+    const { tags: _tags, ...missingTags } = WIRE.skills[0];
+    await expect(
+      loader(
+        recordingFetch(jsonResponse({ catalogVersion: VERSION, skills: [missingTags] })).impl,
+      ).load(),
+    ).rejects.toThrow(/missing tags/);
+  });
+
   it("rejects malformed payloads", async () => {
     const cases: unknown[] = [
       { skills: [] },
@@ -158,6 +206,26 @@ describe("createCloudCatalogLoader", () => {
         CloudCatalogProtocolError,
       );
     }
+  });
+
+  it("rejects a catalogVersion that is not header-safe", async () => {
+    const badVersion = "v1\r\nX-Injected: 1";
+    await expect(
+      loader(recordingFetch(jsonResponse({ ...WIRE, catalogVersion: badVersion })).impl).load(),
+    ).rejects.toThrow(CloudCatalogProtocolError);
+
+    const goodAgain = { ...WIRE, catalogVersion: `${VERSION}ff` };
+    const { impl } = recordingFetch(
+      jsonResponse(WIRE),
+      jsonResponse({ ...WIRE, catalogVersion: badVersion }),
+      jsonResponse(goodAgain),
+    );
+    const client = loader(impl);
+    await client.load();
+    await expect(client.load()).rejects.toThrow(CloudCatalogProtocolError);
+    const third = await client.load();
+    expect(third.snapshot.catalogVersion).toBe(goodAgain.catalogVersion);
+    expect(third.degraded).toBeUndefined();
   });
 
   it("rejects a 304 that arrives before anything is cached", async () => {

--- a/apps/ratel-local/src/cloud/catalog.ts
+++ b/apps/ratel-local/src/cloud/catalog.ts
@@ -1,4 +1,5 @@
 import type { Skill } from "@ratel-ai/sdk";
+import { headerSafeSecret } from "./header-safe-secret.js";
 import { secretFreeHttpsUrl } from "./url.js";
 
 export const DEFAULT_CLOUD_CATALOG_ENDPOINT = "https://cloud.ratel.sh/v1/catalog";
@@ -66,6 +67,7 @@ export function cloudCatalogEndpoint(value: string): URL {
  * acquisition revalidates anyway, and a disk cache would add an offline story
  * the vertical slice does not need.
  * ponytail: daemon-lifetime cache; persistent offline cache deferred.
+ * ponytail: concurrent load() can stampede; ceiling = one in-flight promise.
  *
  * A cached snapshot covers *availability* failures only. An invalid credential
  * or a contract violation always surfaces, so a revoked key cannot hide behind
@@ -73,9 +75,7 @@ export function cloudCatalogEndpoint(value: string): URL {
  */
 export function createCloudCatalogLoader(options: CloudCatalogLoaderOptions) {
   const endpoint = cloudCatalogEndpoint(options.endpoint);
-  if (!options.apiKey.trim() || /[\r\n]/.test(options.apiKey)) {
-    throw new Error("Ratel Cloud API key is required and must fit in an HTTP header");
-  }
+  headerSafeSecret(options.apiKey, "Ratel Cloud API key");
   const fetchUpstream = options.fetch ?? fetch;
   let cached: CloudCatalogSnapshot | undefined;
 
@@ -104,16 +104,28 @@ export function createCloudCatalogLoader(options: CloudCatalogLoaderOptions) {
         if (!cached) {
           throw new CloudCatalogProtocolError("304 without a cached catalog");
         }
-        return { snapshot: cached };
+        return { snapshot: handout(cached) };
       }
       if (response.status !== 200) {
         return degradeOrThrow(cached, `HTTP ${response.status}`);
       }
 
-      cached = parseCatalog(await response.text());
-      return { snapshot: cached };
+      let text: string;
+      try {
+        text = await response.text();
+      } catch (error) {
+        return degradeOrThrow(cached, (error as Error).message);
+      }
+      cached = parseCatalog(text);
+      return { snapshot: handout(cached) };
     },
   };
+}
+
+function handout(snapshot: CloudCatalogSnapshot): CloudCatalogSnapshot {
+  // ponytail: shallow copy guards the cached array; skill objects are still shared,
+  // deep-clone only if a consumer starts mutating them in place.
+  return { catalogVersion: snapshot.catalogVersion, skills: [...snapshot.skills] };
 }
 
 function degradeOrThrow(
@@ -121,7 +133,7 @@ function degradeOrThrow(
   reason: string,
 ): CloudCatalogLoadResult {
   if (!cached) throw new CloudCatalogUnavailableError(reason);
-  return { snapshot: cached, degraded: reason };
+  return { snapshot: handout(cached), degraded: reason };
 }
 
 function parseCatalog(text: string): CloudCatalogSnapshot {
@@ -136,14 +148,19 @@ function parseCatalog(text: string): CloudCatalogSnapshot {
   if (typeof catalogVersion !== "string" || catalogVersion === "") {
     throw new CloudCatalogProtocolError("catalogVersion is missing");
   }
+  if (/[\r\n]/.test(catalogVersion)) {
+    throw new CloudCatalogProtocolError("catalogVersion is not header-safe");
+  }
   if (!Array.isArray(skills)) throw new CloudCatalogProtocolError("skills is not an array");
   return { catalogVersion, skills: skills.map(toSkill) };
 }
 
 /**
- * `CatalogSkillWire` mirrors the engine `Skill` field for field, so this
- * validates rather than remaps. Unknown fields are dropped: the schema allows a
- * source to carry extras, and a conforming client ignores them.
+ * The wire projection is frozen and stricter than the SDK `Skill` type: all
+ * seven fields are required on the wire, while the SDK marks `tags`, `tools`,
+ * `metadata`, and `body` optional. A missing field is a genuine contract
+ * violation. Unknown fields are dropped: the schema allows a source to carry
+ * extras, and a conforming client ignores them.
  */
 function toSkill(value: unknown, index: number): Skill {
   if (!isRecord(value)) throw new CloudCatalogProtocolError(`skill ${index} is not an object`);

--- a/apps/ratel-local/src/cloud/catalog.ts
+++ b/apps/ratel-local/src/cloud/catalog.ts
@@ -1,0 +1,185 @@
+import type { Skill } from "@ratel-ai/sdk";
+import { secretFreeHttpsUrl } from "./url.js";
+
+export const DEFAULT_CLOUD_CATALOG_ENDPOINT = "https://cloud.ratel.sh/v1/catalog";
+
+const TIMEOUT_MS = 10_000;
+
+/** The wire projection `protocol/v1` serves: exactly these seven fields. */
+const WIRE_FIELDS = ["id", "name", "description", "tags", "tools", "metadata", "body"] as const;
+
+/**
+ * One pull of the published Cloud catalog. `catalogVersion` is the source's
+ * ETag, echoed back as `If-None-Match` on the next pull, and is the value a
+ * gateway generation keys on.
+ */
+export interface CloudCatalogSnapshot {
+  catalogVersion: string;
+  skills: Skill[];
+}
+
+export interface CloudCatalogLoadResult {
+  snapshot: CloudCatalogSnapshot;
+  /** Set when the snapshot is a cached one served through an upstream failure. */
+  degraded?: string;
+}
+
+export interface CloudCatalogLoaderOptions {
+  endpoint: string;
+  apiKey: string;
+  /** Injected by tests; the daemon uses the global `fetch`. */
+  fetch?: typeof fetch;
+}
+
+export class CloudCatalogAuthError extends Error {
+  constructor(status: number) {
+    super(`Cloud catalog auth failed: HTTP ${status}`);
+    this.name = "CloudCatalogAuthError";
+  }
+}
+
+export class CloudCatalogProtocolError extends Error {
+  constructor(reason: string) {
+    super(`Ratel Cloud returned a malformed catalog: ${reason}`);
+    this.name = "CloudCatalogProtocolError";
+  }
+}
+
+export class CloudCatalogUnavailableError extends Error {
+  constructor(reason: string) {
+    super(`Ratel Cloud catalog is unavailable and nothing is cached: ${reason}`);
+    this.name = "CloudCatalogUnavailableError";
+  }
+}
+
+// ponytail: the shared guard rejects a query string, which is right while the
+// loader is global-only; a future `?scope=` pull has to relax it for this caller.
+export function cloudCatalogEndpoint(value: string): URL {
+  return secretFreeHttpsUrl(value, "Ratel Cloud catalog endpoint");
+}
+
+/**
+ * Conditional-GET client for the `protocol/v1` catalog pull.
+ *
+ * The cache lives for the life of this loader — a daemon restart re-pulls.
+ * Deliberately: the contract serves `Cache-Control: no-cache`, so every
+ * acquisition revalidates anyway, and a disk cache would add an offline story
+ * the vertical slice does not need.
+ * ponytail: daemon-lifetime cache; persistent offline cache deferred.
+ *
+ * A cached snapshot covers *availability* failures only. An invalid credential
+ * or a contract violation always surfaces, so a revoked key cannot hide behind
+ * the last good catalog indefinitely.
+ */
+export function createCloudCatalogLoader(options: CloudCatalogLoaderOptions) {
+  const endpoint = cloudCatalogEndpoint(options.endpoint);
+  if (!options.apiKey.trim() || /[\r\n]/.test(options.apiKey)) {
+    throw new Error("Ratel Cloud API key is required and must fit in an HTTP header");
+  }
+  const fetchUpstream = options.fetch ?? fetch;
+  let cached: CloudCatalogSnapshot | undefined;
+
+  return {
+    async load() {
+      let response: Response;
+      try {
+        response = await fetchUpstream(endpoint, {
+          method: "GET",
+          headers: {
+            Authorization: `Bearer ${options.apiKey}`,
+            Accept: "application/json",
+            ...(cached ? { "If-None-Match": `"${cached.catalogVersion}"` } : {}),
+          },
+          redirect: "error",
+          signal: AbortSignal.timeout(TIMEOUT_MS),
+        });
+      } catch (error) {
+        return degradeOrThrow(cached, (error as Error).message);
+      }
+
+      if (response.status === 401 || response.status === 403) {
+        throw new CloudCatalogAuthError(response.status);
+      }
+      if (response.status === 304) {
+        if (!cached) {
+          throw new CloudCatalogProtocolError("304 without a cached catalog");
+        }
+        return { snapshot: cached };
+      }
+      if (response.status !== 200) {
+        return degradeOrThrow(cached, `HTTP ${response.status}`);
+      }
+
+      cached = parseCatalog(await response.text());
+      return { snapshot: cached };
+    },
+  };
+}
+
+function degradeOrThrow(
+  cached: CloudCatalogSnapshot | undefined,
+  reason: string,
+): CloudCatalogLoadResult {
+  if (!cached) throw new CloudCatalogUnavailableError(reason);
+  return { snapshot: cached, degraded: reason };
+}
+
+function parseCatalog(text: string): CloudCatalogSnapshot {
+  let body: unknown;
+  try {
+    body = JSON.parse(text);
+  } catch {
+    throw new CloudCatalogProtocolError("response is not JSON");
+  }
+  if (!isRecord(body)) throw new CloudCatalogProtocolError("response is not an object");
+  const { catalogVersion, skills } = body;
+  if (typeof catalogVersion !== "string" || catalogVersion === "") {
+    throw new CloudCatalogProtocolError("catalogVersion is missing");
+  }
+  if (!Array.isArray(skills)) throw new CloudCatalogProtocolError("skills is not an array");
+  return { catalogVersion, skills: skills.map(toSkill) };
+}
+
+/**
+ * `CatalogSkillWire` mirrors the engine `Skill` field for field, so this
+ * validates rather than remaps. Unknown fields are dropped: the schema allows a
+ * source to carry extras, and a conforming client ignores them.
+ */
+function toSkill(value: unknown, index: number): Skill {
+  if (!isRecord(value)) throw new CloudCatalogProtocolError(`skill ${index} is not an object`);
+  for (const field of WIRE_FIELDS) {
+    if (!(field in value)) {
+      throw new CloudCatalogProtocolError(`skill ${index} is missing ${field}`);
+    }
+  }
+  const { id, name, description, tags, tools, metadata, body } = value;
+  if (typeof id !== "string" || id === "") {
+    throw new CloudCatalogProtocolError(`skill ${index} has an invalid id`);
+  }
+  if (typeof name !== "string" || typeof description !== "string" || typeof body !== "string") {
+    throw new CloudCatalogProtocolError(`skill ${id} has an invalid name, description, or body`);
+  }
+  if (!isStringArray(tags) || !isStringArray(tools)) {
+    throw new CloudCatalogProtocolError(`skill ${id} has invalid tags or tools`);
+  }
+  if (!isRecord(metadata) || !Object.values(metadata).every(isStringArray)) {
+    throw new CloudCatalogProtocolError(`skill ${id} has invalid metadata`);
+  }
+  return {
+    id,
+    name,
+    description,
+    tags,
+    tools,
+    metadata: metadata as Record<string, string[]>,
+    body,
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((item) => typeof item === "string");
+}

--- a/apps/ratel-local/src/cloud/header-safe-secret.ts
+++ b/apps/ratel-local/src/cloud/header-safe-secret.ts
@@ -1,0 +1,10 @@
+/**
+ * Bearer credentials (and similar) must be non-empty and free of CR/LF so they
+ * fit in a single HTTP header value without injection.
+ */
+export function headerSafeSecret(value: string, label: string): string {
+  if (!value.trim() || /[\r\n]/.test(value)) {
+    throw new Error(`${label} is required and must fit in an HTTP header`);
+  }
+  return value;
+}

--- a/apps/ratel-local/src/cloud/otlp-trace-relay.ts
+++ b/apps/ratel-local/src/cloud/otlp-trace-relay.ts
@@ -1,4 +1,5 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
+import { secretFreeHttpsUrl } from "./url.js";
 
 export const OTLP_TRACES_PATH = "/otlp/v1/traces";
 export const OTLP_LOGS_PATH = "/otlp/v1/logs";
@@ -198,24 +199,10 @@ function signalForPath(path: string): "traces" | "logs" | undefined {
 }
 
 function parseCloudEndpoint(value: string): URL {
-  let endpoint: URL;
-  try {
-    endpoint = new URL(value);
-  } catch {
-    throw new Error(`Cloud OTLP trace endpoint in ${CLOUD_OTLP_TRACES_ENDPOINT_ENV} is invalid`);
-  }
-  if (
-    endpoint.protocol !== "https:" ||
-    endpoint.username !== "" ||
-    endpoint.password !== "" ||
-    endpoint.search !== "" ||
-    endpoint.hash !== ""
-  ) {
-    throw new Error(
-      `Cloud OTLP trace endpoint in ${CLOUD_OTLP_TRACES_ENDPOINT_ENV} must be a secret-free HTTPS URL`,
-    );
-  }
-  return endpoint;
+  return secretFreeHttpsUrl(
+    value,
+    `Cloud OTLP trace endpoint in ${CLOUD_OTLP_TRACES_ENDPOINT_ENV}`,
+  );
 }
 
 async function readBoundedBody(

--- a/apps/ratel-local/src/cloud/otlp-trace-relay.ts
+++ b/apps/ratel-local/src/cloud/otlp-trace-relay.ts
@@ -1,4 +1,5 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
+import { headerSafeSecret } from "./header-safe-secret.js";
 import { secretFreeHttpsUrl } from "./url.js";
 
 export const OTLP_TRACES_PATH = "/otlp/v1/traces";
@@ -52,9 +53,7 @@ export function cloudOtlpTraceRelayOptions(settings: {
   apiKey: string;
 }): CloudOtlpTraceRelayOptions {
   const endpoint = parseCloudEndpoint(settings.endpoint);
-  if (!settings.apiKey.trim() || /[\r\n]/.test(settings.apiKey)) {
-    throw new Error("Ratel Cloud API key is required and must fit in an HTTP header");
-  }
+  headerSafeSecret(settings.apiKey, "Ratel Cloud API key");
   return {
     endpoint,
     logsEndpoint: deriveCloudOtlpLogsEndpoint(endpoint),

--- a/apps/ratel-local/src/cloud/url.ts
+++ b/apps/ratel-local/src/cloud/url.ts
@@ -1,0 +1,24 @@
+/**
+ * Every Cloud endpoint the daemon holds must be a bare HTTPS URL: TLS because a
+ * Bearer key rides on it, and no userinfo, query, or fragment because those
+ * carry secrets into logs and error messages. `label` names the setting so the
+ * failure points at what the operator has to fix.
+ */
+export function secretFreeHttpsUrl(value: string, label: string): URL {
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    throw new Error(`${label} is invalid`);
+  }
+  if (
+    url.protocol !== "https:" ||
+    url.username !== "" ||
+    url.password !== "" ||
+    url.search !== "" ||
+    url.hash !== ""
+  ) {
+    throw new Error(`${label} must be a secret-free HTTPS URL`);
+  }
+  return url;
+}


### PR DESCRIPTION
## Problem

Ratel Cloud serves a project's published skills at `GET /v1/catalog`, and Ratel Local has no client for it. Nothing in the daemon can read a Cloud catalog.

## Solution

`cloud/catalog.ts`: a conditional-GET client for the `protocol/v1` pull.

- Stores the `catalogVersion` the source issues and echoes it back as `If-None-Match`. A `304` reuses the cached snapshot (handed out as a shallow copy so callers cannot mutate the cache array).
- Maps the seven required wire fields onto the engine `Skill`. The wire projection is frozen and stricter than the SDK `Skill` type (which marks `tags`, `tools`, `metadata`, and `body` optional): a missing field is a contract violation. Unknown fields the schema lets a source add are dropped.
- Global layer only, v1 only. A scoped pull is out of scope: `?scope=` publishes are not served by the sync today.
- Cache lives for the life of the loader. The contract sends `Cache-Control: no-cache`, so every acquisition revalidates anyway.

Failure taxonomy:

| upstream | with a cached snapshot | with none |
| ----------------------- | ---------------------------- | ----------------- |
| `200` | replace | replace |
| `304` | reuse | protocol error |
| `401` / `403` | **hard failure** | hard failure |
| `5xx`, network, timeout (including mid-body / body-read failures) | stale snapshot + degradation | unavailable error |
| malformed `200` | **protocol error** | protocol error |

The cache covers availability, never an invalid credential or a broken contract.
A revoked key must not hide behind the last good catalog.

`cloud/url.ts` extracts the secret-free-HTTPS check the relay already performed, now shared by both callers. `cloud/header-safe-secret.ts` shares the API-key header-safety guard between the catalog loader and the OTLP relay.

## Notes

- Nothing imports the loader yet: it ships dark, and lands behind `RATEL_FEATURE_CLOUD_CATALOG` when the credential plumbing follows.
- `protocol/v1/conformance/verify.mjs` is **not** the oracle here. Its `If-None-Match` vectors pin source-side matcher behaviour and its `etag` vectors pin the canonicalisation algorithm; a loader implements neither. Its fixtures are still useful, its assertions are not applicable.
- Verified against the live source as well as a stubbed `fetch`: two consecutive loads against a seeded project returned the five published skills, the second carrying `If-None-Match` and reusing the cached snapshot by value.
- The shared URL guard rejects a query string, which is correct while the loader is global-only; a future `?scope=` pull must relax it for that caller. Marked at the call site.