### PR TITLE
fix: pnpm dev:ui 

### DIFF
--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -1,6 +1,6 @@
 # Ratel Local UI
 
-Local UI development uses the real `ratel-local ui` API server and Vite for the React app.
+Local UI development attaches to the running daemon and uses Vite for the React app.
 
 From the workspace root:
 
@@ -17,11 +17,13 @@ That command:
 
 Start the daemon with `ratel-local setup` if it is not running.
 
-Optional port overrides:
+Optional overrides:
 
 ```bash
-RATEL_LOCAL_UI_API_PORT=5731 RATEL_LOCAL_UI_VITE_PORT=5173 pnpm dev:ui
+RATEL_LOCAL_UI_VITE_PORT=5173 pnpm dev:ui
 ```
+
+Set `RATEL_LOCAL_UI_OPEN=0` to skip opening the browser.
 
 Use the printed `Vite UI` URL. It has the `?t=...` token that the app sends as the
 `Authorization: Bearer ...` header for API requests.

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -10,11 +10,12 @@ pnpm dev:ui
 
 That command:
 
-- starts `ratel-local ui --no-open` on `127.0.0.1`;
+- asks the daemon for a UI session with `ratel-local ui --no-open`;
 - starts Vite on `127.0.0.1`;
-- chooses alternate free ports when the defaults are busy;
 - wires Vite's `/api` proxy through `RATEL_LOCAL_API_TARGET`;
-- prints the Vite URL with the API session token already attached.
+- prints and opens the Vite URL with the API session token already attached.
+
+Start the daemon with `ratel-local setup` if it is not running.
 
 Optional port overrides:
 

--- a/scripts/dev-ui.ts
+++ b/scripts/dev-ui.ts
@@ -1,94 +1,55 @@
-import { type ChildProcessWithoutNullStreams, spawn } from "node:child_process";
-import { connect, createServer } from "node:net";
-import { platform } from "node:os";
+import { execFile, spawn } from "node:child_process";
+import { promisify } from "node:util";
 
-const DEFAULT_API_PORT = 5731;
-const DEFAULT_VITE_PORT = 5173;
 const HOST = "127.0.0.1";
+const DEFAULT_VITE_PORT = 5173;
 
-type ChildName = "api" | "vite";
+const exec = promisify(execFile);
 
 async function main() {
-  const apiPort = await pickPort(Number(process.env.RATEL_LOCAL_UI_API_PORT) || DEFAULT_API_PORT);
-  const vitePort = await pickPort(
-    Number(process.env.RATEL_LOCAL_UI_VITE_PORT) || DEFAULT_VITE_PORT,
-  );
+  const session = await daemonUiSession();
+  const vitePort = Number(process.env.RATEL_LOCAL_UI_VITE_PORT) || DEFAULT_VITE_PORT;
+  const uiPath = `${session.pathname}${session.search}`;
 
-  const children = new Set<ChildProcessWithoutNullStreams>();
-  let shuttingDown = false;
-
-  const shutdown = (code = 0) => {
-    if (shuttingDown) return;
-    shuttingDown = true;
-    for (const child of children) child.kill("SIGTERM");
-    setTimeout(() => process.exit(code), 150).unref();
-  };
-
-  process.on("SIGINT", () => shutdown(0));
-  process.on("SIGTERM", () => shutdown(0));
-
-  const api = run(
-    "api",
-    [
-      "pnpm",
-      [
-        "--filter",
-        "@ratel-ai/ratel-local",
-        "exec",
-        "tsx",
-        "src/bin.ts",
-        "ui",
-        "--no-open",
-        "--port",
-        String(apiPort),
-      ],
-    ],
-    children,
-    shutdown,
-  );
-
-  const token = await waitForUiToken(api, apiPort);
-  const apiTarget = `http://${HOST}:${apiPort}`;
-  const viteUrl = `http://${HOST}:${vitePort}/?t=${encodeURIComponent(token)}`;
-
-  run(
+  const args = [
+    "--filter",
+    "@ratel-ai/ratel-local-ui",
+    "exec",
     "vite",
-    [
-      "pnpm",
-      [
-        "--filter",
-        "@ratel-ai/ratel-local-ui",
-        "exec",
-        "vite",
-        "--host",
-        HOST,
-        "--port",
-        String(vitePort),
-        "--strictPort",
-      ],
-    ],
-    children,
-    shutdown,
-    { RATEL_LOCAL_API_TARGET: apiTarget },
-  );
+    "--host",
+    HOST,
+    "--port",
+    String(vitePort),
+    "--strictPort",
+  ];
+  if (shouldOpenBrowser()) args.push("--open", uiPath);
 
   console.error("");
-  console.error(`[ratel] API target: ${apiTarget}`);
-  console.error(`[ratel] Vite UI:    ${viteUrl}`);
-  console.error("[ratel] Press Ctrl-C to stop both processes.");
+  console.error(`[ratel] API target: ${session.origin}`);
+  console.error(`[ratel] Vite UI:    http://${HOST}:${vitePort}${uiPath}`);
+  console.error("[ratel] Press Ctrl-C to stop.");
 
-  if (shouldOpenBrowser()) {
-    try {
-      await waitForPort(vitePort);
-      openBrowser(viteUrl);
-      console.error(
-        "[ratel] Opened the tokenized UI in your browser (set RATEL_LOCAL_UI_OPEN=0 to disable).",
-      );
-    } catch (err) {
-      console.error(`[ratel] Auto-open skipped: ${(err as Error).message}`);
-      console.error(`[ratel] Open ${viteUrl} manually.`);
-    }
-  }
+  const vite = spawn("pnpm", args, {
+    stdio: "inherit",
+    env: { ...process.env, RATEL_LOCAL_API_TARGET: session.origin },
+  });
+  vite.on("exit", (code, signal) => process.exit(code ?? (signal ? 1 : 0)));
+}
+
+/** Asks the running daemon for a UI session; its URL carries both the proxy target and the token. */
+async function daemonUiSession(): Promise<URL> {
+  const { stdout, stderr } = await exec("pnpm", [
+    "--filter",
+    "@ratel-ai/ratel-local",
+    "exec",
+    "tsx",
+    "src/bin.ts",
+    "ui",
+    "--no-open",
+  ]);
+  const match = /https?:\/\/\S+\?t=\S+/.exec(`${stdout}\n${stderr}`);
+  if (!match) throw new Error("`ratel-local ui --no-open` printed no session URL");
+  return new URL(match[0]);
 }
 
 function shouldOpenBrowser(): boolean {
@@ -97,133 +58,8 @@ function shouldOpenBrowser(): boolean {
   return flag !== "0" && flag !== "false";
 }
 
-function waitForPort(port: number, timeoutMs = 15_000): Promise<void> {
-  const deadline = Date.now() + timeoutMs;
-  return new Promise((resolve, reject) => {
-    const attempt = () => {
-      const socket = connect(port, HOST);
-      socket.once("connect", () => {
-        socket.destroy();
-        resolve();
-      });
-      socket.once("error", () => {
-        socket.destroy();
-        if (Date.now() > deadline) {
-          reject(new Error(`timed out waiting for Vite to listen on port ${port}`));
-          return;
-        }
-        setTimeout(attempt, 200).unref();
-      });
-    };
-    attempt();
-  });
-}
-
-function openBrowser(url: string): void {
-  const [bin, args] =
-    platform() === "darwin"
-      ? (["open", [url]] as const)
-      : platform() === "win32"
-        ? (["cmd", ["/c", "start", "", url]] as const)
-        : (["xdg-open", [url]] as const);
-
-  const child = spawn(bin, [...args], { stdio: "ignore", detached: true });
-  child.on("error", () => {
-    console.error(`[ratel] Could not auto-open a browser; open ${url} manually.`);
-  });
-  child.unref();
-}
-
-function run(
-  name: ChildName,
-  command: [string, string[]],
-  children: Set<ChildProcessWithoutNullStreams>,
-  shutdown: (code?: number) => void,
-  env: NodeJS.ProcessEnv = {},
-): ChildProcessWithoutNullStreams {
-  const [bin, args] = command;
-  const child = spawn(bin, args, {
-    cwd: process.cwd(),
-    env: { ...process.env, ...env },
-    stdio: ["ignore", "pipe", "pipe"],
-  });
-
-  children.add(child);
-  child.stdout.on("data", (chunk) => writePrefixed(name, chunk));
-  child.stderr.on("data", (chunk) => writePrefixed(name, chunk));
-  child.on("exit", (code, signal) => {
-    children.delete(child);
-    if (code !== 0 && signal !== "SIGTERM") {
-      console.error(`[ratel] ${name} exited with ${code ?? signal}`);
-      shutdown(code ?? 1);
-    }
-  });
-
-  return child;
-}
-
-function waitForUiToken(child: ChildProcessWithoutNullStreams, port: number): Promise<string> {
-  const pattern = new RegExp(`http://${HOST}:${port}/\\?t=([^\\s]+)`);
-  let buffer = "";
-
-  return new Promise((resolve, reject) => {
-    const timeout = setTimeout(() => {
-      reject(new Error("timed out waiting for ratel-local ui to print its session URL"));
-    }, 15_000);
-
-    const onData = (chunk: Buffer) => {
-      buffer += chunk.toString("utf8");
-      const match = pattern.exec(buffer);
-      if (!match) return;
-      clearTimeout(timeout);
-      child.stderr.off("data", onData);
-      child.stdout.off("data", onData);
-      resolve(match[1]);
-    };
-
-    child.stderr.on("data", onData);
-    child.stdout.on("data", onData);
-    child.once("exit", (code, signal) => {
-      clearTimeout(timeout);
-      reject(new Error(`ratel-local ui exited before printing a URL: ${code ?? signal}`));
-    });
-  });
-}
-
-async function pickPort(preferred: number): Promise<number> {
-  if (await isPortFree(preferred)) return preferred;
-  return new Promise((resolve, reject) => {
-    const server = createServer();
-    server.once("error", reject);
-    server.listen(0, HOST, () => {
-      const address = server.address();
-      if (!address || typeof address === "string") {
-        reject(new Error("could not allocate a free port"));
-        return;
-      }
-      const port = address.port;
-      server.close(() => resolve(port));
-    });
-  });
-}
-
-function isPortFree(port: number): Promise<boolean> {
-  return new Promise((resolve) => {
-    const server = createServer();
-    server.once("error", () => resolve(false));
-    server.listen(port, HOST, () => {
-      server.close(() => resolve(true));
-    });
-  });
-}
-
-function writePrefixed(name: ChildName, chunk: Buffer) {
-  for (const line of chunk.toString("utf8").split(/\r?\n/)) {
-    if (line) console.error(`[${name}] ${line}`);
-  }
-}
-
 main().catch((err) => {
-  console.error(`[ratel] ${(err as Error).message}`);
+  const stderr = (err as { stderr?: string }).stderr?.trim();
+  console.error(stderr || `[ratel] ${(err as Error).message}`);
   process.exit(1);
 });


### PR DESCRIPTION
## Problem

`pnpm dev:ui` still spawned `ratel-local ui --port`, which the daemon-era CLI rejects. The script then died before Vite started, so local UI work could not attach to the running daemon.

## Solution

Ask the already-running daemon for a UI session (`ratel-local ui --no-open`), take origin and token from the printed URL, and start only Vite with `RATEL_LOCAL_API_TARGET` pointed at that daemon. If the daemon is down, tell the developer to run `ratel-local setup`.

## Notes

- `RATEL_LOCAL_UI_API_PORT` no longer does anything; Vite still honors `RATEL_LOCAL_UI_VITE_PORT`. The UI README still shows the API env var in the optional-port example.
- Auto-open now uses Vite `--open` instead of a custom browser helper.