### PR TITLE
release: v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this package are documented here. The format is based on 
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-09-04
+
 ### Added
 - Added the off-by-default `RATEL_FEATURE_CLOUD_CATALOG=1` daemon flag. When it
   is on, the daemon pulls published Cloud skills into the snapshot using the

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ persistent daemon, detects Claude Code and Codex, connects the agents you
 select, and offers existing MCP servers and skills as a separate reviewed
 import.
 
-This README tracks the `0.8.2` stable release, matching the package version
+This README tracks the `0.9.0` stable release, matching the package version
 pinned by the bundled plugin. Unqualified npm installs resolve the `latest`
 dist-tag; the examples below remain exact-versioned for reproducibility.
 
@@ -44,7 +44,7 @@ the gateway and agent skills. Stable builds use the **Ratel** marketplace from
 the repository's default `main` branch. Prerelease builds alone pin the same
 marketplace identity to their immutable matching release tag: Codex uses
 `--ref`, while Claude Code uses the equivalent `owner/repo@ref` source. Stable
-`0.8.2` therefore carries no RC branch or tag override.
+`0.9.0` therefore carries no RC branch or tag override.
 
 If an agent already has the plugin, `link` reconciles that marketplace channel and reinstalls the plugin. It verifies that an RC tag exists before changing a working installation and attempts to restore the stable plugin if an RC switch fails after removal. When stable is restored, the command preserves that connection but reports the RC setup as failed rather than claiming the requested channel is active. If no usable plugin remains, a new link uses the reviewed explicit MCP gateway fallback; a failed existing-plugin reconciliation stops with an error. Importing still recognizes an enabled plugin as an existing Ratel connection and does not add a second gateway. If the Codex plugin is enabled but its bundled Ratel MCP server is disabled, `link` re-enables that server. Agent Setup offers **Fix duplicate installation** when both the plugin and an explicit Ratel MCP entry are present, and **Switch to plugin** for MCP-only installations. Both actions preserve the existing MCP connection unless plugin installation succeeds, and only recognized Ratel entries are removed.
 
@@ -55,7 +55,7 @@ If an agent already has the plugin, `link` reconciles that marketplace channel a
 Node.js 20.6 or newer is required.
 
 ```bash
-npm install --global @ratel-ai/ratel-local@0.8.2
+npm install --global @ratel-ai/ratel-local@0.9.0
 ratel-local --version
 ```
 
@@ -82,7 +82,7 @@ marketplace channel.
 If you do not have a global installation, run the release-pinned package:
 
 ```bash
-npx -y @ratel-ai/ratel-local@0.8.2 setup
+npx -y @ratel-ai/ratel-local@0.9.0 setup
 ```
 
 #### 3. Confirm Ratel Local and restart

--- a/apps/ratel-local/package.json
+++ b/apps/ratel-local/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ratel-ai/ratel-local",
-  "version": "0.8.2",
+  "version": "0.9.0",
   "description": "Ratel Local package: a project-scoped persistent MCP gateway with BM25, semantic, and hybrid capability search plus the ratel-local CLI.",
   "private": false,
   "type": "module",

--- a/apps/ratel-local/plugin/.claude-plugin/plugin.json
+++ b/apps/ratel-local/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ratel-local",
   "displayName": "Ratel Local",
-  "version": "0.8.2",
+  "version": "0.9.0",
   "description": "Persistent project-scoped Ratel gateway with BM25, semantic, and hybrid capability search.",
   "author": {
     "name": "Agentified",

--- a/apps/ratel-local/plugin/.codex-plugin/plugin.json
+++ b/apps/ratel-local/plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ratel-local",
-  "version": "0.8.2",
+  "version": "0.9.0",
   "description": "Persistent project-scoped Ratel gateway with BM25, semantic, and hybrid capability search.",
   "author": {
     "name": "Agentified",

--- a/apps/ratel-local/plugin/.mcp.json
+++ b/apps/ratel-local/plugin/.mcp.json
@@ -5,7 +5,7 @@
       "command": "npx",
       "args": [
         "-y",
-        "@ratel-ai/ratel-local@0.8.2",
+        "@ratel-ai/ratel-local@0.9.0",
         "connect"
       ]
     }

--- a/apps/ratel-local/plugin/README.md
+++ b/apps/ratel-local/plugin/README.md
@@ -24,7 +24,7 @@ shared `assets/icon.svg` remains referenced by the Codex manifest.
 The plugin MCP config starts the lightweight scoped connector through `npx`:
 
 ```bash
-npx -y @ratel-ai/ratel-local@0.8.2 connect
+npx -y @ratel-ai/ratel-local@0.9.0 connect
 ```
 
 The connector forwards the agent's resolved project root to the authenticated
@@ -35,7 +35,7 @@ connections only between sessions in the same canonical project.
 Run complete onboarding once on macOS or Linux:
 
 ```bash
-npx -y @ratel-ai/ratel-local@0.8.2 setup
+npx -y @ratel-ai/ratel-local@0.9.0 setup
 ```
 
 The wizard installs, updates, or starts the daemon; detects Claude Code and
@@ -105,7 +105,7 @@ claude plugin install ratel-local@ratel
 
 Stable Ratel Local packages use the marketplace from the repository's default
 `main` branch. Prerelease packages alone reconcile that same marketplace to the
-immutable Git tag matching their exact package version; stable `0.8.2` does not
+immutable Git tag matching their exact package version; stable `0.9.0` does not
 use an RC branch or ref.
 
 If Claude Code is already running, restart it or run `/reload-plugins` inside

--- a/apps/ratel-local/plugin/skills/ratel-local/SKILL.md
+++ b/apps/ratel-local/plugin/skills/ratel-local/SKILL.md
@@ -19,7 +19,7 @@ the plugin `.mcp.json`.
 
 ## Plugin Runtime
 
-The plugin `.mcp.json` runs `npx -y @ratel-ai/ratel-local@0.8.2 connect`.
+The plugin `.mcp.json` runs `npx -y @ratel-ai/ratel-local@0.9.0 connect`.
 The connector sends its resolved project root to the authenticated loopback
 daemon, which loads the appropriate config chain and shares upstream
 connections only within that canonical project scope. Do not replace the
@@ -28,12 +28,12 @@ into the plugin `.mcp.json`.
 
 Stable packages install the Ratel marketplace from the repository's default
 `main` branch. Only prerelease package versions reconcile the marketplace to an
-immutable matching Git tag. Never add an RC branch or ref for stable `0.8.2`.
+immutable matching Git tag. Never add an RC branch or ref for stable `0.9.0`.
 
 Run the setup wizard once from a terminal:
 
 ```bash
-npx -y @ratel-ai/ratel-local@0.8.2 setup
+npx -y @ratel-ai/ratel-local@0.9.0 setup
 ```
 
 This is the default onboarding path: it makes the daemon ready, detects Claude
@@ -49,7 +49,7 @@ never be run on MCP stdio.
 For human CLI work, install the package globally and use the `ratel-local` bin:
 
 ```bash
-pnpm add -g @ratel-ai/ratel-local@0.8.2
+pnpm add -g @ratel-ai/ratel-local@0.9.0
 ratel-local --version
 ```
 
@@ -380,7 +380,7 @@ ratel-local backup list
 ## Debug Checklist
 
 1. Confirm Node and `npx` are available.
-2. Confirm the plugin `.mcp.json` starts `@ratel-ai/ratel-local@0.8.2` with `connect`.
+2. Confirm the plugin `.mcp.json` starts `@ratel-ai/ratel-local@0.9.0` with `connect`.
 3. Run `ratel-local daemon status`; if needed, run `ratel-local setup`.
 4. Run `ratel-local mcp list` to verify Ratel config has upstreams.
 5. Run `ratel-local connect` from the relevant project to reproduce the scoped bridge outside the host, or `ratel-local serve --auto-config` to isolate the gateway itself.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ratel-local-workspace",
-  "version": "0.8.2",
+  "version": "0.9.0",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.33.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ratel-ai/ratel-local-core",
-  "version": "0.8.2",
+  "version": "0.9.0",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ratel-ai/ratel-local-ui",
   "private": true,
-  "version": "0.8.2",
+  "version": "0.9.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary

This promotes Ratel Local to stable `0.9.0`, landing the feature-gated Cloud skill catalog, daemon-side feature-flag reconfiguration, and the removal of the deprecated `search_tools` gateway alias.

## Why

`search_tools` was still advertised and dispatchable in `0.8.2`. It was removed from `main` two days after that release and has never shipped, so the break lands on this upgrade rather than silently earlier.

Merging this PR and publishing `v0.9.0` puts the CLI, daemon, bundled skills, plugin manifests, connector runtime, and documentation back on one production version.

## What changed

### Capability search

- remove the deprecated `search_tools` alias from MCP discovery and call dispatch
- leave `search_capabilities` as the single capability-search entry point
- omit duplicate `server.instructions` from search responses only when they are exactly equal to `server.description`

### Cloud skill catalog

- add the off-by-default `RATEL_FEATURE_CLOUD_CATALOG=1` daemon flag that pulls published Cloud skills into the snapshot using the saved Cloud API key
- serve published Cloud skills through the gateway, with local skills of the same id winning and a failed pull degrading to a warning
- hold a rejected API key for 60 seconds after HTTP 401/403, and an unreachable catalog for 10 seconds when nothing is cached
- surface catalog and other resolve warnings as context snapshot diagnostics in the UI shell without failing the page

### Daemon

- make `daemon restart` reconfigure `RATEL_FEATURE_CLOUD_TELEMETRY` and `RATEL_FEATURE_CLOUD_CATALOG` independently in an installed launchd or systemd service, confirming both through `/api/daemon/status`
- wait for the stopped daemon to release its port before restarting
- raise the healthy-status wait for `daemon install|start|restart` from 5 to 15 seconds
- fix `pnpm dev:ui` development command

### Release

- bump all synchronized package/plugin/documentation pins and the changelog to `0.9.0`

## User impact

MCP clients that call `search_tools` by name must migrate to `search_capabilities`, which also returns skills. 
Cloud catalog behavior remains unavailable unless explicitly enabled.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm build`
- `pnpm typecheck`
- `pnpm lint` — 331 files checked
- `pnpm test` — 1,172 tests passed
- `pnpm check:pack`
- packed `@ratel-ai/ratel-local@0.9.0` and inspected its published manifest
- installed the tarball into a clean directory and smoke-checked `--version` and `--help`