### PR TITLE
feat: serve published Cloud skills through the gateway

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this package are documented here. The format is based on 
 
 ## [Unreleased]
 
+### Added
+- Added the off-by-default `RATEL_FEATURE_CLOUD_CATALOG=1` daemon flag. When it
+  is on, the daemon pulls published Cloud skills into the snapshot using the
+  saved Cloud API key. Local skills of the same id win; a failed pull warns.
+- Added context snapshot diagnostics in the UI shell so catalog and other
+  resolve warnings are visible without failing the page.
+
 ### Changed
 - Made `daemon restart` reconfigure the Cloud telemetry feature flag in an
   installed launchd or systemd service when `RATEL_FEATURE_CLOUD_TELEMETRY` is
@@ -11,12 +18,17 @@ All notable changes to this package are documented here. The format is based on 
   absent preserves). Restart now waits for the stopped daemon to release its
   port, and confirms the restarted daemon adopted the change through the new
   `cloudTelemetry` field on `/api/daemon/status`.
+- Made `daemon restart` reconfigure `RATEL_FEATURE_CLOUD_CATALOG` the same way,
+  independently of Cloud telemetry, and confirm the result through
+  `cloudCatalog` on `/api/daemon/status`.
 
 ### Removed
 - Removed the deprecated `search_tools` alias from MCP discovery and call dispatch. Agents now have a single capability-search entry point: `search_capabilities`.
 
 ### Fixed
 - Removed duplicate upstream metadata from capability search responses: Ratel keeps `server.description` and omits `server.instructions` only when their strings are exactly equal; distinct metadata remains unchanged.
+- Held a rejected Cloud catalog API key for 60 seconds after HTTP 401 or 403,
+  so a revoked key is not retried on every context resolve.
 
 ## [0.8.2] - 2026-08-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ All notable changes to this package are documented here. The format is based on 
 - Made `daemon restart` reconfigure `RATEL_FEATURE_CLOUD_CATALOG` the same way,
   independently of Cloud telemetry, and confirm the result through
   `cloudCatalog` on `/api/daemon/status`.
+- Raised how long `daemon install`, `daemon start` and `daemon restart`
+  wait for healthy status from 5 to 15 seconds.
 
 ### Removed
 - Removed the deprecated `search_tools` alias from MCP discovery and call dispatch. Agents now have a single capability-search entry point: `search_capabilities`.
@@ -29,6 +31,8 @@ All notable changes to this package are documented here. The format is based on 
 - Removed duplicate upstream metadata from capability search responses: Ratel keeps `server.description` and omits `server.instructions` only when their strings are exactly equal; distinct metadata remains unchanged.
 - Held a rejected Cloud catalog API key for 60 seconds after HTTP 401 or 403,
   so a revoked key is not retried on every context resolve.
+- Held an unreachable Cloud catalog for 10 seconds when nothing is cached, so an
+  unavailable source is not retried on every context resolve.
 
 ## [0.8.2] - 2026-08-19
 

--- a/README.md
+++ b/README.md
@@ -202,6 +202,33 @@ the variable leaves an installed daemon unchanged. See the [Cloud OTLP relay and
 contract](docs/cloud-otlp-relay.md) for privacy levels, precedence, failure
 behavior, and rollback instructions.
 
+### Experimental Cloud skill catalog
+
+A project's skills published to Ratel Cloud can join the locally resolved skill
+set, served through the same gateway and the same capability search as local
+ones. Off by default:
+
+```bash
+# New installation
+RATEL_FEATURE_CLOUD_CATALOG=1 ratel-local setup
+
+# Existing installed daemon
+RATEL_FEATURE_CLOUD_CATALOG=1 ratel-local daemon restart
+
+# Disable
+RATEL_FEATURE_CLOUD_CATALOG=0 ratel-local daemon restart
+```
+
+The flag follows same flag semantics as Cloud telemetry above, and the two are independent.
+
+The catalog reuses the credential the trace relay stores in
+`~/.ratel/cloud-traces.json`, read on every pull, so a rotated key applies
+without a restart.
+
+A local skill with the same id wins, and the shadowed Cloud one is reported as a
+warning in the daemon UI. An unreachable or stale catalog is a warning too, never
+a failed context resolve.
+
 ### Verify capability search
 
 Ask the agent to call Ratel Local explicitly:

--- a/apps/ratel-local/src/cli/handlers/daemon-startup.test.ts
+++ b/apps/ratel-local/src/cli/handlers/daemon-startup.test.ts
@@ -81,8 +81,7 @@ describe("daemon startup budget", () => {
 
     const callsAt: number[] = [];
     const started = Date.now();
-    // Cloud accepts the connection and never answers: only the loader's own
-    // AbortSignal.timeout(10s) ends the request.
+    // Hang until the loader's AbortSignal.timeout fires.
     const catalogFetch = vi.fn(
       (_input: string | URL | Request, init?: RequestInit) =>
         new Promise<Response>((_resolve, reject) => {
@@ -121,8 +120,7 @@ describe("daemon startup budget", () => {
     const bootMs = Date.now() - started;
     try {
       expect(healthyWithin5s).toBeDefined();
-      // The migration resolves the global context plus every registered project;
-      // one catalog pull each would overrun the budget on its own.
+      // Migration must not pull: one timeout per registered context would miss the budget.
       expect(catalogFetch).not.toHaveBeenCalled();
       expect(bootMs).toBeLessThan(5_000);
       expect(callsAt).toEqual([]);

--- a/apps/ratel-local/src/cli/handlers/daemon-startup.test.ts
+++ b/apps/ratel-local/src/cli/handlers/daemon-startup.test.ts
@@ -8,7 +8,7 @@ import { describe, expect, it, vi } from "vitest";
 import { CLOUD_CATALOG_FEATURE_ENV } from "../../feature-flags.js";
 import type { ParsedArgs } from "../args.js";
 import { silentPromptAdapter } from "../prompts.js";
-import { runDaemon } from "./daemon.js";
+import { DAEMON_STARTUP_BUDGET_MS, runDaemon } from "./daemon.js";
 import { createTestPreparedChanges } from "./test-prepared-changes.js";
 import type { HandlerCtx } from "./types.js";
 
@@ -53,7 +53,7 @@ async function freePort(): Promise<number> {
   return port;
 }
 
-/** The same 5s /healthz poll `waitForDaemon` runs after launchd/systemd starts the daemon. */
+/** The same /healthz poll `waitForDaemon` runs after launchd/systemd starts the daemon. */
 async function pollHealthz(port: number, timeoutMs: number): Promise<number | undefined> {
   const started = Date.now();
   while (Date.now() - started < timeoutMs) {
@@ -69,7 +69,7 @@ async function pollHealthz(port: number, timeoutMs: number): Promise<number | un
 }
 
 describe("daemon startup budget", () => {
-  it("serves /healthz within the restart budget while Cloud hangs", async () => {
+  it("pulls the catalog once for every context the OAuth migration resolves", async () => {
     const homeDir = await mkdtemp(join(tmpdir(), "ratel-startup-repro-"));
     const projectA = join(homeDir, "project-a");
     const projectB = join(homeDir, "project-b");
@@ -79,18 +79,11 @@ describe("daemon startup budget", () => {
     await registry.registerRoot(projectA);
     await registry.registerRoot(projectB);
 
-    const callsAt: number[] = [];
     const started = Date.now();
-    // Hang until the loader's AbortSignal.timeout fires.
-    const catalogFetch = vi.fn(
-      (_input: string | URL | Request, init?: RequestInit) =>
-        new Promise<Response>((_resolve, reject) => {
-          callsAt.push(Date.now() - started);
-          init?.signal?.addEventListener("abort", () =>
-            reject(new DOMException("The operation was aborted.", "TimeoutError")),
-          );
-        }),
-    );
+    const catalogFetch = vi.fn(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      return new Response(JSON.stringify({ catalogVersion: "v1", skills: [] }), { status: 200 });
+    });
 
     const port = await freePort();
     const fs = new MemFs();
@@ -115,15 +108,14 @@ describe("daemon startup budget", () => {
       },
     );
 
-    const healthyWithin5s = await pollHealthz(port, 5_000);
+    const healthy = await pollHealthz(port, DAEMON_STARTUP_BUDGET_MS);
     const result = await booting;
     const bootMs = Date.now() - started;
     try {
-      expect(healthyWithin5s).toBeDefined();
-      // Migration must not pull: one timeout per registered context would miss the budget.
-      expect(catalogFetch).not.toHaveBeenCalled();
-      expect(bootMs).toBeLessThan(5_000);
-      expect(callsAt).toEqual([]);
+      expect(healthy).toBeDefined();
+      // Three contexts — the global one plus two projects — sharing one request.
+      expect(catalogFetch).toHaveBeenCalledTimes(1);
+      expect(bootMs).toBeLessThan(DAEMON_STARTUP_BUDGET_MS);
     } finally {
       await result.shutdown?.();
       await rm(homeDir, { recursive: true, force: true });

--- a/apps/ratel-local/src/cli/handlers/daemon-startup.test.ts
+++ b/apps/ratel-local/src/cli/handlers/daemon-startup.test.ts
@@ -1,0 +1,134 @@
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { createServer } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { BackupFs, HierarchyEnv, JsonFs } from "@ratel-ai/ratel-local-core";
+import { createProjectRegistry } from "@ratel-ai/ratel-local-core";
+import { describe, expect, it, vi } from "vitest";
+import { CLOUD_CATALOG_FEATURE_ENV } from "../../feature-flags.js";
+import type { ParsedArgs } from "../args.js";
+import { silentPromptAdapter } from "../prompts.js";
+import { runDaemon } from "./daemon.js";
+import { createTestPreparedChanges } from "./test-prepared-changes.js";
+import type { HandlerCtx } from "./types.js";
+
+class MemFs implements BackupFs, JsonFs {
+  files = new Map<string, string>();
+  async read(path: string) {
+    return this.files.get(path) ?? null;
+  }
+  async write(path: string, content: string) {
+    this.files.set(path, content);
+  }
+  async writeAtomic(path: string, content: string) {
+    this.files.set(path, content);
+  }
+  async remove(path: string) {
+    this.files.delete(path);
+  }
+  async mkdirp() {}
+  async exists(path: string) {
+    return this.files.has(path);
+  }
+  async list() {
+    return [];
+  }
+}
+
+function makeCtx(fs: MemFs, env: HierarchyEnv): HandlerCtx {
+  return {
+    argv: { group: "daemon", configPaths: [], rest: [], extras: [], flags: {} } as ParsedArgs,
+    env,
+    fs,
+    log: () => {},
+    prompts: silentPromptAdapter(),
+  };
+}
+
+async function freePort(): Promise<number> {
+  const server = createServer();
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const { port } = server.address() as { port: number };
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+  return port;
+}
+
+/** The same 5s /healthz poll `waitForDaemon` runs after launchd/systemd starts the daemon. */
+async function pollHealthz(port: number, timeoutMs: number): Promise<number | undefined> {
+  const started = Date.now();
+  while (Date.now() - started < timeoutMs) {
+    try {
+      const res = await fetch(`http://127.0.0.1:${port}/healthz`);
+      if (res.ok) return Date.now() - started;
+    } catch {
+      // daemon not listening yet
+    }
+    await new Promise((resolve) => setTimeout(resolve, 150));
+  }
+  return undefined;
+}
+
+describe("daemon startup budget", () => {
+  it("serves /healthz within the restart budget while Cloud hangs", async () => {
+    const homeDir = await mkdtemp(join(tmpdir(), "ratel-startup-repro-"));
+    const projectA = join(homeDir, "project-a");
+    const projectB = join(homeDir, "project-b");
+    await mkdir(projectA, { recursive: true });
+    await mkdir(projectB, { recursive: true });
+    const registry = createProjectRegistry({ homeDir });
+    await registry.registerRoot(projectA);
+    await registry.registerRoot(projectB);
+
+    const callsAt: number[] = [];
+    const started = Date.now();
+    // Cloud accepts the connection and never answers: only the loader's own
+    // AbortSignal.timeout(10s) ends the request.
+    const catalogFetch = vi.fn(
+      (_input: string | URL | Request, init?: RequestInit) =>
+        new Promise<Response>((_resolve, reject) => {
+          callsAt.push(Date.now() - started);
+          init?.signal?.addEventListener("abort", () =>
+            reject(new DOMException("The operation was aborted.", "TimeoutError")),
+          );
+        }),
+    );
+
+    const port = await freePort();
+    const fs = new MemFs();
+    const ctx = makeCtx(fs, { homeDir, projectRoot: projectA });
+    const booting = runDaemon(
+      {
+        group: "daemon",
+        configPaths: [],
+        rest: [],
+        extras: [],
+        flags: { open: false, telemetry: "off", port: String(port) },
+      } as ParsedArgs,
+      ctx,
+      { processEnv: { [CLOUD_CATALOG_FEATURE_ENV]: "1", RATEL_API_KEY: "rtl_repro" } },
+      () => {},
+      {
+        open: () => {},
+        ensureToken: async () => "daemon-test-token",
+        cloudCatalogFetch: catalogFetch as unknown as typeof fetch,
+        cloudTraceSettingsStore: { load: async () => undefined, save: async () => {} },
+        preparedChanges: createTestPreparedChanges(fs),
+      },
+    );
+
+    const healthyWithin5s = await pollHealthz(port, 5_000);
+    const result = await booting;
+    const bootMs = Date.now() - started;
+    try {
+      expect(healthyWithin5s).toBeDefined();
+      // The migration resolves the global context plus every registered project;
+      // one catalog pull each would overrun the budget on its own.
+      expect(catalogFetch).not.toHaveBeenCalled();
+      expect(bootMs).toBeLessThan(5_000);
+      expect(callsAt).toEqual([]);
+    } finally {
+      await result.shutdown?.();
+      await rm(homeDir, { recursive: true, force: true });
+    }
+  }, 90_000);
+});

--- a/apps/ratel-local/src/cli/handlers/daemon.test.ts
+++ b/apps/ratel-local/src/cli/handlers/daemon.test.ts
@@ -345,8 +345,6 @@ describe("runDaemon", () => {
 
       expect(config.status).toBe(200);
       expect(catalogFetch).toHaveBeenCalled();
-      // The credential reached the catalog without enabling telemetry: the relay
-      // route stays absent and the settings endpoint still reports it unconfigured.
       const relay = await fetch(new URL("/otlp/v1/traces", daemonUrl), {
         method: "POST",
         headers: { "Content-Type": "application/x-protobuf" },
@@ -970,7 +968,7 @@ describe("runDaemon", () => {
       homeDir: HOME,
       port: DEFAULT_DAEMON_PORT,
       pathEnv: "/opt/node/bin:/usr/bin:/bin",
-      featureFlags: { cloudTelemetry: true, cloudCatalog: false },
+      featureFlags: { cloudTelemetry: true },
     });
 
     expect(plist).toContain("<key>EnvironmentVariables</key>");
@@ -1069,7 +1067,7 @@ describe("runDaemon", () => {
         homeDir: HOME,
         port: DEFAULT_DAEMON_PORT,
         pathEnv,
-        featureFlags: { cloudTelemetry: false, cloudCatalog: false },
+        featureFlags: { cloudTelemetry: false },
       };
       fs.files.set(
         servicePath,
@@ -1122,7 +1120,7 @@ describe("runDaemon", () => {
         homeDir: HOME,
         port: DEFAULT_DAEMON_PORT,
         pathEnv,
-        featureFlags: { cloudTelemetry: true, cloudCatalog: false },
+        featureFlags: { cloudTelemetry: true },
       };
       const original =
         platform === "linux" ? createSystemdUserService(input) : createLaunchAgentPlist(input);
@@ -1166,7 +1164,7 @@ describe("runDaemon", () => {
         homeDir: HOME,
         port: DEFAULT_DAEMON_PORT,
         pathEnv,
-        featureFlags: { cloudTelemetry: true, cloudCatalog: false },
+        featureFlags: { cloudTelemetry: true },
       };
       fs.files.set(
         servicePath,
@@ -1200,7 +1198,7 @@ describe("runDaemon", () => {
       executablePath: "/opt/bin/ratel-local",
       homeDir: HOME,
       port: DEFAULT_DAEMON_PORT,
-      featureFlags: { cloudTelemetry: true, cloudCatalog: false },
+      featureFlags: { cloudTelemetry: true },
     });
     fs.files.set(paths.systemdService, original);
     const commands: Array<{ command: string; args: string[] }> = [];
@@ -1298,7 +1296,7 @@ describe("runDaemon", () => {
       executablePath: "/opt/bin/ratel-local",
       homeDir: HOME,
       port: DEFAULT_DAEMON_PORT,
-      featureFlags: { cloudTelemetry: false, cloudCatalog: false },
+      featureFlags: { cloudTelemetry: false },
     });
 
   const restartWithProbe = (
@@ -1387,7 +1385,7 @@ describe("runDaemon", () => {
         executablePath: "/opt/bin/ratel-local",
         homeDir: HOME,
         port: DEFAULT_DAEMON_PORT,
-        featureFlags: { cloudTelemetry: false, cloudCatalog: false },
+        featureFlags: { cloudTelemetry: false },
       };
       fs.files.set(
         servicePath,
@@ -1584,7 +1582,7 @@ describe("runDaemon", () => {
       homeDir: HOME,
       port: DEFAULT_DAEMON_PORT,
       pathEnv: "/opt/node/bin:/usr/bin:/bin",
-      featureFlags: { cloudTelemetry: true, cloudCatalog: false },
+      featureFlags: { cloudTelemetry: true },
     });
 
     expect(service).toContain("Environment=PATH=/opt/node/bin:/usr/bin:/bin");

--- a/apps/ratel-local/src/cli/handlers/daemon.test.ts
+++ b/apps/ratel-local/src/cli/handlers/daemon.test.ts
@@ -12,7 +12,7 @@ import type { BackupFs, HierarchyEnv, JsonFs } from "@ratel-ai/ratel-local-core"
 import { projectIdFromCanonicalRoot } from "@ratel-ai/ratel-local-core";
 import { describe, expect, it, vi } from "vitest";
 import { connectorHeaders } from "../../daemon/access.js";
-import { CLOUD_TELEMETRY_FEATURE_ENV } from "../../feature-flags.js";
+import { CLOUD_CATALOG_FEATURE_ENV, CLOUD_TELEMETRY_FEATURE_ENV } from "../../feature-flags.js";
 import type { ParsedArgs } from "../args.js";
 import { silentPromptAdapter } from "../prompts.js";
 import {
@@ -309,6 +309,54 @@ describe("runDaemon", () => {
       expect(configureRatelTelemetry).not.toHaveBeenCalled();
       expect(cloudFetch).not.toHaveBeenCalled();
       expect(daemonProcessEnv).not.toHaveProperty("RATEL_API_KEY");
+    } finally {
+      await result.shutdown?.();
+    }
+  });
+
+  it("pulls the Cloud catalog with the environment credential while the relay stays off", async () => {
+    const fs = new MemFs();
+    const logs: string[] = [];
+    const catalogFetch = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ catalogVersion: "v1", skills: [] }), { status: 200 }),
+    );
+    const result = await runDaemon(
+      daemonArgs(),
+      makeCtx(fs),
+      {
+        readConfig: async () => ({ mcpServers: {} }),
+        processEnv: { [CLOUD_CATALOG_FEATURE_ENV]: "1", RATEL_API_KEY: "rtl_env" },
+      },
+      (message) => logs.push(message),
+      {
+        open: () => {},
+        ensureToken: async () => "daemon-test-token",
+        cloudCatalogFetch: catalogFetch,
+        cloudTraceSettingsStore: { load: async () => undefined, save: async () => {} },
+      },
+    );
+    const daemonUrl = daemonUrlFromLogs(logs);
+
+    try {
+      const config = await fetch(new URL("/api/config", daemonUrl), {
+        headers: { Authorization: "Bearer daemon-test-token" },
+      });
+
+      expect(config.status).toBe(200);
+      expect(catalogFetch).toHaveBeenCalled();
+      // The credential reached the catalog without enabling telemetry: the relay
+      // route stays absent and the settings endpoint still reports it unconfigured.
+      const relay = await fetch(new URL("/otlp/v1/traces", daemonUrl), {
+        method: "POST",
+        headers: { "Content-Type": "application/x-protobuf" },
+        body: Buffer.from([0x0a, 0x00]),
+      });
+      expect(relay.status).toBe(404);
+      const status = await fetch(new URL("/api/cloud-traces", daemonUrl), {
+        headers: { Authorization: "Bearer daemon-test-token" },
+      });
+      expect(await status.json()).toMatchObject({ featureEnabled: false, configured: false });
     } finally {
       await result.shutdown?.();
     }

--- a/apps/ratel-local/src/cli/handlers/daemon.test.ts
+++ b/apps/ratel-local/src/cli/handlers/daemon.test.ts
@@ -16,8 +16,6 @@ import { CLOUD_TELEMETRY_FEATURE_ENV } from "../../feature-flags.js";
 import type { ParsedArgs } from "../args.js";
 import { silentPromptAdapter } from "../prompts.js";
 import {
-  applyCloudTelemetryToLaunchAgentPlist,
-  applyCloudTelemetryToSystemdUserService,
   createLaunchAgentPlist,
   createSystemdUserService,
   DAEMON_INSTALL_PATH_ENV,
@@ -924,7 +922,7 @@ describe("runDaemon", () => {
       homeDir: HOME,
       port: DEFAULT_DAEMON_PORT,
       pathEnv: "/opt/node/bin:/usr/bin:/bin",
-      featureFlags: { cloudTelemetry: true },
+      featureFlags: { cloudTelemetry: true, cloudCatalog: false },
     });
 
     expect(plist).toContain("<key>EnvironmentVariables</key>");
@@ -1012,57 +1010,6 @@ describe("runDaemon", () => {
     expect(fs.files.get(paths.plist)).toBe(original);
   });
 
-  it("refuses to enable Cloud telemetry in an unrecognised service file", () => {
-    expect(() => applyCloudTelemetryToLaunchAgentPlist("<plist />", true)).toThrow(
-      /not a Ratel Local unit/,
-    );
-    expect(() => applyCloudTelemetryToSystemdUserService("[Service]\n", true)).toThrow(
-      /not a Ratel Local unit/,
-    );
-    // Disabling stays a no-op there: there is no Ratel route to remove.
-    expect(applyCloudTelemetryToLaunchAgentPlist("<plist />", false)).toBe("<plist />");
-    expect(applyCloudTelemetryToSystemdUserService("[Service]\n", false)).toBe("[Service]\n");
-  });
-
-  // Without `pathEnv` the flag is the only environment entry, so enabling has to
-  // create the dict from scratch and disabling has to remove it again. That is
-  // the shape an install performs when PATH is unset in its environment.
-  for (const pathEnv of ["/opt/node/bin:/usr/bin:/bin", undefined]) {
-    it(`round-trips Cloud telemetry flag edits against generated service files (pathEnv: ${pathEnv ? "set" : "unset"})`, () => {
-      const base = {
-        executablePath: "/opt/bin/ratel-local",
-        homeDir: HOME,
-        port: DEFAULT_DAEMON_PORT,
-        ...(pathEnv ? { pathEnv } : {}),
-      };
-      const disabledPlist = createLaunchAgentPlist({
-        ...base,
-        featureFlags: { cloudTelemetry: false },
-      });
-      const enabledPlist = createLaunchAgentPlist({
-        ...base,
-        featureFlags: { cloudTelemetry: true },
-      });
-      expect(applyCloudTelemetryToLaunchAgentPlist(disabledPlist, true)).toBe(enabledPlist);
-      expect(applyCloudTelemetryToLaunchAgentPlist(enabledPlist, false)).toBe(disabledPlist);
-      expect(applyCloudTelemetryToLaunchAgentPlist(enabledPlist, true)).toBe(enabledPlist);
-      expect(applyCloudTelemetryToLaunchAgentPlist(disabledPlist, false)).toBe(disabledPlist);
-
-      const disabledUnit = createSystemdUserService({
-        ...base,
-        featureFlags: { cloudTelemetry: false },
-      });
-      const enabledUnit = createSystemdUserService({
-        ...base,
-        featureFlags: { cloudTelemetry: true },
-      });
-      expect(applyCloudTelemetryToSystemdUserService(disabledUnit, true)).toBe(enabledUnit);
-      expect(applyCloudTelemetryToSystemdUserService(enabledUnit, false)).toBe(disabledUnit);
-      expect(applyCloudTelemetryToSystemdUserService(enabledUnit, true)).toBe(enabledUnit);
-      expect(applyCloudTelemetryToSystemdUserService(disabledUnit, false)).toBe(disabledUnit);
-    });
-  }
-
   for (const platform of ["darwin", "linux"] as const) {
     it(`enables Cloud telemetry on ${platform} restart when the flag is explicitly set`, async () => {
       const fs = new MemFs();
@@ -1074,7 +1021,7 @@ describe("runDaemon", () => {
         homeDir: HOME,
         port: DEFAULT_DAEMON_PORT,
         pathEnv,
-        featureFlags: { cloudTelemetry: false },
+        featureFlags: { cloudTelemetry: false, cloudCatalog: false },
       };
       fs.files.set(
         servicePath,
@@ -1127,7 +1074,7 @@ describe("runDaemon", () => {
         homeDir: HOME,
         port: DEFAULT_DAEMON_PORT,
         pathEnv,
-        featureFlags: { cloudTelemetry: true },
+        featureFlags: { cloudTelemetry: true, cloudCatalog: false },
       };
       const original =
         platform === "linux" ? createSystemdUserService(input) : createLaunchAgentPlist(input);
@@ -1171,7 +1118,7 @@ describe("runDaemon", () => {
         homeDir: HOME,
         port: DEFAULT_DAEMON_PORT,
         pathEnv,
-        featureFlags: { cloudTelemetry: true },
+        featureFlags: { cloudTelemetry: true, cloudCatalog: false },
       };
       fs.files.set(
         servicePath,
@@ -1205,7 +1152,7 @@ describe("runDaemon", () => {
       executablePath: "/opt/bin/ratel-local",
       homeDir: HOME,
       port: DEFAULT_DAEMON_PORT,
-      featureFlags: { cloudTelemetry: true },
+      featureFlags: { cloudTelemetry: true, cloudCatalog: false },
     });
     fs.files.set(paths.systemdService, original);
     const commands: Array<{ command: string; args: string[] }> = [];
@@ -1303,7 +1250,7 @@ describe("runDaemon", () => {
       executablePath: "/opt/bin/ratel-local",
       homeDir: HOME,
       port: DEFAULT_DAEMON_PORT,
-      featureFlags: { cloudTelemetry: false },
+      featureFlags: { cloudTelemetry: false, cloudCatalog: false },
     });
 
   const restartWithProbe = (
@@ -1378,9 +1325,9 @@ describe("runDaemon", () => {
 
     await restartWithProbe(fs, restartStatusProbe(undefined), logs);
 
-    expect(logs.some((message) => message.includes("could not confirm Cloud telemetry"))).toBe(
-      true,
-    );
+    expect(
+      logs.some((message) => message.includes("could not confirm the requested feature flags")),
+    ).toBe(true);
   });
 
   for (const platform of ["darwin", "linux"] as const) {
@@ -1392,7 +1339,7 @@ describe("runDaemon", () => {
         executablePath: "/opt/bin/ratel-local",
         homeDir: HOME,
         port: DEFAULT_DAEMON_PORT,
-        featureFlags: { cloudTelemetry: false },
+        featureFlags: { cloudTelemetry: false, cloudCatalog: false },
       };
       fs.files.set(
         servicePath,
@@ -1589,7 +1536,7 @@ describe("runDaemon", () => {
       homeDir: HOME,
       port: DEFAULT_DAEMON_PORT,
       pathEnv: "/opt/node/bin:/usr/bin:/bin",
-      featureFlags: { cloudTelemetry: true },
+      featureFlags: { cloudTelemetry: true, cloudCatalog: false },
     });
 
     expect(service).toContain("Environment=PATH=/opt/node/bin:/usr/bin:/bin");

--- a/apps/ratel-local/src/cli/handlers/daemon.ts
+++ b/apps/ratel-local/src/cli/handlers/daemon.ts
@@ -33,6 +33,7 @@ import {
   type TelemetryHandle,
   type TelemetryInitOptions,
 } from "@ratel-ai/telemetry-otlp";
+import { createCloudCatalogSource } from "../../cloud/catalog.js";
 import {
   CLOUD_API_KEY_ENV,
   type CloudOtlpTraceRelayOptions,
@@ -76,6 +77,8 @@ import {
   featureFlagOverridesFromEnv,
   featureFlagServiceEnvironment,
   featureFlagsFromEnv,
+  SERVICE_FEATURE_FLAG_ENVS,
+  type ServiceFeatureFlagOverrides,
 } from "../../feature-flags.js";
 import { openBrowser } from "../../ui/open-browser.js";
 import { InMemoryUiSessionTokens, newSessionToken } from "../../ui/security.js";
@@ -170,6 +173,7 @@ interface DaemonHandlerDeps {
   skillRegistrationControlPlane?: SkillRegistrationControlPlane;
   preparedChanges?: PreparedChangeCoordinator;
   cloudOtlpFetch?: typeof fetch;
+  cloudCatalogFetch?: typeof fetch;
   configureRatelTelemetry?: ConfigureRatelTelemetry;
   cloudTraceSettingsStore?: CloudTraceSettingsStoreLike;
   lifecycleProgress?: boolean;
@@ -368,9 +372,6 @@ export async function runDaemonServer(
   const projectAdmissionLock = createProjectAdmissionLock({
     controlDir: join(ctx.env.homeDir, ".ratel"),
   });
-  const snapshotResolver =
-    opts.snapshotResolver ??
-    createContextSnapshotResolver({ homeDir: ctx.env.homeDir, projectRegistry });
   const serverVersion = options.serverVersion ?? "0.0.0";
   const daemonProcessEnv = options.processEnv ?? process.env;
   const featureFlags = featureFlagsFromEnv(daemonProcessEnv);
@@ -386,6 +387,12 @@ export async function runDaemonServer(
       log(`[ratel] ignored invalid Cloud trace settings: ${(error as Error).message}`);
     }
   }
+  // Catalog pulls after the strip below; hold the env credential so they still
+  // see it. Subprocesses must not inherit `RATEL_API_KEY`.
+  const environmentApiKey =
+    featureFlags.cloudTelemetry || featureFlags.cloudCatalog
+      ? daemonProcessEnv[CLOUD_API_KEY_ENV]
+      : undefined;
   let environmentCloudOptions: CloudOtlpTraceRelayOptions | undefined;
   try {
     if (featureFlags.cloudTelemetry) {
@@ -418,6 +425,20 @@ export async function runDaemonServer(
       log(`[ratel] Ratel runtime telemetry disabled: ${(error as Error).message}`);
     }
   };
+  const cloudCatalog = featureFlags.cloudCatalog
+    ? createCloudCatalogSource({
+        apiKey: async () => environmentApiKey ?? (await cloudTraceSettingsStore.load())?.apiKey,
+        log,
+        ...(opts.cloudCatalogFetch ? { fetch: opts.cloudCatalogFetch } : {}),
+      })
+    : undefined;
+  const snapshotResolver =
+    opts.snapshotResolver ??
+    createContextSnapshotResolver({
+      homeDir: ctx.env.homeDir,
+      projectRegistry,
+      ...(cloudCatalog ? { cloudCatalog } : {}),
+    });
   const daemonToken = await (opts.ensureToken ?? ensureDaemonToken)(ctx.env.homeDir);
   const generationPool = new InMemoryScopedGatewayPool(async (scope) => {
     if (scope.resolvedContext) {
@@ -972,15 +993,15 @@ WantedBy=default.target
 }
 
 /**
- * Apply an explicit Cloud telemetry override to the installed service file.
- * Returns the applied value, or `undefined` when nothing was written — no
+ * Apply explicit feature-flag overrides to the installed service file.
+ * Returns the applied overrides, or `undefined` when nothing was named — no
  * override in the environment, or no installed service to rewrite.
  */
 async function reconfigureInstalledServiceFeatureFlags(
   ctx: HandlerCtx,
   options: ServeOptions,
   opts: DaemonHandlerDeps,
-): Promise<Readonly<Record<string, boolean>> | undefined> {
+): Promise<ServiceFeatureFlagOverrides | undefined> {
   const overrides = featureFlagOverridesFromEnv(options.processEnv ?? process.env);
   if (Object.keys(overrides).length === 0) return undefined;
   const platform = daemonPlatform(opts);
@@ -999,30 +1020,32 @@ async function reconfigureInstalledServiceFeatureFlags(
   return overrides;
 }
 
-/**
- * Confirm the restarted daemon actually runs with the flag we just wrote.
- * Rewriting the service file is not proof: launchd or systemd may still be
- * serving the previous definition. Throws on a mismatch; returns a note when
- * the running daemon is too old to report the flag at all.
- */
 /** Which status field reports each flag a service file can carry. */
-const FLAG_STATUS_FIELD: Record<string, keyof DaemonStatusBody> = {
+const FLAG_STATUS_FIELD = {
   [CLOUD_TELEMETRY_FEATURE_ENV]: "cloudTelemetry",
   [CLOUD_CATALOG_FEATURE_ENV]: "cloudCatalog",
-};
+} as const;
 
+/**
+ * Confirm the restarted daemon actually runs with the flags we just wrote.
+ * Rewriting the service file is not proof: launchd or systemd may still be
+ * serving the previous definition. Throws on a mismatch; returns a note when
+ * the running daemon is too old to report them at all.
+ */
 async function verifyFeatureFlagsApplied(
   port: number,
   probe: ProbeDaemon,
-  expected: Readonly<Record<string, boolean>>,
+  expected: ServiceFeatureFlagOverrides,
 ): Promise<string | undefined> {
   const result = await probe(port);
   const unconfirmed = (reason: string) =>
     `[ratel] could not confirm the requested feature flags: ${reason}. Check "ratel-local traces status".`;
   if (!result.ok) return unconfirmed("the daemon did not answer");
   const unreported: string[] = [];
-  for (const [name, want] of Object.entries(expected)) {
-    const observed = result.status?.[FLAG_STATUS_FIELD[name] as keyof DaemonStatusBody];
+  for (const name of SERVICE_FEATURE_FLAG_ENVS) {
+    if (!Object.hasOwn(expected, name)) continue;
+    const want = expected[name];
+    const observed = result.status?.[FLAG_STATUS_FIELD[name]];
     if (observed === want) continue;
     if (observed === undefined) {
       unreported.push(name);

--- a/apps/ratel-local/src/cli/handlers/daemon.ts
+++ b/apps/ratel-local/src/cli/handlers/daemon.ts
@@ -33,7 +33,7 @@ import {
   type TelemetryHandle,
   type TelemetryInitOptions,
 } from "@ratel-ai/telemetry-otlp";
-import { createCloudCatalogSource } from "../../cloud/catalog.js";
+import { CLOUD_CATALOG_TIMEOUT_MS, createCloudCatalogSource } from "../../cloud/catalog.js";
 import {
   CLOUD_API_KEY_ENV,
   type CloudOtlpTraceRelayOptions,
@@ -88,6 +88,7 @@ import { buildConfiguredGateway, type ServeOptions } from "./serve.js";
 import type { HandlerCtx } from "./types.js";
 
 export const DEFAULT_DAEMON_PORT = 5731;
+export const DAEMON_STARTUP_BUDGET_MS = 5_000 + CLOUD_CATALOG_TIMEOUT_MS;
 export const DAEMON_LABEL = "ai.ratel.local.daemon";
 export const SYSTEMD_SERVICE = "ratel-local-daemon.service";
 export const DAEMON_SERVICE_ID = "ratel-local-daemon";
@@ -432,16 +433,13 @@ export async function runDaemonServer(
         ...(opts.cloudCatalogFetch ? { fetch: opts.cloudCatalogFetch } : {}),
       })
     : undefined;
-  const resolverOptions = { homeDir: ctx.env.homeDir, projectRegistry };
   const snapshotResolver =
     opts.snapshotResolver ??
     createContextSnapshotResolver({
-      ...resolverOptions,
+      homeDir: ctx.env.homeDir,
+      projectRegistry,
       ...(cloudCatalog ? { cloudCatalog } : {}),
     });
-  // OAuth migration reads `mcpEntries` only; a catalog pull here would block
-  // listen by one timeout per context.
-  const migrationResolver = opts.snapshotResolver ?? createContextSnapshotResolver(resolverOptions);
   const daemonToken = await (opts.ensureToken ?? ensureDaemonToken)(ctx.env.homeDir);
   const generationPool = new InMemoryScopedGatewayPool(async (scope) => {
     if (scope.resolvedContext) {
@@ -479,7 +477,7 @@ export async function runDaemonServer(
   // Recover any interrupted config ownership change before snapshots drive OAuth
   // migration; otherwise a transient half-transaction could mis-scope credentials.
   if (useResolvedControlPlane) {
-    await migrateDaemonOAuthStores(ctx.env.homeDir, projectRegistry, migrationResolver, log);
+    await migrateDaemonOAuthStores(ctx.env.homeDir, projectRegistry, snapshotResolver, log);
   }
   const localGitExcludeManager = useResolvedControlPlane
     ? createLocalGitExcludeManager()
@@ -800,17 +798,17 @@ async function migrateDaemonOAuthStores(
       .filter(({ status }) => status === "available")
       .map(({ id }) => ({ kind: "project" as const, projectId: id })),
   ];
-  const entries = [];
-  for (const context of contexts) {
-    try {
-      entries.push(...(await resolver.resolve(context)).mcpEntries);
-    } catch (error) {
-      log(
-        `[ratel] skipped OAuth migration because a context is invalid: ${(error as Error).message}`,
-      );
-      return;
-    }
+  const resolved = await Promise.allSettled(contexts.map((context) => resolver.resolve(context)));
+  const failed = resolved.filter((result) => result.status === "rejected");
+  if (failed[0]) {
+    log(
+      `[ratel] skipped OAuth migration because ${failed.length} of ${contexts.length} contexts are invalid: ${(failed[0].reason as Error).message}`,
+    );
+    return;
   }
+  const entries = resolved.flatMap((result) =>
+    result.status === "fulfilled" ? result.value.mcpEntries : [],
+  );
   try {
     const report = await migrateLegacyOAuthStores({ homeDir, entries });
     for (const item of report.migrated) {
@@ -1395,7 +1393,7 @@ async function waitForDaemon(
   probe: ProbeDaemon,
   expectedVersion?: string,
 ): Promise<void> {
-  const deadline = Date.now() + 5_000;
+  const deadline = Date.now() + DAEMON_STARTUP_BUDGET_MS;
   let lastError = "not responding";
   while (Date.now() < deadline) {
     const result = await probe(port);

--- a/apps/ratel-local/src/cli/handlers/daemon.ts
+++ b/apps/ratel-local/src/cli/handlers/daemon.ts
@@ -432,13 +432,16 @@ export async function runDaemonServer(
         ...(opts.cloudCatalogFetch ? { fetch: opts.cloudCatalogFetch } : {}),
       })
     : undefined;
+  const resolverOptions = { homeDir: ctx.env.homeDir, projectRegistry };
   const snapshotResolver =
     opts.snapshotResolver ??
     createContextSnapshotResolver({
-      homeDir: ctx.env.homeDir,
-      projectRegistry,
+      ...resolverOptions,
       ...(cloudCatalog ? { cloudCatalog } : {}),
     });
+  // The migration reads `mcpEntries` only, and a pull here costs one catalog
+  // timeout per context before the HTTP server listens.
+  const migrationResolver = opts.snapshotResolver ?? createContextSnapshotResolver(resolverOptions);
   const daemonToken = await (opts.ensureToken ?? ensureDaemonToken)(ctx.env.homeDir);
   const generationPool = new InMemoryScopedGatewayPool(async (scope) => {
     if (scope.resolvedContext) {
@@ -476,7 +479,7 @@ export async function runDaemonServer(
   // Recover any interrupted config ownership change before snapshots drive OAuth
   // migration; otherwise a transient half-transaction could mis-scope credentials.
   if (useResolvedControlPlane) {
-    await migrateDaemonOAuthStores(ctx.env.homeDir, projectRegistry, snapshotResolver, log);
+    await migrateDaemonOAuthStores(ctx.env.homeDir, projectRegistry, migrationResolver, log);
   }
   const localGitExcludeManager = useResolvedControlPlane
     ? createLocalGitExcludeManager()

--- a/apps/ratel-local/src/cli/handlers/daemon.ts
+++ b/apps/ratel-local/src/cli/handlers/daemon.ts
@@ -64,11 +64,16 @@ import {
   type ResolvedGatewaySnapshot,
   type RetrievalHealthStats,
 } from "../../daemon/scoped-gateway-pool.js";
+import {
+  applyFeatureFlagsToLaunchAgentPlist,
+  applyFeatureFlagsToSystemdUserService,
+} from "../../daemon/service-file.js";
 import { DAEMON_INSTALL_PATH_ENV } from "../../daemon/subprocess-environment.js";
 import {
+  CLOUD_CATALOG_FEATURE_ENV,
   CLOUD_TELEMETRY_FEATURE_ENV,
-  cloudTelemetryOverrideFromEnv,
   type FeatureFlags,
+  featureFlagOverridesFromEnv,
   featureFlagServiceEnvironment,
   featureFlagsFromEnv,
 } from "../../feature-flags.js";
@@ -128,6 +133,7 @@ export interface DaemonStatusBody extends DaemonState {
   retrievalHealth?: RetrievalHealthStats;
   /** Absent on daemons older than the restart-reconfiguration support. */
   cloudTelemetry?: boolean;
+  cloudCatalog?: boolean;
 }
 
 interface CommandResult {
@@ -272,7 +278,7 @@ export async function runDaemon(
         spinner?.message("Starting Ratel Local again…");
         await startDaemon(parsed, ctx, options, lifecycleLog, opts, "restart");
         if (applied !== undefined) {
-          restartNote = await verifyCloudTelemetryApplied(
+          restartNote = await verifyFeatureFlagsApplied(
             await daemonPort(parsed, ctx),
             opts.probe ?? probeDaemon,
             applied,
@@ -687,6 +693,7 @@ export async function runDaemonServer(
           activeUserGatewayCount: poolStats.activeUserGatewayCount,
           activeProjectGatewayCount: poolStats.activeProjectGatewayCount,
           cloudTelemetry: featureFlags.cloudTelemetry,
+          cloudCatalog: featureFlags.cloudCatalog,
           ...(retrievalHealthEnabled ? { retrievalHealth: poolStats.retrievalHealth } : {}),
         });
         return true;
@@ -882,7 +889,9 @@ export function createLaunchAgentPlist(input: {
   ];
   const serviceEnvironment = {
     ...(input.pathEnv ? { PATH: input.pathEnv, [DAEMON_INSTALL_PATH_ENV]: input.pathEnv } : {}),
-    ...featureFlagServiceEnvironment(input.featureFlags ?? { cloudTelemetry: false }),
+    ...featureFlagServiceEnvironment(
+      input.featureFlags ?? { cloudTelemetry: false, cloudCatalog: false },
+    ),
   };
   const environmentXml = Object.entries(serviceEnvironment)
     .map(
@@ -937,7 +946,9 @@ export function createSystemdUserService(input: {
     .join(" ");
   const serviceEnvironment = {
     ...(input.pathEnv ? { PATH: input.pathEnv, [DAEMON_INSTALL_PATH_ENV]: input.pathEnv } : {}),
-    ...featureFlagServiceEnvironment(input.featureFlags ?? { cloudTelemetry: false }),
+    ...featureFlagServiceEnvironment(
+      input.featureFlags ?? { cloudTelemetry: false, cloudCatalog: false },
+    ),
   };
   const environmentLines = Object.entries(serviceEnvironment)
     .map(([key, value]) => `Environment=${systemdQuote(`${key}=${value}`)}`)
@@ -960,49 +971,6 @@ WantedBy=default.target
 `;
 }
 
-const LAUNCH_AGENT_FLAG_ENTRY = `    <key>${CLOUD_TELEMETRY_FEATURE_ENV}</key>\n    <string>1</string>`;
-const LAUNCH_AGENT_FLAG_ENTRY_RE = new RegExp(
-  `\\n    <key>${CLOUD_TELEMETRY_FEATURE_ENV}</key>\\n    <string>[^<]*</string>`,
-);
-const EMPTY_LAUNCH_AGENT_ENV_BLOCK_RE =
-  /\n {2}<key>EnvironmentVariables<\/key>\n {2}<dict>\n {2}<\/dict>/;
-const SYSTEMD_FLAG_LINE = `Environment=${CLOUD_TELEMETRY_FEATURE_ENV}=1`;
-const SYSTEMD_FLAG_LINE_RE = new RegExp(`^Environment=${CLOUD_TELEMETRY_FEATURE_ENV}=.*\\n`, "m");
-const SERVICE_SHAPE_ERROR =
-  'installed daemon service is not a Ratel Local unit; reinstall with "ratel-local daemon install"';
-
-export function applyCloudTelemetryToLaunchAgentPlist(plist: string, enabled: boolean): string {
-  // Drop the flag entry, then an environment dict it may have left empty. Both
-  // branches below assume the shape `createLaunchAgentPlist` emits: without the
-  // second replace, enabling twice appends a new dict beside the emptied one.
-  const stripped = plist
-    .replace(LAUNCH_AGENT_FLAG_ENTRY_RE, "")
-    .replace(EMPTY_LAUNCH_AGENT_ENV_BLOCK_RE, "");
-  if (!enabled) return stripped;
-  const envBlock =
-    /(<key>EnvironmentVariables<\/key>\n {2}<dict>\n)([\s\S]*?)(\n {2}<\/dict>)/.exec(stripped);
-  if (envBlock?.index !== undefined) {
-    const inserted = `${envBlock[1]}${envBlock[2]}\n${LAUNCH_AGENT_FLAG_ENTRY}${envBlock[3]}`;
-    return (
-      stripped.slice(0, envBlock.index) +
-      inserted +
-      stripped.slice(envBlock.index + envBlock[0].length)
-    );
-  }
-  if (!stripped.includes("<key>StandardOutPath</key>")) throw new Error(SERVICE_SHAPE_ERROR);
-  return stripped.replace(
-    "  <key>StandardOutPath</key>",
-    `  <key>EnvironmentVariables</key>\n  <dict>\n${LAUNCH_AGENT_FLAG_ENTRY}\n  </dict>\n  <key>StandardOutPath</key>`,
-  );
-}
-
-export function applyCloudTelemetryToSystemdUserService(unit: string, enabled: boolean): string {
-  const stripped = unit.replace(SYSTEMD_FLAG_LINE_RE, "");
-  if (!enabled) return stripped;
-  if (!stripped.includes("Restart=always")) throw new Error(SERVICE_SHAPE_ERROR);
-  return stripped.replace("Restart=always", `${SYSTEMD_FLAG_LINE}\nRestart=always`);
-}
-
 /**
  * Apply an explicit Cloud telemetry override to the installed service file.
  * Returns the applied value, or `undefined` when nothing was written — no
@@ -1012,9 +980,9 @@ async function reconfigureInstalledServiceFeatureFlags(
   ctx: HandlerCtx,
   options: ServeOptions,
   opts: DaemonHandlerDeps,
-): Promise<boolean | undefined> {
-  const override = cloudTelemetryOverrideFromEnv(options.processEnv ?? process.env);
-  if (override === undefined) return undefined;
+): Promise<Readonly<Record<string, boolean>> | undefined> {
+  const overrides = featureFlagOverridesFromEnv(options.processEnv ?? process.env);
+  if (Object.keys(overrides).length === 0) return undefined;
   const platform = daemonPlatform(opts);
   const paths = daemonPaths(ctx.env.homeDir);
   const servicePath = platform === "linux" ? paths.systemdService : paths.plist;
@@ -1022,13 +990,13 @@ async function reconfigureInstalledServiceFeatureFlags(
   if (current === null) return undefined;
   const next =
     platform === "linux"
-      ? applyCloudTelemetryToSystemdUserService(current, override)
-      : applyCloudTelemetryToLaunchAgentPlist(current, override);
+      ? applyFeatureFlagsToSystemdUserService(current, overrides)
+      : applyFeatureFlagsToLaunchAgentPlist(current, overrides);
   if (next !== current) {
     await ctx.fs.writeAtomic(servicePath, next);
     if (platform === "linux") await systemctl(opts, ["daemon-reload"]);
   }
-  return override;
+  return overrides;
 }
 
 /**
@@ -1037,22 +1005,36 @@ async function reconfigureInstalledServiceFeatureFlags(
  * serving the previous definition. Throws on a mismatch; returns a note when
  * the running daemon is too old to report the flag at all.
  */
-async function verifyCloudTelemetryApplied(
+/** Which status field reports each flag a service file can carry. */
+const FLAG_STATUS_FIELD: Record<string, keyof DaemonStatusBody> = {
+  [CLOUD_TELEMETRY_FEATURE_ENV]: "cloudTelemetry",
+  [CLOUD_CATALOG_FEATURE_ENV]: "cloudCatalog",
+};
+
+async function verifyFeatureFlagsApplied(
   port: number,
   probe: ProbeDaemon,
-  expected: boolean,
+  expected: Readonly<Record<string, boolean>>,
 ): Promise<string | undefined> {
-  const wanted = expected ? "enabled" : "disabled";
   const result = await probe(port);
   const unconfirmed = (reason: string) =>
-    `[ratel] could not confirm Cloud telemetry is ${wanted}: ${reason}. Check "ratel-local traces status".`;
+    `[ratel] could not confirm the requested feature flags: ${reason}. Check "ratel-local traces status".`;
   if (!result.ok) return unconfirmed("the daemon did not answer");
-  const observed = result.status?.cloudTelemetry;
-  if (observed === expected) return undefined;
-  if (observed === undefined) return unconfirmed("the running daemon does not report it");
-  throw new Error(
-    `service was updated but the restarted daemon reports Cloud telemetry ${observed ? "enabled" : "disabled"}, expected ${wanted}; the previous service definition may still be loaded. Reinstall with "ratel-local daemon uninstall" then "${CLOUD_TELEMETRY_FEATURE_ENV}=${expected ? "1" : "0"} ratel-local daemon install".`,
-  );
+  const unreported: string[] = [];
+  for (const [name, want] of Object.entries(expected)) {
+    const observed = result.status?.[FLAG_STATUS_FIELD[name] as keyof DaemonStatusBody];
+    if (observed === want) continue;
+    if (observed === undefined) {
+      unreported.push(name);
+      continue;
+    }
+    throw new Error(
+      `service was updated but the restarted daemon reports ${name} ${observed ? "enabled" : "disabled"}, expected ${want ? "enabled" : "disabled"}; the previous service definition may still be loaded. Reinstall with "ratel-local daemon uninstall" then "${name}=${want ? "1" : "0"} ratel-local daemon install".`,
+    );
+  }
+  return unreported.length > 0
+    ? unconfirmed(`the running daemon does not report ${unreported.join(", ")}`)
+    : undefined;
 }
 
 async function installDaemon(

--- a/apps/ratel-local/src/cli/handlers/daemon.ts
+++ b/apps/ratel-local/src/cli/handlers/daemon.ts
@@ -387,8 +387,8 @@ export async function runDaemonServer(
       log(`[ratel] ignored invalid Cloud trace settings: ${(error as Error).message}`);
     }
   }
-  // Catalog pulls after the strip below; hold the env credential so they still
-  // see it. Subprocesses must not inherit `RATEL_API_KEY`.
+  // Capture before the strip below; catalog pulls still need it. Subprocesses
+  // must not inherit `RATEL_API_KEY`.
   const environmentApiKey =
     featureFlags.cloudTelemetry || featureFlags.cloudCatalog
       ? daemonProcessEnv[CLOUD_API_KEY_ENV]
@@ -439,8 +439,8 @@ export async function runDaemonServer(
       ...resolverOptions,
       ...(cloudCatalog ? { cloudCatalog } : {}),
     });
-  // The migration reads `mcpEntries` only, and a pull here costs one catalog
-  // timeout per context before the HTTP server listens.
+  // OAuth migration reads `mcpEntries` only; a catalog pull here would block
+  // listen by one timeout per context.
   const migrationResolver = opts.snapshotResolver ?? createContextSnapshotResolver(resolverOptions);
   const daemonToken = await (opts.ensureToken ?? ensureDaemonToken)(ctx.env.homeDir);
   const generationPool = new InMemoryScopedGatewayPool(async (scope) => {
@@ -898,7 +898,7 @@ export function createLaunchAgentPlist(input: {
   homeDir: string;
   port: number;
   pathEnv?: string;
-  featureFlags?: FeatureFlags;
+  featureFlags?: Partial<FeatureFlags>;
 }): string {
   const paths = daemonPaths(input.homeDir);
   const args = [
@@ -913,9 +913,11 @@ export function createLaunchAgentPlist(input: {
   ];
   const serviceEnvironment = {
     ...(input.pathEnv ? { PATH: input.pathEnv, [DAEMON_INSTALL_PATH_ENV]: input.pathEnv } : {}),
-    ...featureFlagServiceEnvironment(
-      input.featureFlags ?? { cloudTelemetry: false, cloudCatalog: false },
-    ),
+    ...featureFlagServiceEnvironment({
+      cloudTelemetry: false,
+      cloudCatalog: false,
+      ...input.featureFlags,
+    }),
   };
   const environmentXml = Object.entries(serviceEnvironment)
     .map(
@@ -962,7 +964,7 @@ export function createSystemdUserService(input: {
   homeDir: string;
   port: number;
   pathEnv?: string;
-  featureFlags?: FeatureFlags;
+  featureFlags?: Partial<FeatureFlags>;
 }): string {
   const paths = daemonPaths(input.homeDir);
   const command = [input.executablePath, ...(input.executableArgs ?? [])]
@@ -970,9 +972,11 @@ export function createSystemdUserService(input: {
     .join(" ");
   const serviceEnvironment = {
     ...(input.pathEnv ? { PATH: input.pathEnv, [DAEMON_INSTALL_PATH_ENV]: input.pathEnv } : {}),
-    ...featureFlagServiceEnvironment(
-      input.featureFlags ?? { cloudTelemetry: false, cloudCatalog: false },
-    ),
+    ...featureFlagServiceEnvironment({
+      cloudTelemetry: false,
+      cloudCatalog: false,
+      ...input.featureFlags,
+    }),
   };
   const environmentLines = Object.entries(serviceEnvironment)
     .map(([key, value]) => `Environment=${systemdQuote(`${key}=${value}`)}`)
@@ -1023,7 +1027,6 @@ async function reconfigureInstalledServiceFeatureFlags(
   return overrides;
 }
 
-/** Which status field reports each flag a service file can carry. */
 const FLAG_STATUS_FIELD = {
   [CLOUD_TELEMETRY_FEATURE_ENV]: "cloudTelemetry",
   [CLOUD_CATALOG_FEATURE_ENV]: "cloudCatalog",

--- a/apps/ratel-local/src/cloud/catalog.test.ts
+++ b/apps/ratel-local/src/cloud/catalog.test.ts
@@ -77,7 +77,6 @@ describe("createCloudCatalogLoader", () => {
     expect(snapshot.catalogVersion).toBe(VERSION);
     expect(snapshot.skills).toEqual(WIRE.skills);
     expect(calls[0].headers.get("authorization")).toBe("Bearer rtl_test");
-    // Nothing cached yet, so the first pull must be unconditional.
     expect(calls[0].headers.has("if-none-match")).toBe(false);
   });
 
@@ -211,8 +210,6 @@ describe("createCloudCatalogLoader", () => {
     });
 
     await expect(client.load()).rejects.toThrow(CloudCatalogUnavailableError);
-    // A commit fans out to every active context in series; without this the burst
-    // pays the 10s timeout once per context.
     await expect(client.load()).rejects.toThrow(/HTTP 503/);
     expect(calls).toHaveLength(1);
 
@@ -317,7 +314,6 @@ describe("createCloudCatalogSource", () => {
       "Bearer rtl_one",
       "Bearer rtl_two",
     ]);
-    // The rotated key gets its own loader, so it revalidates nothing it never fetched.
     expect(calls[1]?.headers.get("If-None-Match")).toBeNull();
   });
 

--- a/apps/ratel-local/src/cloud/catalog.test.ts
+++ b/apps/ratel-local/src/cloud/catalog.test.ts
@@ -5,13 +5,14 @@ import {
   CloudCatalogUnavailableError,
   cloudCatalogEndpoint,
   createCloudCatalogLoader,
+  createCloudCatalogSource,
   DEFAULT_CLOUD_CATALOG_ENDPOINT,
 } from "./catalog.js";
 
 const ENDPOINT = DEFAULT_CLOUD_CATALOG_ENDPOINT;
 const VERSION = "6f7f0cee520a24a6edbb6dc7df6b623751cbdf05771e7e7bbe45cc9de943f0a6";
 
-// Shape taken from a real `GET /v1/catalog` against a seeded project; the
+// Shape taken from a real `GET /api/v1/catalog` against a seeded project; the
 // bodies are truncated because the loader treats them as opaque strings.
 const WIRE = {
   catalogVersion: VERSION,
@@ -231,5 +232,63 @@ describe("createCloudCatalogLoader", () => {
   it("rejects a 304 that arrives before anything is cached", async () => {
     const { impl } = recordingFetch(new Response(null, { status: 304 }));
     await expect(loader(impl).load()).rejects.toThrow(/304 without a cached catalog/);
+  });
+});
+
+describe("createCloudCatalogSource", () => {
+  const source = (
+    apiKey: () => Promise<string | undefined>,
+    fetchImpl: typeof fetch,
+    log: (message: string) => void = () => {},
+  ) => createCloudCatalogSource({ apiKey, endpoint: ENDPOINT, log, fetch: fetchImpl });
+
+  it("pulls nothing, and asks Cloud nothing, when no credential is configured", async () => {
+    const { calls, impl } = recordingFetch();
+
+    expect(await source(async () => undefined, impl)()).toBeUndefined();
+    expect(calls).toHaveLength(0);
+  });
+
+  it("keeps one loader across pulls, so the second revalidates instead of re-downloading", async () => {
+    const { calls, impl } = recordingFetch(jsonResponse(WIRE), new Response(null, { status: 304 }));
+    const pull = source(async () => "rtl_one", impl);
+
+    expect((await pull())?.catalog.catalogVersion).toBe(VERSION);
+    expect((await pull())?.catalog.catalogVersion).toBe(VERSION);
+    expect(calls[1]?.headers.get("If-None-Match")).toBe(`"${VERSION}"`);
+  });
+
+  it("picks up a key rotated while the daemon runs", async () => {
+    const { calls, impl } = recordingFetch(jsonResponse(WIRE), jsonResponse(WIRE));
+    let apiKey = "rtl_one";
+    const pull = source(async () => apiKey, impl);
+
+    await pull();
+    apiKey = "rtl_two";
+    await pull();
+
+    expect(calls.map(({ headers }) => headers.get("Authorization"))).toEqual([
+      "Bearer rtl_one",
+      "Bearer rtl_two",
+    ]);
+    // The rotated key gets its own loader, so it revalidates nothing it never fetched.
+    expect(calls[1]?.headers.get("If-None-Match")).toBeNull();
+  });
+
+  it("marks a cached catalog as degraded and says so in the daemon log", async () => {
+    const { impl } = recordingFetch(jsonResponse(WIRE), jsonResponse({}, 500));
+    const logs: string[] = [];
+    const pull = source(
+      async () => "rtl_one",
+      impl,
+      (message) => logs.push(message),
+    );
+
+    await pull();
+    const stale = await pull();
+
+    expect(stale?.degraded).toBe("HTTP 500");
+    expect(stale?.catalog.catalogVersion).toBe(VERSION);
+    expect(logs.some((message) => message.includes("HTTP 500"))).toBe(true);
   });
 });

--- a/apps/ratel-local/src/cloud/catalog.test.ts
+++ b/apps/ratel-local/src/cloud/catalog.test.ts
@@ -175,6 +175,28 @@ describe("createCloudCatalogLoader", () => {
     await expect(client.load()).rejects.toThrow(CloudCatalogAuthError);
   });
 
+  it("holds a rejected key rather than asking Cloud on every resolve", async () => {
+    const { calls, impl } = recordingFetch(
+      jsonResponse({ error: "nope" }, 401),
+      jsonResponse(WIRE),
+    );
+    let clock = 0;
+    const client = createCloudCatalogLoader({
+      endpoint: ENDPOINT,
+      apiKey: "rtl_revoked",
+      fetch: impl,
+      now: () => clock,
+    });
+
+    await expect(client.load()).rejects.toThrow(/auth failed: HTTP 401/);
+    await expect(client.load()).rejects.toThrow(/auth failed: HTTP 401/);
+    expect(calls).toHaveLength(1);
+
+    clock = 60_001;
+    await client.load();
+    expect(calls).toHaveLength(2);
+  });
+
   it("surfaces a contract violation instead of falling back to the cache", async () => {
     const { impl } = recordingFetch(
       jsonResponse(WIRE),

--- a/apps/ratel-local/src/cloud/catalog.test.ts
+++ b/apps/ratel-local/src/cloud/catalog.test.ts
@@ -196,6 +196,33 @@ describe("createCloudCatalogLoader", () => {
     expect(calls).toHaveLength(2);
   });
 
+  it("serves overlapping loads from one request", async () => {
+    let release = () => {};
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const calls: string[] = [];
+    const impl = (async (input: URL | RequestInfo) => {
+      calls.push(String(input));
+      await gate;
+      return jsonResponse(WIRE);
+    }) as unknown as typeof fetch;
+    const client = loader(impl);
+
+    const [first, second, third] = [client.load(), client.load(), client.load()];
+    release();
+    const results = await Promise.all([first, second, third]);
+
+    expect(calls).toHaveLength(1);
+    expect(results.map(({ snapshot }) => snapshot.catalogVersion)).toEqual([
+      VERSION,
+      VERSION,
+      VERSION,
+    ]);
+    await client.load();
+    expect(calls).toHaveLength(2);
+  });
+
   it("holds an unreachable Cloud rather than paying its timeout on every resolve", async () => {
     const { calls, impl } = recordingFetch(
       jsonResponse({ error: "gateway" }, 503),

--- a/apps/ratel-local/src/cloud/catalog.test.ts
+++ b/apps/ratel-local/src/cloud/catalog.test.ts
@@ -197,6 +197,30 @@ describe("createCloudCatalogLoader", () => {
     expect(calls).toHaveLength(2);
   });
 
+  it("holds an unreachable Cloud rather than paying its timeout on every resolve", async () => {
+    const { calls, impl } = recordingFetch(
+      jsonResponse({ error: "gateway" }, 503),
+      jsonResponse(WIRE),
+    );
+    let clock = 0;
+    const client = createCloudCatalogLoader({
+      endpoint: ENDPOINT,
+      apiKey: "rtl_test",
+      fetch: impl,
+      now: () => clock,
+    });
+
+    await expect(client.load()).rejects.toThrow(CloudCatalogUnavailableError);
+    // A commit fans out to every active context in series; without this the burst
+    // pays the 10s timeout once per context.
+    await expect(client.load()).rejects.toThrow(/HTTP 503/);
+    expect(calls).toHaveLength(1);
+
+    clock = 10_001;
+    expect((await client.load()).snapshot.catalogVersion).toBe(VERSION);
+    expect(calls).toHaveLength(2);
+  });
+
   it("surfaces a contract violation instead of falling back to the cache", async () => {
     const { impl } = recordingFetch(
       jsonResponse(WIRE),

--- a/apps/ratel-local/src/cloud/catalog.ts
+++ b/apps/ratel-local/src/cloud/catalog.ts
@@ -7,6 +7,7 @@ export const DEFAULT_CLOUD_CATALOG_ENDPOINT = "https://cloud.ratel.sh/api/v1/cat
 
 const TIMEOUT_MS = 10_000;
 const AUTH_FAILURE_COOLDOWN_MS = 60_000;
+const UNAVAILABLE_COOLDOWN_MS = TIMEOUT_MS;
 
 /** The wire projection `protocol/v1` serves: exactly these seven fields. */
 const WIRE_FIELDS = ["id", "name", "description", "tags", "tools", "metadata", "body"] as const;
@@ -84,12 +85,22 @@ export function createCloudCatalogLoader(options: CloudCatalogLoaderOptions) {
   const now = options.now ?? Date.now;
   let cached: CloudCatalogSnapshot | undefined;
   let rejected: { until: number; status: number } | undefined;
+  let unavailable: { until: number; reason: string } | undefined;
 
   return {
     async load() {
       // A revoked key fails identically every time, and every context resolve
       // asks again. Hold the answer rather than ask Cloud on a loop.
       if (rejected && now() < rejected.until) throw new CloudCatalogAuthError(rejected.status);
+      // Same for an unreachable Cloud with nothing cached, except each of those
+      // asks costs the full timeout, and contexts are resolved in series.
+      if (!cached && unavailable && now() < unavailable.until) {
+        throw new CloudCatalogUnavailableError(unavailable.reason);
+      }
+      const degrade = (reason: string) => {
+        if (!cached) unavailable = { until: now() + UNAVAILABLE_COOLDOWN_MS, reason };
+        return degradeOrThrow(cached, reason);
+      };
       let response: Response;
       try {
         response = await fetchUpstream(endpoint, {
@@ -103,7 +114,7 @@ export function createCloudCatalogLoader(options: CloudCatalogLoaderOptions) {
           signal: AbortSignal.timeout(TIMEOUT_MS),
         });
       } catch (error) {
-        return degradeOrThrow(cached, (error as Error).message);
+        return degrade((error as Error).message);
       }
 
       if (response.status === 401 || response.status === 403) {
@@ -117,14 +128,14 @@ export function createCloudCatalogLoader(options: CloudCatalogLoaderOptions) {
         return { snapshot: handout(cached) };
       }
       if (response.status !== 200) {
-        return degradeOrThrow(cached, `HTTP ${response.status}`);
+        return degrade(`HTTP ${response.status}`);
       }
 
       let text: string;
       try {
         text = await response.text();
       } catch (error) {
-        return degradeOrThrow(cached, (error as Error).message);
+        return degrade((error as Error).message);
       }
       cached = parseCatalog(text);
       return { snapshot: handout(cached) };

--- a/apps/ratel-local/src/cloud/catalog.ts
+++ b/apps/ratel-local/src/cloud/catalog.ts
@@ -58,25 +58,16 @@ export class CloudCatalogUnavailableError extends Error {
   }
 }
 
-// ponytail: the shared guard rejects a query string, which is right while the
-// loader is global-only; a future `?scope=` pull has to relax it for this caller.
 export function cloudCatalogEndpoint(value: string): URL {
   return secretFreeHttpsUrl(value, "Ratel Cloud catalog endpoint");
 }
 
 /**
  * Conditional-GET client for the `protocol/v1` catalog pull.
- *
- * The cache lives for the life of this loader — a daemon restart re-pulls.
- * Deliberately: the contract serves `Cache-Control: no-cache`, so every
- * acquisition revalidates anyway, and a disk cache would add an offline story
- * the vertical slice does not need.
- * ponytail: daemon-lifetime cache; persistent offline cache deferred.
- * ponytail: concurrent load() can stampede; ceiling = one in-flight promise.
- *
- * A cached snapshot covers *availability* failures only. An invalid credential
- * or a contract violation always surfaces, so a revoked key cannot hide behind
- * the last good catalog indefinitely.
+ * The cache lives for this loader's lifetime — a restart re-pulls. A cached
+ * snapshot covers availability failures only; a revoked key or contract
+ * violation always surfaces. Auth failures and uncached misses are held
+ * briefly so context resolves do not retry Cloud in a loop.
  */
 export function createCloudCatalogLoader(options: CloudCatalogLoaderOptions) {
   const endpoint = cloudCatalogEndpoint(options.endpoint);
@@ -89,11 +80,7 @@ export function createCloudCatalogLoader(options: CloudCatalogLoaderOptions) {
 
   return {
     async load() {
-      // A revoked key fails identically every time, and every context resolve
-      // asks again. Hold the answer rather than ask Cloud on a loop.
       if (rejected && now() < rejected.until) throw new CloudCatalogAuthError(rejected.status);
-      // Same for an unreachable Cloud with nothing cached, except each of those
-      // asks costs the full timeout, and contexts are resolved in series.
       if (!cached && unavailable && now() < unavailable.until) {
         throw new CloudCatalogUnavailableError(unavailable.reason);
       }
@@ -144,13 +131,9 @@ export function createCloudCatalogLoader(options: CloudCatalogLoaderOptions) {
 }
 
 /**
- * The catalog pull the context resolver injects. The credential is read per
- * pull rather than captured at boot, so a key rotated while the daemon runs is
- * picked up on the next context resolve instead of at the next restart.
- *
- * One loader is kept, rebuilt when the credential changes, because the loader
- * owns the conditional-GET cache: a new one per pull would re-download the
- * catalog every time.
+ * Catalog pull injected into the context resolver. Reads the credential on
+ * each call so a rotated key applies without a restart, and reuses one loader
+ * so the conditional-GET cache survives across pulls.
  */
 export function createCloudCatalogSource(input: {
   apiKey: () => Promise<string | undefined>;
@@ -170,7 +153,7 @@ export function createCloudCatalogSource(input: {
         loader: createCloudCatalogLoader({
           endpoint,
           apiKey,
-          ...(input.fetch ? { fetch: input.fetch } : {}),
+          fetch: input.fetch,
         }),
       };
     }
@@ -181,8 +164,7 @@ export function createCloudCatalogSource(input: {
 }
 
 function handout(snapshot: CloudCatalogSnapshot): CloudCatalogSnapshot {
-  // ponytail: shallow copy guards the cached array; skill objects are still shared,
-  // deep-clone only if a consumer starts mutating them in place.
+  // Copy the array; skill objects stay shared.
   return { catalogVersion: snapshot.catalogVersion, skills: [...snapshot.skills] };
 }
 

--- a/apps/ratel-local/src/cloud/catalog.ts
+++ b/apps/ratel-local/src/cloud/catalog.ts
@@ -1,8 +1,9 @@
+import type { CloudCatalogPullResult } from "@ratel-ai/ratel-local-core";
 import type { Skill } from "@ratel-ai/sdk";
 import { headerSafeSecret } from "./header-safe-secret.js";
 import { secretFreeHttpsUrl } from "./url.js";
 
-export const DEFAULT_CLOUD_CATALOG_ENDPOINT = "https://cloud.ratel.sh/v1/catalog";
+export const DEFAULT_CLOUD_CATALOG_ENDPOINT = "https://cloud.ratel.sh/api/v1/catalog";
 
 const TIMEOUT_MS = 10_000;
 
@@ -119,6 +120,43 @@ export function createCloudCatalogLoader(options: CloudCatalogLoaderOptions) {
       cached = parseCatalog(text);
       return { snapshot: handout(cached) };
     },
+  };
+}
+
+/**
+ * The catalog pull the context resolver injects. The credential is read per
+ * pull rather than captured at boot, so a key rotated while the daemon runs is
+ * picked up on the next context resolve instead of at the next restart.
+ *
+ * One loader is kept, rebuilt when the credential changes, because the loader
+ * owns the conditional-GET cache: a new one per pull would re-download the
+ * catalog every time.
+ */
+export function createCloudCatalogSource(input: {
+  apiKey: () => Promise<string | undefined>;
+  endpoint?: string;
+  log: (message: string) => void;
+  fetch?: typeof fetch;
+}) {
+  let current: { apiKey: string; loader: ReturnType<typeof createCloudCatalogLoader> } | undefined;
+  const endpoint = input.endpoint ?? DEFAULT_CLOUD_CATALOG_ENDPOINT;
+
+  return async (): Promise<CloudCatalogPullResult | undefined> => {
+    const apiKey = await input.apiKey();
+    if (!apiKey) return undefined;
+    if (current?.apiKey !== apiKey) {
+      current = {
+        apiKey,
+        loader: createCloudCatalogLoader({
+          endpoint,
+          apiKey,
+          ...(input.fetch ? { fetch: input.fetch } : {}),
+        }),
+      };
+    }
+    const { snapshot, degraded } = await current.loader.load();
+    if (degraded) input.log(`[ratel] serving a cached Cloud catalog: ${degraded}`);
+    return { catalog: snapshot, ...(degraded ? { degraded } : {}) };
   };
 }
 

--- a/apps/ratel-local/src/cloud/catalog.ts
+++ b/apps/ratel-local/src/cloud/catalog.ts
@@ -5,9 +5,9 @@ import { secretFreeHttpsUrl } from "./url.js";
 
 export const DEFAULT_CLOUD_CATALOG_ENDPOINT = "https://cloud.ratel.sh/api/v1/catalog";
 
-const TIMEOUT_MS = 10_000;
+export const CLOUD_CATALOG_TIMEOUT_MS = 10_000;
 const AUTH_FAILURE_COOLDOWN_MS = 60_000;
-const UNAVAILABLE_COOLDOWN_MS = TIMEOUT_MS;
+const UNAVAILABLE_COOLDOWN_MS = CLOUD_CATALOG_TIMEOUT_MS;
 
 /** The wire projection `protocol/v1` serves: exactly these seven fields. */
 const WIRE_FIELDS = ["id", "name", "description", "tags", "tools", "metadata", "body"] as const;
@@ -78,56 +78,67 @@ export function createCloudCatalogLoader(options: CloudCatalogLoaderOptions) {
   let rejected: { until: number; status: number } | undefined;
   let unavailable: { until: number; reason: string } | undefined;
 
-  return {
-    async load() {
-      if (rejected && now() < rejected.until) throw new CloudCatalogAuthError(rejected.status);
-      if (!cached && unavailable && now() < unavailable.until) {
-        throw new CloudCatalogUnavailableError(unavailable.reason);
-      }
-      const degrade = (reason: string) => {
-        if (!cached) unavailable = { until: now() + UNAVAILABLE_COOLDOWN_MS, reason };
-        return degradeOrThrow(cached, reason);
-      };
-      let response: Response;
-      try {
-        response = await fetchUpstream(endpoint, {
-          method: "GET",
-          headers: {
-            Authorization: `Bearer ${options.apiKey}`,
-            Accept: "application/json",
-            ...(cached ? { "If-None-Match": `"${cached.catalogVersion}"` } : {}),
-          },
-          redirect: "error",
-          signal: AbortSignal.timeout(TIMEOUT_MS),
-        });
-      } catch (error) {
-        return degrade((error as Error).message);
-      }
+  const pull = async (): Promise<CloudCatalogLoadResult> => {
+    if (rejected && now() < rejected.until) throw new CloudCatalogAuthError(rejected.status);
+    if (!cached && unavailable && now() < unavailable.until) {
+      throw new CloudCatalogUnavailableError(unavailable.reason);
+    }
+    const degrade = (reason: string) => {
+      if (!cached) unavailable = { until: now() + UNAVAILABLE_COOLDOWN_MS, reason };
+      return degradeOrThrow(cached, reason);
+    };
+    let response: Response;
+    try {
+      response = await fetchUpstream(endpoint, {
+        method: "GET",
+        headers: {
+          Authorization: `Bearer ${options.apiKey}`,
+          Accept: "application/json",
+          ...(cached ? { "If-None-Match": `"${cached.catalogVersion}"` } : {}),
+        },
+        redirect: "error",
+        signal: AbortSignal.timeout(CLOUD_CATALOG_TIMEOUT_MS),
+      });
+    } catch (error) {
+      return degrade((error as Error).message);
+    }
 
-      if (response.status === 401 || response.status === 403) {
-        rejected = { until: now() + AUTH_FAILURE_COOLDOWN_MS, status: response.status };
-        throw new CloudCatalogAuthError(response.status);
+    if (response.status === 401 || response.status === 403) {
+      rejected = { until: now() + AUTH_FAILURE_COOLDOWN_MS, status: response.status };
+      throw new CloudCatalogAuthError(response.status);
+    }
+    if (response.status === 304) {
+      if (!cached) {
+        throw new CloudCatalogProtocolError("304 without a cached catalog");
       }
-      if (response.status === 304) {
-        if (!cached) {
-          throw new CloudCatalogProtocolError("304 without a cached catalog");
-        }
-        return { snapshot: handout(cached) };
-      }
-      if (response.status !== 200) {
-        return degrade(`HTTP ${response.status}`);
-      }
-
-      let text: string;
-      try {
-        text = await response.text();
-      } catch (error) {
-        return degrade((error as Error).message);
-      }
-      cached = parseCatalog(text);
       return { snapshot: handout(cached) };
-    },
+    }
+    if (response.status !== 200) {
+      return degrade(`HTTP ${response.status}`);
+    }
+
+    let text: string;
+    try {
+      text = await response.text();
+    } catch (error) {
+      return degrade((error as Error).message);
+    }
+    cached = parseCatalog(text);
+    return { snapshot: handout(cached) };
   };
+
+  const load = singleFlight(pull);
+
+  return { load };
+}
+
+/** Runs `fn` once for every set of overlapping calls. The next call starts afresh. */
+function singleFlight<T>(fn: () => Promise<T>): () => Promise<T> {
+  let inflight: Promise<T> | undefined;
+  return () =>
+    (inflight ??= fn().finally(() => {
+      inflight = undefined;
+    }));
 }
 
 /**

--- a/apps/ratel-local/src/cloud/catalog.ts
+++ b/apps/ratel-local/src/cloud/catalog.ts
@@ -6,6 +6,7 @@ import { secretFreeHttpsUrl } from "./url.js";
 export const DEFAULT_CLOUD_CATALOG_ENDPOINT = "https://cloud.ratel.sh/api/v1/catalog";
 
 const TIMEOUT_MS = 10_000;
+const AUTH_FAILURE_COOLDOWN_MS = 60_000;
 
 /** The wire projection `protocol/v1` serves: exactly these seven fields. */
 const WIRE_FIELDS = ["id", "name", "description", "tags", "tools", "metadata", "body"] as const;
@@ -31,6 +32,8 @@ export interface CloudCatalogLoaderOptions {
   apiKey: string;
   /** Injected by tests; the daemon uses the global `fetch`. */
   fetch?: typeof fetch;
+  /** Injected by tests; the daemon uses the wall clock. */
+  now?: () => number;
 }
 
 export class CloudCatalogAuthError extends Error {
@@ -78,10 +81,15 @@ export function createCloudCatalogLoader(options: CloudCatalogLoaderOptions) {
   const endpoint = cloudCatalogEndpoint(options.endpoint);
   headerSafeSecret(options.apiKey, "Ratel Cloud API key");
   const fetchUpstream = options.fetch ?? fetch;
+  const now = options.now ?? Date.now;
   let cached: CloudCatalogSnapshot | undefined;
+  let rejected: { until: number; status: number } | undefined;
 
   return {
     async load() {
+      // A revoked key fails identically every time, and every context resolve
+      // asks again. Hold the answer rather than ask Cloud on a loop.
+      if (rejected && now() < rejected.until) throw new CloudCatalogAuthError(rejected.status);
       let response: Response;
       try {
         response = await fetchUpstream(endpoint, {
@@ -99,6 +107,7 @@ export function createCloudCatalogLoader(options: CloudCatalogLoaderOptions) {
       }
 
       if (response.status === 401 || response.status === 403) {
+        rejected = { until: now() + AUTH_FAILURE_COOLDOWN_MS, status: response.status };
         throw new CloudCatalogAuthError(response.status);
       }
       if (response.status === 304) {

--- a/apps/ratel-local/src/daemon/service-file.test.ts
+++ b/apps/ratel-local/src/daemon/service-file.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest";
+import {
+  createLaunchAgentPlist,
+  createSystemdUserService,
+  DEFAULT_DAEMON_PORT,
+} from "../cli/handlers/daemon.js";
+import { CLOUD_CATALOG_FEATURE_ENV, CLOUD_TELEMETRY_FEATURE_ENV } from "../feature-flags.js";
+import {
+  applyFeatureFlagsToLaunchAgentPlist,
+  applyFeatureFlagsToSystemdUserService,
+} from "./service-file.js";
+
+const HOME = "/Users/tester";
+const base = {
+  executablePath: "/opt/bin/ratel-local",
+  homeDir: HOME,
+  port: DEFAULT_DAEMON_PORT,
+};
+
+describe("service file feature flags", () => {
+  // Without `pathEnv` the flag is the only environment entry, so enabling has to
+  // create the dict from scratch and disabling has to remove it again. That is
+  // the shape an install performs when PATH is unset in its environment.
+  for (const pathEnv of ["/opt/node/bin:/usr/bin:/bin", undefined]) {
+    it(`round-trips against generated service files (pathEnv: ${pathEnv ? "set" : "unset"})`, () => {
+      const input = { ...base, ...(pathEnv ? { pathEnv } : {}) };
+      const on = { [CLOUD_TELEMETRY_FEATURE_ENV]: true };
+      const off = { [CLOUD_TELEMETRY_FEATURE_ENV]: false };
+
+      const disabledPlist = createLaunchAgentPlist({
+        ...input,
+        featureFlags: { cloudTelemetry: false, cloudCatalog: false },
+      });
+      const enabledPlist = createLaunchAgentPlist({
+        ...input,
+        featureFlags: { cloudTelemetry: true, cloudCatalog: false },
+      });
+      expect(applyFeatureFlagsToLaunchAgentPlist(disabledPlist, on)).toBe(enabledPlist);
+      expect(applyFeatureFlagsToLaunchAgentPlist(enabledPlist, off)).toBe(disabledPlist);
+      expect(applyFeatureFlagsToLaunchAgentPlist(enabledPlist, on)).toBe(enabledPlist);
+      expect(applyFeatureFlagsToLaunchAgentPlist(disabledPlist, off)).toBe(disabledPlist);
+
+      const disabledUnit = createSystemdUserService({
+        ...input,
+        featureFlags: { cloudTelemetry: false, cloudCatalog: false },
+      });
+      const enabledUnit = createSystemdUserService({
+        ...input,
+        featureFlags: { cloudTelemetry: true, cloudCatalog: false },
+      });
+      expect(applyFeatureFlagsToSystemdUserService(disabledUnit, on)).toBe(enabledUnit);
+      expect(applyFeatureFlagsToSystemdUserService(enabledUnit, off)).toBe(disabledUnit);
+      expect(applyFeatureFlagsToSystemdUserService(enabledUnit, on)).toBe(enabledUnit);
+      expect(applyFeatureFlagsToSystemdUserService(disabledUnit, off)).toBe(disabledUnit);
+    });
+  }
+
+  it("moves one flag without disturbing another", () => {
+    // A flag left out of the overrides keeps whatever the service already says,
+    // so enabling the catalog can never silently switch telemetry off.
+    const both = createLaunchAgentPlist({
+      ...base,
+      pathEnv: "/usr/bin",
+      featureFlags: { cloudTelemetry: true, cloudCatalog: true },
+    });
+    const withoutCatalog = applyFeatureFlagsToLaunchAgentPlist(both, {
+      [CLOUD_CATALOG_FEATURE_ENV]: false,
+    });
+    expect(withoutCatalog).toContain(CLOUD_TELEMETRY_FEATURE_ENV);
+    expect(withoutCatalog).not.toContain(CLOUD_CATALOG_FEATURE_ENV);
+
+    const unit = createSystemdUserService({
+      ...base,
+      pathEnv: "/usr/bin",
+      featureFlags: { cloudTelemetry: true, cloudCatalog: true },
+    });
+    const unitWithoutTelemetry = applyFeatureFlagsToSystemdUserService(unit, {
+      [CLOUD_TELEMETRY_FEATURE_ENV]: false,
+    });
+    expect(unitWithoutTelemetry).toContain(CLOUD_CATALOG_FEATURE_ENV);
+    expect(unitWithoutTelemetry).not.toContain(`${CLOUD_TELEMETRY_FEATURE_ENV}=`);
+  });
+
+  it("refuses to enable a flag in an unrecognised service file", () => {
+    const on = { [CLOUD_TELEMETRY_FEATURE_ENV]: true };
+    const off = { [CLOUD_TELEMETRY_FEATURE_ENV]: false };
+    expect(() => applyFeatureFlagsToLaunchAgentPlist("<plist />", on)).toThrow(
+      /not a Ratel Local unit/,
+    );
+    expect(() => applyFeatureFlagsToSystemdUserService("[Service]\n", on)).toThrow(
+      /not a Ratel Local unit/,
+    );
+    // Disabling stays a no-op there: there is no Ratel route to remove.
+    expect(applyFeatureFlagsToLaunchAgentPlist("<plist />", off)).toBe("<plist />");
+    expect(applyFeatureFlagsToSystemdUserService("[Service]\n", off)).toBe("[Service]\n");
+  });
+});

--- a/apps/ratel-local/src/daemon/service-file.ts
+++ b/apps/ratel-local/src/daemon/service-file.ts
@@ -1,0 +1,71 @@
+/**
+ * Feature-flag reconciliation inside an installed launchd or systemd service.
+ *
+ * `daemon restart` rewrites only the flag entries an operator named explicitly
+ * (ADR-0020), never the whole unit: regenerating it from the invoking shell
+ * would refresh install-time `PATH` and `RATEL_DAEMON_INSTALL_PATH`, which are
+ * preserved so npm/npx cannot reorder agent plugin executables.
+ */
+
+const EMPTY_LAUNCH_AGENT_ENV_BLOCK_RE =
+  /\n {2}<key>EnvironmentVariables<\/key>\n {2}<dict>\n {2}<\/dict>/;
+const LAUNCH_AGENT_ENV_BLOCK_RE =
+  /(<key>EnvironmentVariables<\/key>\n {2}<dict>\n)([\s\S]*?)(\n {2}<\/dict>)/;
+
+export const SERVICE_SHAPE_ERROR =
+  'installed daemon service is not a Ratel Local unit; reinstall with "ratel-local daemon install"';
+
+/** The flags an operator asked to change, by environment variable name. */
+export type ServiceFeatureFlagOverrides = Readonly<Record<string, boolean>>;
+
+const launchAgentEntry = (name: string) => `    <key>${name}</key>\n    <string>1</string>`;
+const launchAgentEntryRe = (name: string) =>
+  new RegExp(`\\n    <key>${name}</key>\\n    <string>[^<]*</string>`);
+const systemdLine = (name: string) => `Environment=${name}=1`;
+const systemdLineRe = (name: string) => new RegExp(`^Environment=${name}=.*\\n`, "m");
+
+/**
+ * Apply overrides to a launchd plist. Only the named flags move: a flag absent
+ * from `overrides` keeps whatever the installed service already says.
+ */
+export function applyFeatureFlagsToLaunchAgentPlist(
+  plist: string,
+  overrides: ServiceFeatureFlagOverrides,
+): string {
+  let next = plist;
+  for (const [name, enabled] of Object.entries(overrides)) {
+    // Drop the entry, then an environment dict it may have left empty, so the
+    // insertion below always sees the shape `createLaunchAgentPlist` emits.
+    // Without that, enabling twice appends a dict beside the emptied one.
+    const stripped = next.replace(launchAgentEntryRe(name), "");
+    next = stripped.replace(EMPTY_LAUNCH_AGENT_ENV_BLOCK_RE, "");
+    if (!enabled) continue;
+    const block = LAUNCH_AGENT_ENV_BLOCK_RE.exec(next);
+    if (block?.index !== undefined) {
+      const inserted = `${block[1]}${block[2]}\n${launchAgentEntry(name)}${block[3]}`;
+      next = next.slice(0, block.index) + inserted + next.slice(block.index + block[0].length);
+      continue;
+    }
+    if (!next.includes("<key>StandardOutPath</key>")) throw new Error(SERVICE_SHAPE_ERROR);
+    next = next.replace(
+      "  <key>StandardOutPath</key>",
+      `  <key>EnvironmentVariables</key>\n  <dict>\n${launchAgentEntry(name)}\n  </dict>\n  <key>StandardOutPath</key>`,
+    );
+  }
+  return next;
+}
+
+/** The systemd twin: `Environment=` lines immediately above `Restart=always`. */
+export function applyFeatureFlagsToSystemdUserService(
+  unit: string,
+  overrides: ServiceFeatureFlagOverrides,
+): string {
+  let next = unit;
+  for (const [name, enabled] of Object.entries(overrides)) {
+    next = next.replace(systemdLineRe(name), "");
+    if (!enabled) continue;
+    if (!next.includes("Restart=always")) throw new Error(SERVICE_SHAPE_ERROR);
+    next = next.replace("Restart=always", `${systemdLine(name)}\nRestart=always`);
+  }
+  return next;
+}

--- a/apps/ratel-local/src/daemon/service-file.ts
+++ b/apps/ratel-local/src/daemon/service-file.ts
@@ -8,26 +8,15 @@ const LAUNCH_AGENT_ENV_BLOCK_RE =
 export const SERVICE_SHAPE_ERROR =
   'installed daemon service is not a Ratel Local unit; reinstall with "ratel-local daemon install"';
 
-/**
- * Rewrite named feature-flag entries in an installed launchd plist without
- * regenerating the unit. Regenerating would refresh install-time `PATH` and
- * `RATEL_DAEMON_INSTALL_PATH`, which ADR-0020 preserves so npm/npx cannot
- * reorder agent plugin executables.
- * ponytail: string surgery on the generated unit; a plist parser only if we
- * start editing fields we did not emit.
- *
- * Enabled entries go in the `EnvironmentVariables` dict `createLaunchAgentPlist`
- * emits, immediately above `StandardOutPath`. An unrecognised shape throws.
- */
 export function applyFeatureFlagsToLaunchAgentPlist(
   plist: string,
   overrides: ServiceFeatureFlagOverrides,
 ): string {
   let next = plist;
   for (const [name, enabled] of Object.entries(overrides)) {
-    // Drop the entry, then an environment dict it may have left empty, so the
-    // insertion below always sees the shape `createLaunchAgentPlist` emits.
-    // Without that, enabling twice appends a dict beside the emptied one.
+    // Drop the entry, then an environment dict it may have left empty. Both
+    // branches below assume the shape `createLaunchAgentPlist` emits: without the
+    // second replace, enabling twice appends a new dict beside the emptied one.
     const stripped = next.replace(launchAgentEntryRe(name), "");
     next = stripped.replace(EMPTY_LAUNCH_AGENT_ENV_BLOCK_RE, "");
     if (!enabled) continue;
@@ -46,10 +35,6 @@ export function applyFeatureFlagsToLaunchAgentPlist(
   return next;
 }
 
-/**
- * The same rewrite for a systemd user unit. `Environment=` lines sit
- * immediately above `Restart=always`, matching `createSystemdUserService`.
- */
 export function applyFeatureFlagsToSystemdUserService(
   unit: string,
   overrides: ServiceFeatureFlagOverrides,

--- a/apps/ratel-local/src/daemon/service-file.ts
+++ b/apps/ratel-local/src/daemon/service-file.ts
@@ -8,6 +8,8 @@ const LAUNCH_AGENT_ENV_BLOCK_RE =
 export const SERVICE_SHAPE_ERROR =
   'installed daemon service is not a Ratel Local unit; reinstall with "ratel-local daemon install"';
 
+// Rewrite the installed unit rather than regenerate it: regenerating refreshes
+// install-time PATH, which ADR-0020 preserves so npx can't reorder plugin binaries.
 export function applyFeatureFlagsToLaunchAgentPlist(
   plist: string,
   overrides: ServiceFeatureFlagOverrides,

--- a/apps/ratel-local/src/daemon/service-file.ts
+++ b/apps/ratel-local/src/daemon/service-file.ts
@@ -1,11 +1,4 @@
-/**
- * Feature-flag reconciliation inside an installed launchd or systemd service.
- *
- * `daemon restart` rewrites only the flag entries an operator named explicitly
- * (ADR-0020), never the whole unit: regenerating it from the invoking shell
- * would refresh install-time `PATH` and `RATEL_DAEMON_INSTALL_PATH`, which are
- * preserved so npm/npx cannot reorder agent plugin executables.
- */
+import type { ServiceFeatureFlagOverrides } from "../feature-flags.js";
 
 const EMPTY_LAUNCH_AGENT_ENV_BLOCK_RE =
   /\n {2}<key>EnvironmentVariables<\/key>\n {2}<dict>\n {2}<\/dict>/;
@@ -15,18 +8,16 @@ const LAUNCH_AGENT_ENV_BLOCK_RE =
 export const SERVICE_SHAPE_ERROR =
   'installed daemon service is not a Ratel Local unit; reinstall with "ratel-local daemon install"';
 
-/** The flags an operator asked to change, by environment variable name. */
-export type ServiceFeatureFlagOverrides = Readonly<Record<string, boolean>>;
-
-const launchAgentEntry = (name: string) => `    <key>${name}</key>\n    <string>1</string>`;
-const launchAgentEntryRe = (name: string) =>
-  new RegExp(`\\n    <key>${name}</key>\\n    <string>[^<]*</string>`);
-const systemdLine = (name: string) => `Environment=${name}=1`;
-const systemdLineRe = (name: string) => new RegExp(`^Environment=${name}=.*\\n`, "m");
-
 /**
- * Apply overrides to a launchd plist. Only the named flags move: a flag absent
- * from `overrides` keeps whatever the installed service already says.
+ * Rewrite named feature-flag entries in an installed launchd plist without
+ * regenerating the unit. Regenerating would refresh install-time `PATH` and
+ * `RATEL_DAEMON_INSTALL_PATH`, which ADR-0020 preserves so npm/npx cannot
+ * reorder agent plugin executables.
+ * ponytail: string surgery on the generated unit; a plist parser only if we
+ * start editing fields we did not emit.
+ *
+ * Enabled entries go in the `EnvironmentVariables` dict `createLaunchAgentPlist`
+ * emits, immediately above `StandardOutPath`. An unrecognised shape throws.
  */
 export function applyFeatureFlagsToLaunchAgentPlist(
   plist: string,
@@ -55,7 +46,10 @@ export function applyFeatureFlagsToLaunchAgentPlist(
   return next;
 }
 
-/** The systemd twin: `Environment=` lines immediately above `Restart=always`. */
+/**
+ * The same rewrite for a systemd user unit. `Environment=` lines sit
+ * immediately above `Restart=always`, matching `createSystemdUserService`.
+ */
 export function applyFeatureFlagsToSystemdUserService(
   unit: string,
   overrides: ServiceFeatureFlagOverrides,
@@ -68,4 +62,20 @@ export function applyFeatureFlagsToSystemdUserService(
     next = next.replace("Restart=always", `${systemdLine(name)}\nRestart=always`);
   }
   return next;
+}
+
+function launchAgentEntry(name: string): string {
+  return `    <key>${name}</key>\n    <string>1</string>`;
+}
+
+function launchAgentEntryRe(name: string): RegExp {
+  return new RegExp(`\\n    <key>${name}</key>\\n    <string>[^<]*</string>`);
+}
+
+function systemdLine(name: string): string {
+  return `Environment=${name}=1`;
+}
+
+function systemdLineRe(name: string): RegExp {
+  return new RegExp(`^Environment=${name}=.*\\n`, "m");
 }

--- a/apps/ratel-local/src/feature-flags.test.ts
+++ b/apps/ratel-local/src/feature-flags.test.ts
@@ -8,13 +8,20 @@ import {
 } from "./feature-flags.js";
 
 describe("feature flags", () => {
-  it("keeps cloud telemetry off by default and accepts only an explicit 1", () => {
-    expect(featureFlagsFromEnv({}).cloudTelemetry).toBe(false);
-    expect(featureFlagsFromEnv({ [CLOUD_TELEMETRY_FEATURE_ENV]: "0" }).cloudTelemetry).toBe(false);
-    expect(featureFlagsFromEnv({ [CLOUD_TELEMETRY_FEATURE_ENV]: "true" }).cloudTelemetry).toBe(
-      false,
-    );
-    expect(featureFlagsFromEnv({ [CLOUD_TELEMETRY_FEATURE_ENV]: "1" }).cloudTelemetry).toBe(true);
+  it("keeps flags off by default and accepts only an explicit 1", () => {
+    expect(featureFlagsFromEnv({})).toEqual({ cloudTelemetry: false, cloudCatalog: false });
+    expect(
+      featureFlagsFromEnv({
+        [CLOUD_TELEMETRY_FEATURE_ENV]: "0",
+        [CLOUD_CATALOG_FEATURE_ENV]: "true",
+      }),
+    ).toEqual({ cloudTelemetry: false, cloudCatalog: false });
+    expect(
+      featureFlagsFromEnv({
+        [CLOUD_TELEMETRY_FEATURE_ENV]: "1",
+        [CLOUD_CATALOG_FEATURE_ENV]: "1",
+      }),
+    ).toEqual({ cloudTelemetry: true, cloudCatalog: true });
   });
 
   it("persists only enabled flags into daemon service environments", () => {
@@ -27,6 +34,10 @@ describe("feature flags", () => {
     expect(featureFlagServiceEnvironment({ cloudTelemetry: false, cloudCatalog: true })).toEqual({
       [CLOUD_CATALOG_FEATURE_ENV]: "1",
     });
+    expect(featureFlagServiceEnvironment({ cloudTelemetry: true, cloudCatalog: true })).toEqual({
+      [CLOUD_TELEMETRY_FEATURE_ENV]: "1",
+      [CLOUD_CATALOG_FEATURE_ENV]: "1",
+    });
   });
 
   it("reports only the flags the environment names, so changing one never moves another", () => {
@@ -37,6 +48,7 @@ describe("feature flags", () => {
     expect(featureFlagOverridesFromEnv({ [CLOUD_CATALOG_FEATURE_ENV]: "0" })).toEqual({
       [CLOUD_CATALOG_FEATURE_ENV]: false,
     });
+    // Presence is the override signal; only exact `1` enables.
     expect(
       featureFlagOverridesFromEnv({
         [CLOUD_TELEMETRY_FEATURE_ENV]: "true",

--- a/apps/ratel-local/src/feature-flags.test.ts
+++ b/apps/ratel-local/src/feature-flags.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from "vitest";
 import {
+  CLOUD_CATALOG_FEATURE_ENV,
   CLOUD_TELEMETRY_FEATURE_ENV,
-  cloudTelemetryOverrideFromEnv,
+  featureFlagOverridesFromEnv,
   featureFlagServiceEnvironment,
   featureFlagsFromEnv,
 } from "./feature-flags.js";
@@ -17,17 +18,30 @@ describe("feature flags", () => {
   });
 
   it("persists only enabled flags into daemon service environments", () => {
-    expect(featureFlagServiceEnvironment({ cloudTelemetry: false })).toEqual({});
-    expect(featureFlagServiceEnvironment({ cloudTelemetry: true })).toEqual({
+    expect(featureFlagServiceEnvironment({ cloudTelemetry: false, cloudCatalog: false })).toEqual(
+      {},
+    );
+    expect(featureFlagServiceEnvironment({ cloudTelemetry: true, cloudCatalog: false })).toEqual({
       [CLOUD_TELEMETRY_FEATURE_ENV]: "1",
+    });
+    expect(featureFlagServiceEnvironment({ cloudTelemetry: false, cloudCatalog: true })).toEqual({
+      [CLOUD_CATALOG_FEATURE_ENV]: "1",
     });
   });
 
-  it("treats Cloud telemetry env presence as an explicit service override", () => {
-    expect(cloudTelemetryOverrideFromEnv({})).toBeUndefined();
-    expect(cloudTelemetryOverrideFromEnv({ [CLOUD_TELEMETRY_FEATURE_ENV]: "1" })).toBe(true);
-    expect(cloudTelemetryOverrideFromEnv({ [CLOUD_TELEMETRY_FEATURE_ENV]: "0" })).toBe(false);
-    expect(cloudTelemetryOverrideFromEnv({ [CLOUD_TELEMETRY_FEATURE_ENV]: "" })).toBe(false);
-    expect(cloudTelemetryOverrideFromEnv({ [CLOUD_TELEMETRY_FEATURE_ENV]: "true" })).toBe(false);
+  it("reports only the flags the environment names, so changing one never moves another", () => {
+    expect(featureFlagOverridesFromEnv({})).toEqual({});
+    expect(featureFlagOverridesFromEnv({ [CLOUD_TELEMETRY_FEATURE_ENV]: "1" })).toEqual({
+      [CLOUD_TELEMETRY_FEATURE_ENV]: true,
+    });
+    expect(featureFlagOverridesFromEnv({ [CLOUD_CATALOG_FEATURE_ENV]: "0" })).toEqual({
+      [CLOUD_CATALOG_FEATURE_ENV]: false,
+    });
+    expect(
+      featureFlagOverridesFromEnv({
+        [CLOUD_TELEMETRY_FEATURE_ENV]: "true",
+        [CLOUD_CATALOG_FEATURE_ENV]: "1",
+      }),
+    ).toEqual({ [CLOUD_TELEMETRY_FEATURE_ENV]: false, [CLOUD_CATALOG_FEATURE_ENV]: true });
   });
 });

--- a/apps/ratel-local/src/feature-flags.ts
+++ b/apps/ratel-local/src/feature-flags.ts
@@ -1,10 +1,21 @@
 export const CLOUD_TELEMETRY_FEATURE_ENV = "RATEL_FEATURE_CLOUD_TELEMETRY";
 export const CLOUD_CATALOG_FEATURE_ENV = "RATEL_FEATURE_CLOUD_CATALOG";
 
+/** Every daemon-wide flag an installed service may carry. */
+export const SERVICE_FEATURE_FLAG_ENVS = [
+  CLOUD_TELEMETRY_FEATURE_ENV,
+  CLOUD_CATALOG_FEATURE_ENV,
+] as const;
+
 export interface FeatureFlags {
   cloudTelemetry: boolean;
   cloudCatalog: boolean;
 }
+
+/** The flags an operator named explicitly, keyed by environment variable. */
+export type ServiceFeatureFlagOverrides = Readonly<
+  Partial<Record<(typeof SERVICE_FEATURE_FLAG_ENVS)[number], boolean>>
+>;
 
 /**
  * Resolve daemon-wide feature flags from the startup environment. Flags are
@@ -17,7 +28,7 @@ export function featureFlagsFromEnv(env: NodeJS.ProcessEnv): FeatureFlags {
   };
 }
 
-/** Environment entries that an installed daemon service must retain. */
+/** Persist only enabled flags into an installed service; absence means off. */
 export function featureFlagServiceEnvironment(flags: FeatureFlags): Record<string, string> {
   return {
     ...(flags.cloudTelemetry ? { [CLOUD_TELEMETRY_FEATURE_ENV]: "1" } : {}),
@@ -25,21 +36,13 @@ export function featureFlagServiceEnvironment(flags: FeatureFlags): Record<strin
   };
 }
 
-/** Every daemon-wide flag an installed service may carry. */
-export const SERVICE_FEATURE_FLAG_ENVS = [
-  CLOUD_TELEMETRY_FEATURE_ENV,
-  CLOUD_CATALOG_FEATURE_ENV,
-] as const;
-
 /**
  * The flags an operator named explicitly, by presence in the environment. A
  * flag left out keeps whatever the installed service already says, so changing
- * one never disturbs another (ADR-0020, ADR-0021).
+ * one never disturbs another (ADR-0020).
  */
-export function featureFlagOverridesFromEnv(
-  env: NodeJS.ProcessEnv,
-): Readonly<Record<string, boolean>> {
-  const overrides: Record<string, boolean> = {};
+export function featureFlagOverridesFromEnv(env: NodeJS.ProcessEnv): ServiceFeatureFlagOverrides {
+  const overrides: Partial<Record<(typeof SERVICE_FEATURE_FLAG_ENVS)[number], boolean>> = {};
   for (const name of SERVICE_FEATURE_FLAG_ENVS) {
     if (Object.hasOwn(env, name)) overrides[name] = env[name] === "1";
   }

--- a/apps/ratel-local/src/feature-flags.ts
+++ b/apps/ratel-local/src/feature-flags.ts
@@ -1,7 +1,9 @@
 export const CLOUD_TELEMETRY_FEATURE_ENV = "RATEL_FEATURE_CLOUD_TELEMETRY";
+export const CLOUD_CATALOG_FEATURE_ENV = "RATEL_FEATURE_CLOUD_CATALOG";
 
 export interface FeatureFlags {
   cloudTelemetry: boolean;
+  cloudCatalog: boolean;
 }
 
 /**
@@ -11,20 +13,35 @@ export interface FeatureFlags {
 export function featureFlagsFromEnv(env: NodeJS.ProcessEnv): FeatureFlags {
   return {
     cloudTelemetry: env[CLOUD_TELEMETRY_FEATURE_ENV] === "1",
+    cloudCatalog: env[CLOUD_CATALOG_FEATURE_ENV] === "1",
   };
 }
 
 /** Environment entries that an installed daemon service must retain. */
 export function featureFlagServiceEnvironment(flags: FeatureFlags): Record<string, string> {
-  return flags.cloudTelemetry ? { [CLOUD_TELEMETRY_FEATURE_ENV]: "1" } : {};
+  return {
+    ...(flags.cloudTelemetry ? { [CLOUD_TELEMETRY_FEATURE_ENV]: "1" } : {}),
+    ...(flags.cloudCatalog ? { [CLOUD_CATALOG_FEATURE_ENV]: "1" } : {}),
+  };
 }
 
+/** Every daemon-wide flag an installed service may carry. */
+export const SERVICE_FEATURE_FLAG_ENVS = [
+  CLOUD_TELEMETRY_FEATURE_ENV,
+  CLOUD_CATALOG_FEATURE_ENV,
+] as const;
+
 /**
- * Explicit Cloud telemetry override from the invoking environment.
- * `undefined` means the variable is absent and installed service state must
- * be preserved. Any present value is an override: only exact `1` enables.
+ * The flags an operator named explicitly, by presence in the environment. A
+ * flag left out keeps whatever the installed service already says, so changing
+ * one never disturbs another (ADR-0020, ADR-0021).
  */
-export function cloudTelemetryOverrideFromEnv(env: NodeJS.ProcessEnv): boolean | undefined {
-  if (!Object.hasOwn(env, CLOUD_TELEMETRY_FEATURE_ENV)) return undefined;
-  return env[CLOUD_TELEMETRY_FEATURE_ENV] === "1";
+export function featureFlagOverridesFromEnv(
+  env: NodeJS.ProcessEnv,
+): Readonly<Record<string, boolean>> {
+  const overrides: Record<string, boolean> = {};
+  for (const name of SERVICE_FEATURE_FLAG_ENVS) {
+    if (Object.hasOwn(env, name)) overrides[name] = env[name] === "1";
+  }
+  return overrides;
 }

--- a/apps/ratel-local/src/feature-flags.ts
+++ b/apps/ratel-local/src/feature-flags.ts
@@ -28,7 +28,7 @@ export function featureFlagsFromEnv(env: NodeJS.ProcessEnv): FeatureFlags {
   };
 }
 
-/** Environment entries that an installed daemon service must retain. */
+/** Only enabled flags reach the service file; absence means off. */
 export function featureFlagServiceEnvironment(flags: FeatureFlags): Record<string, string> {
   return {
     ...(flags.cloudTelemetry ? { [CLOUD_TELEMETRY_FEATURE_ENV]: "1" } : {}),

--- a/apps/ratel-local/src/feature-flags.ts
+++ b/apps/ratel-local/src/feature-flags.ts
@@ -28,7 +28,7 @@ export function featureFlagsFromEnv(env: NodeJS.ProcessEnv): FeatureFlags {
   };
 }
 
-/** Persist only enabled flags into an installed service; absence means off. */
+/** Environment entries that an installed daemon service must retain. */
 export function featureFlagServiceEnvironment(flags: FeatureFlags): Record<string, string> {
   return {
     ...(flags.cloudTelemetry ? { [CLOUD_TELEMETRY_FEATURE_ENV]: "1" } : {}),
@@ -37,9 +37,9 @@ export function featureFlagServiceEnvironment(flags: FeatureFlags): Record<strin
 }
 
 /**
- * The flags an operator named explicitly, by presence in the environment. A
- * flag left out keeps whatever the installed service already says, so changing
- * one never disturbs another (ADR-0020).
+ * Explicit feature-flag overrides from the invoking environment.
+ * A flag left out keeps installed service state. Any present value is an
+ * override: only exact `1` enables.
  */
 export function featureFlagOverridesFromEnv(env: NodeJS.ProcessEnv): ServiceFeatureFlagOverrides {
   const overrides: Partial<Record<(typeof SERVICE_FEATURE_FLAG_ENVS)[number], boolean>> = {};

--- a/packages/core/src/context-snapshot.test.ts
+++ b/packages/core/src/context-snapshot.test.ts
@@ -197,4 +197,129 @@ describe("ContextSnapshotResolver", () => {
       InvalidContextSnapshotError,
     );
   });
+
+  it("adds Cloud skills, lets a local skill of the same id win, and says which was shadowed", async () => {
+    const { homeDir, project } = await fixture();
+    await mkdir(join(homeDir, ".ratel", "skills", "shared"), { recursive: true });
+    await writeFile(
+      join(homeDir, ".ratel", "skills", "shared", "SKILL.md"),
+      "---\nname: shared\ndescription: the local copy\n---\n\nlocal body\n",
+    );
+    await writeFile(
+      join(homeDir, ".ratel", "config.json"),
+      JSON.stringify({ skills: { dirs: [join(homeDir, ".ratel", "skills")] } }),
+    );
+    const registry = createProjectRegistry({ homeDir });
+    const resolver = createContextSnapshotResolver({
+      homeDir,
+      projectRegistry: registry,
+      cloudCatalog: async () => ({
+        catalog: {
+          catalogVersion: "v1",
+          skills: [
+            { id: "shared", name: "shared", description: "the published copy", body: "cloud" },
+            { id: "cloud-only", name: "cloud-only", description: "published", body: "cloud" },
+          ],
+        },
+      }),
+    });
+
+    const snapshot = await resolver.resolve({ kind: "project", projectId: project.id });
+    const byId = new Map(snapshot.skills.effectiveSkills.map((skill) => [skill.id, skill]));
+    expect([...byId.keys()].sort()).toEqual(["cloud-only", "shared"]);
+    expect(byId.get("shared")?.description).toBe("the local copy");
+    const shadowed = snapshot.diagnostics.find((d) => d.code === "cloud-skill-shadowed");
+    expect(shadowed?.severity).toBe("warning");
+    expect(shadowed?.message).toContain('"shared"');
+    expect(shadowed?.message).toContain("rename the local skill to use the published one");
+  });
+
+  it("changes the runtime revision when only the Cloud catalog version changes", async () => {
+    const { homeDir, project } = await fixture();
+    const registry = createProjectRegistry({ homeDir });
+    const resolverFor = (catalogVersion: string) =>
+      createContextSnapshotResolver({
+        homeDir,
+        projectRegistry: registry,
+        cloudCatalog: async () => ({ catalog: { catalogVersion, skills: [] } }),
+      });
+
+    const context = { kind: "project" as const, projectId: project.id };
+    const first = await resolverFor("v1").resolve(context);
+    const same = await resolverFor("v1").resolve(context);
+    const later = await resolverFor("v2").resolve(context);
+
+    expect(same.runtimeRevision).toBe(first.runtimeRevision);
+    expect(later.runtimeRevision).not.toBe(first.runtimeRevision);
+  });
+
+  it("pulls the Cloud catalog once per resolve, and again on the next one", async () => {
+    // The memo lives inside `resolve`. Hoisting it would make a published
+    // change invisible until the daemon restarted.
+    const { homeDir, project } = await fixture();
+    const registry = createProjectRegistry({ homeDir });
+    const pulls: unknown[] = [];
+    const resolver = createContextSnapshotResolver({
+      homeDir,
+      projectRegistry: registry,
+      cloudCatalog: async () => {
+        pulls.push(null);
+        return { catalog: { catalogVersion: `v${pulls.length}`, skills: [] } };
+      },
+    });
+
+    const context = { kind: "project" as const, projectId: project.id };
+    const first = await resolver.resolve(context);
+    const second = await resolver.resolve(context);
+
+    expect(pulls).toHaveLength(2);
+    expect(second.runtimeRevision).not.toBe(first.runtimeRevision);
+  });
+
+  it("reports a failed Cloud pull as a warning instead of failing the resolve", async () => {
+    const { homeDir, project } = await fixture();
+    const resolver = createContextSnapshotResolver({
+      homeDir,
+      projectRegistry: createProjectRegistry({ homeDir }),
+      cloudCatalog: async () => {
+        throw new Error("Cloud catalog auth failed: HTTP 401");
+      },
+    });
+
+    const snapshot = await resolver.resolve({ kind: "project", projectId: project.id });
+
+    const failed = snapshot.diagnostics.find((d) => d.code === "cloud-catalog-unavailable");
+    expect(failed?.severity).toBe("warning");
+    expect(failed?.message).toContain("HTTP 401");
+    expect(snapshot.skills.effectiveSkills).toEqual([]);
+  });
+
+  it("warns when the catalog served is a cached one, so a stale catalog is not silent", async () => {
+    const { homeDir, project } = await fixture();
+    const resolver = createContextSnapshotResolver({
+      homeDir,
+      projectRegistry: createProjectRegistry({ homeDir }),
+      cloudCatalog: async () => ({
+        catalog: { catalogVersion: "v1", skills: [] },
+        degraded: "The operation was aborted due to timeout",
+      }),
+    });
+
+    const snapshot = await resolver.resolve({ kind: "project", projectId: project.id });
+
+    const stale = snapshot.diagnostics.find((d) => d.code === "cloud-catalog-degraded");
+    expect(stale?.severity).toBe("warning");
+    expect(stale?.message).toContain("aborted due to timeout");
+    // Degraded is not unavailable: the cached catalog is still in use.
+    expect(
+      snapshot.diagnostics.find((d) => d.code === "cloud-catalog-unavailable"),
+    ).toBeUndefined();
+  });
+
+  it("resolves without a Cloud catalog at all", async () => {
+    const { project, resolver } = await fixture();
+    const snapshot = await resolver.resolve({ kind: "project", projectId: project.id });
+    expect(snapshot.skills.effectiveSkills).toEqual([]);
+    expect(snapshot.diagnostics).toEqual([]);
+  });
 });

--- a/packages/core/src/context-snapshot.test.ts
+++ b/packages/core/src/context-snapshot.test.ts
@@ -254,8 +254,6 @@ describe("ContextSnapshotResolver", () => {
   });
 
   it("pulls the Cloud catalog once per resolve, and again on the next one", async () => {
-    // The memo lives inside `resolve`. Hoisting it would make a published
-    // change invisible until the daemon restarted.
     const { homeDir, project } = await fixture();
     const registry = createProjectRegistry({ homeDir });
     const pulls: unknown[] = [];
@@ -310,7 +308,6 @@ describe("ContextSnapshotResolver", () => {
     const stale = snapshot.diagnostics.find((d) => d.code === "cloud-catalog-degraded");
     expect(stale?.severity).toBe("warning");
     expect(stale?.message).toContain("aborted due to timeout");
-    // Degraded is not unavailable: the cached catalog is still in use.
     expect(
       snapshot.diagnostics.find((d) => d.code === "cloud-catalog-unavailable"),
     ).toBeUndefined();

--- a/packages/core/src/context-snapshot.ts
+++ b/packages/core/src/context-snapshot.ts
@@ -1,6 +1,7 @@
 import { createHash } from "node:crypto";
 import { readFile, stat } from "node:fs/promises";
 import { dirname } from "node:path";
+import type { Skill } from "@ratel-ai/sdk";
 import type {
   DocumentRevision,
   ProjectId,
@@ -72,6 +73,18 @@ export interface ContextSnapshotResolverOptions {
   maxReadAttempts?: number;
   /** Daemon environment used to resolve MCP URL placeholders. Defaults to process.env. */
   env?: NodeJS.ProcessEnv;
+  /** Injected catalog pull; this module does no network I/O. */
+  cloudCatalog?: (context: RuntimeContextRef) => Promise<CloudCatalogPullResult | undefined>;
+}
+
+export interface CloudCatalogPullResult {
+  catalog: CloudSkillCatalog;
+  degraded?: string;
+}
+
+export interface CloudSkillCatalog {
+  catalogVersion: string;
+  skills: Skill[];
 }
 
 export class InvalidContextSnapshotError extends Error {
@@ -110,12 +123,22 @@ interface OAuthStoreRevision {
   revision: string;
 }
 
+/** One catalog pull: what it returned, or why it did not. */
+interface CloudCatalogPull {
+  catalog?: CloudSkillCatalog;
+  error?: string;
+  degraded?: string;
+}
+
 export function createContextSnapshotResolver(
   options: ContextSnapshotResolverOptions,
 ): ContextSnapshotResolver {
   const maxReadAttempts = options.maxReadAttempts ?? 3;
   return {
     async resolve(context) {
+      let pulled: Promise<CloudCatalogPull> | undefined;
+      const pullCloudCatalog = () =>
+        (pulled ??= pullCloudCatalogOnce(options.cloudCatalog, context));
       const projectRoot = await resolveProjectRoot(context, options.projectRegistry);
       const targets = documentTargets(options.homeDir, context, projectRoot);
       if (projectRoot) {
@@ -173,7 +196,10 @@ export function createContextSnapshotResolver(
         const confirmedOAuthStoreRevisions = await readOAuthStoreRevisions(mcpEntries);
         if (!sameOAuthStoreRevisions(oauthStoreRevisions, confirmedOAuthStoreRevisions)) continue;
         const retrieval = mergeConfigs(documents.map(({ config }) => config)).retrieval;
+        const cloud = await pullCloudCatalog();
+        const composed = composeSkills(skills.effectiveSkills, cloud.catalog?.skills ?? []);
         const diagnostics: Diagnostic[] = [
+          ...cloudDiagnostics(cloud, composed.shadowed),
           ...skills.diagnostics.map(({ code, severity, message, path }) => ({
             code,
             severity,
@@ -193,6 +219,7 @@ export function createContextSnapshotResolver(
           mcpEntries,
           skills.fingerprint,
           oauthStoreRevisions,
+          cloud.catalog?.catalogVersion,
         );
         const skillWatchInputs = await Promise.all(
           skills.watchInputs.map(async (path): Promise<WatchInput> => {
@@ -220,7 +247,8 @@ export function createContextSnapshotResolver(
           documents,
           runtimeRevision,
           mcpEntries,
-          skills,
+          // Cloud skills have no registration or file to watch.
+          skills: { ...skills, effectiveSkills: composed.skills },
           ...(retrieval ? { retrieval } : {}),
           diagnostics,
           watchInputs,
@@ -389,11 +417,62 @@ function sameScope(a: RatelScopeRef, b: RatelScopeRef): boolean {
   );
 }
 
+/** Local id wins; shadowed Cloud ids are returned, not dropped. */
+function composeSkills(local: Skill[], cloud: Skill[]) {
+  const localIds = new Set(local.map(({ id }) => id));
+  return {
+    skills: [...local, ...cloud.filter(({ id }) => !localIds.has(id))],
+    shadowed: cloud.filter(({ id }) => localIds.has(id)).map(({ id }) => id),
+  };
+}
+
+function cloudDiagnostics(cloud: CloudCatalogPull, shadowed: string[]): Diagnostic[] {
+  return [
+    ...(cloud.error
+      ? [
+          {
+            code: "cloud-catalog-unavailable",
+            severity: "warning" as const,
+            message: `Cloud skills are not in use: ${cloud.error}`,
+          },
+        ]
+      : []),
+    ...(cloud.degraded
+      ? [
+          {
+            code: "cloud-catalog-degraded",
+            severity: "warning" as const,
+            message: `Cloud skills may be out of date: the last cached catalog is being served because ${cloud.degraded}`,
+          },
+        ]
+      : []),
+    ...shadowed.map((id) => ({
+      code: "cloud-skill-shadowed",
+      severity: "warning" as const,
+      message: `Cloud skill "${id}" is not in use: a local skill with the same id takes precedence; rename the local skill to use the published one`,
+    })),
+  ];
+}
+
+async function pullCloudCatalogOnce(
+  pull: ContextSnapshotResolverOptions["cloudCatalog"],
+  context: RuntimeContextRef,
+): Promise<CloudCatalogPull> {
+  if (!pull) return {};
+  try {
+    const result = await pull(context);
+    return result ? { catalog: result.catalog, degraded: result.degraded } : {};
+  } catch (error) {
+    return { error: (error as Error).message };
+  }
+}
+
 function digestRuntimeRevision(
   documents: ScopedDocumentSnapshot[],
   mcpEntries: ResolvedMcpEntry[],
   skillFingerprint: string,
   oauthStoreRevisions: readonly OAuthStoreRevision[],
+  cloudCatalogVersion: string | undefined,
 ): RuntimeRevision {
   const normalizedDocuments = documents.map(({ ref, config }) => ({ ref, config }));
   const runtimeMcpEntries = mcpEntries.map(({ name, owner, status, runtimeCwd, oauthKey }) => ({
@@ -403,16 +482,21 @@ function digestRuntimeRevision(
     runtimeCwd,
     oauthFingerprint: oauthKey.fingerprint,
   }));
-  return createHash("sha256")
-    .update(`ratel-runtime-v${CONTEXT_SNAPSHOT_RESOLVER_VERSION}\0`)
-    .update(stableStringify(normalizedDocuments))
-    .update("\0")
-    .update(stableStringify(runtimeMcpEntries))
-    .update("\0")
-    .update(skillFingerprint)
-    .update("\0")
-    .update(stableStringify(oauthStoreRevisions))
-    .digest("base64url") as RuntimeRevision;
+  return (
+    createHash("sha256")
+      .update(`ratel-runtime-v${CONTEXT_SNAPSHOT_RESOLVER_VERSION}\0`)
+      .update(stableStringify(normalizedDocuments))
+      .update("\0")
+      .update(stableStringify(runtimeMcpEntries))
+      .update("\0")
+      .update(skillFingerprint)
+      .update("\0")
+      .update(stableStringify(oauthStoreRevisions))
+      .update("\0")
+      // Cloud skills have no path, so the fingerprint above cannot see them.
+      .update(cloudCatalogVersion ?? "")
+      .digest("base64url") as RuntimeRevision
+  );
 }
 
 function stableStringify(value: unknown): string {

--- a/packages/core/src/context-snapshot.ts
+++ b/packages/core/src/context-snapshot.ts
@@ -482,6 +482,7 @@ function digestRuntimeRevision(
     runtimeCwd,
     oauthFingerprint: oauthKey.fingerprint,
   }));
+  // Cloud skills have no path, so the catalog version stands in for them.
   return createHash("sha256")
     .update(`ratel-runtime-v${CONTEXT_SNAPSHOT_RESOLVER_VERSION}\0`)
     .update(stableStringify(normalizedDocuments))
@@ -492,7 +493,6 @@ function digestRuntimeRevision(
     .update("\0")
     .update(stableStringify(oauthStoreRevisions))
     .update("\0")
-    // Cloud skills have no path, so the fingerprint above cannot see them.
     .update(cloudCatalogVersion ?? "")
     .digest("base64url") as RuntimeRevision;
 }

--- a/packages/core/src/context-snapshot.ts
+++ b/packages/core/src/context-snapshot.ts
@@ -482,20 +482,19 @@ function digestRuntimeRevision(
     runtimeCwd,
     oauthFingerprint: oauthKey.fingerprint,
   }));
-  return (
-    createHash("sha256")
-      .update(`ratel-runtime-v${CONTEXT_SNAPSHOT_RESOLVER_VERSION}\0`)
-      .update(stableStringify(normalizedDocuments))
-      .update("\0")
-      .update(stableStringify(runtimeMcpEntries))
-      .update("\0")
-      .update(skillFingerprint)
-      .update("\0")
-      .update(stableStringify(oauthStoreRevisions))
-      .update("\0")
-      .update(cloudCatalogVersion ?? "")
-      .digest("base64url") as RuntimeRevision
-  );
+  return createHash("sha256")
+    .update(`ratel-runtime-v${CONTEXT_SNAPSHOT_RESOLVER_VERSION}\0`)
+    .update(stableStringify(normalizedDocuments))
+    .update("\0")
+    .update(stableStringify(runtimeMcpEntries))
+    .update("\0")
+    .update(skillFingerprint)
+    .update("\0")
+    .update(stableStringify(oauthStoreRevisions))
+    .update("\0")
+    // Cloud skills have no path, so the fingerprint above cannot see them.
+    .update(cloudCatalogVersion ?? "")
+    .digest("base64url") as RuntimeRevision;
 }
 
 function stableStringify(value: unknown): string {

--- a/packages/core/src/context-snapshot.ts
+++ b/packages/core/src/context-snapshot.ts
@@ -493,7 +493,6 @@ function digestRuntimeRevision(
       .update("\0")
       .update(stableStringify(oauthStoreRevisions))
       .update("\0")
-      // Cloud skills have no path, so the fingerprint above cannot see them.
       .update(cloudCatalogVersion ?? "")
       .digest("base64url") as RuntimeRevision
   );

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -26,6 +26,7 @@ import {
   useState,
 } from "react";
 import { BrandLogo } from "@/components/brand-logo";
+import { ContextDiagnostics, type SnapshotDiagnostic } from "@/components/context-diagnostics";
 import { ContextSwitcher } from "@/components/context-switcher";
 import { ShortcutHint } from "@/components/shortcut-hint";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
@@ -159,6 +160,7 @@ export interface ConfigResponse {
   }>;
   runtimeRevision?: string;
   effectiveRetrieval?: RetrievalConfig;
+  diagnostics?: SnapshotDiagnostic[];
 }
 
 export interface ServerToolTokenEstimate {
@@ -440,7 +442,10 @@ export function AppShell() {
                 </Alert>
               </main>
             ) : (
-              <Outlet />
+              <>
+                <ContextDiagnostics diagnostics={config?.diagnostics ?? []} />
+                <Outlet />
+              </>
             )}
           </div>
         </div>

--- a/packages/ui/src/components/context-diagnostics.test.tsx
+++ b/packages/ui/src/components/context-diagnostics.test.tsx
@@ -1,0 +1,66 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { ContextDiagnostics, type SnapshotDiagnostic } from "./context-diagnostics";
+
+const warning = (code: string, message: string): SnapshotDiagnostic => ({
+  code,
+  severity: "warning",
+  message,
+});
+
+describe("ContextDiagnostics", () => {
+  it("renders nothing when the context is healthy", () => {
+    expect(renderToStaticMarkup(<ContextDiagnostics diagnostics={[]} />)).toBe("");
+  });
+
+  it("shows the message and the code, so a warning can be acted on and searched for", () => {
+    const html = renderToStaticMarkup(
+      <ContextDiagnostics
+        diagnostics={[
+          warning(
+            "cloud-skill-shadowed",
+            'Cloud skill "shared" is not in use: a local skill with the same id takes precedence.',
+          ),
+        ]}
+      />,
+    );
+
+    expect(html).toContain("cloud-skill-shadowed");
+    expect(html).toContain("a local skill with the same id takes precedence");
+  });
+
+  it("puts errors above warnings", () => {
+    const html = renderToStaticMarkup(
+      <ContextDiagnostics
+        diagnostics={[
+          warning("cloud-catalog-degraded", "serving a cached catalog"),
+          { code: "project-control-path-unsafe", severity: "error", message: "outside the root" },
+        ]}
+      />,
+    );
+
+    expect(html.indexOf("outside the root")).toBeLessThan(html.indexOf("serving a cached catalog"));
+  });
+
+  it("marks an error apart from a warning instead of showing both the same", () => {
+    const asError = renderToStaticMarkup(
+      <ContextDiagnostics diagnostics={[{ code: "boom", severity: "error", message: "broken" }]} />,
+    );
+    const asWarning = renderToStaticMarkup(
+      <ContextDiagnostics diagnostics={[warning("boom", "broken")]} />,
+    );
+
+    expect(asError).toContain("text-destructive");
+    expect(asWarning).not.toContain("text-destructive");
+  });
+
+  it("shows the path when the diagnostic names one", () => {
+    const html = renderToStaticMarkup(
+      <ContextDiagnostics
+        diagnostics={[{ ...warning("skill-unreadable", "cannot read"), path: "/a/b/SKILL.md" }]}
+      />,
+    );
+
+    expect(html).toContain("/a/b/SKILL.md");
+  });
+});

--- a/packages/ui/src/components/context-diagnostics.tsx
+++ b/packages/ui/src/components/context-diagnostics.tsx
@@ -1,0 +1,38 @@
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+
+export interface SnapshotDiagnostic {
+  code: string;
+  severity: "warning" | "error";
+  message: string;
+  path?: string;
+}
+
+function bySeverity(a: SnapshotDiagnostic, b: SnapshotDiagnostic): number {
+  if (a.severity === b.severity) return 0;
+  return a.severity === "error" ? -1 : 1;
+}
+
+export function ContextDiagnostics({ diagnostics }: { diagnostics: SnapshotDiagnostic[] }) {
+  if (diagnostics.length === 0) return null;
+  return (
+    <div className="flex flex-col gap-2 px-6 pt-6" data-slot="context-diagnostics">
+      {[...diagnostics].sort(bySeverity).map((diagnostic) => (
+        // One cause can produce several diagnostics sharing a code.
+        <Alert
+          key={`${diagnostic.code}:${diagnostic.path ?? ""}:${diagnostic.message}`}
+          variant={diagnostic.severity === "error" ? "destructive" : "default"}
+        >
+          <AlertTitle className="font-mono text-xs">{diagnostic.code}</AlertTitle>
+          <AlertDescription>
+            {diagnostic.message}
+            {diagnostic.path && (
+              <span className="mt-1 block truncate font-mono text-xs opacity-80">
+                {diagnostic.path}
+              </span>
+            )}
+          </AlertDescription>
+        </Alert>
+      ))}
+    </div>
+  );
+}

--- a/packages/ui/src/components/context-diagnostics.tsx
+++ b/packages/ui/src/components/context-diagnostics.tsx
@@ -17,7 +17,7 @@ export function ContextDiagnostics({ diagnostics }: { diagnostics: SnapshotDiagn
   return (
     <div className="flex flex-col gap-2 px-6 pt-6" data-slot="context-diagnostics">
       {[...diagnostics].sort(bySeverity).map((diagnostic) => (
-        // One cause can produce several diagnostics sharing a code.
+        // Codes are not unique: one cause can emit several diagnostics.
         <Alert
           key={`${diagnostic.code}:${diagnostic.path ?? ""}:${diagnostic.message}`}
           variant={diagnostic.severity === "error" ? "destructive" : "default"}


### PR DESCRIPTION
## What

Ratel Local can serve a project's published Cloud skills alongside local ones, behind `RATEL_FEATURE_CLOUD_CATALOG`, off by default.

PR #47 added the catalog loader but nothing called it. This wires it into the context snapshot resolver, so a published skill joins the resolved set, gets indexed, and reaches an agent through the gateway.

## Changes

- Cloud skills join the resolved skill set. A local skill with the same id wins, and the shadowed one is reported rather than disappearing silently.
- A failed or cached catalog pull becomes a diagnostic instead of failing the resolve.
- The catalog version enters the runtime revision, so a published change builds a new gateway generation instead of reusing a stale one.
- Snapshot diagnostics render in the UI shell. They were already returned by `/api/config` and shown nowhere, so a shadowed skill or an unreadable `SKILL.md` was reachable only by curling the daemon with its token.
- Daemon feature flags generalise past one. The plist entry and the systemd line were module constants built from the single telemetry variable name, so a second flag could not be persisted at all. A flag absent from the environment now keeps whatever the installed service says.
- A rejected catalog key is held for a minute instead of being re-asked on every context resolve.

## Enabling it

Off by default. Two steps: turn the flag on, then give the daemon a credential.

**The flag** is written into the installed launchd or systemd service, so it survives restarts:

```
RATEL_FEATURE_CLOUD_CATALOG=1 ratel-local daemon restart
```

Leave it out of a later restart and it stays as it is; pass `=0` to turn it off. The same applies to `RATEL_FEATURE_CLOUD_TELEMETRY`, and changing one no longer disturbs the other.

**The credential**, either way:

Stored, in `~/.ratel/cloud-traces.json`, the same file the trace relay already uses:

```json
{ "endpoint": "https://cloud.ratel.sh/api/v1/traces", "apiKey": "rtl_..." }
```

This is read on every pull rather than captured at boot, so a key rotated while the daemon runs is picked up on the next context resolve, and a daemon started before the file existed picks it up without a restart. The catalog takes only the key from there: that `endpoint` is the traces one, and the catalog uses its own.

From the environment, with `RATEL_API_KEY`:

```
RATEL_API_KEY=rtl_... RATEL_FEATURE_CLOUD_CATALOG=1 ratel-local daemon run
```

This reaches a foreground daemon only. The service file persists feature flags and never the key, and the key is scrubbed from the environment right after it is read so no subprocess inherits it. For an installed service, use the stored file.

The key is now read whenever either Cloud flag is on, since it belongs to the account rather than to telemetry only. The relay is untouched and still needs its own flag and its own endpoint.

### Disabling it

Rolling back needs no code change: 

```
RATEL_FEATURE_CLOUD_CATALOG=0 ratel-local daemon restart
```

This command returns the daemon to local skills only, leaving Cloud telemetry as it was.

## Verified against real Cloud

On a machine wiped to nothing, with the daemon reinstalled from this branch:

- five published skills resolved, with zero local registrations
- the credential is read per pull, not captured at boot: the skills appeared on a daemon that had been started before the key existed
- a local skill with the same id as a published one takes precedence, and the `cloud-skill-shadowed` warning shows in the UI shell
- a coding agent invoked `ffmpeg__extract_audio` and got a real mp3 back
- spans for that search and invocation reached the Cloud dashboard /traces page
